### PR TITLE
fix(kernel_tuning): re-enable SMT in boot parameters

### DIFF
--- a/inventory/group_vars/proxmox.yml
+++ b/inventory/group_vars/proxmox.yml
@@ -20,7 +20,7 @@ kernel_tuning_overcommit_memory: 0
 kernel_tuning_boot_params_enabled: true
 kernel_tuning_clocksource: hpet
 kernel_tuning_tsc_mode: unstable
-kernel_tuning_disable_smt: true
+kernel_tuning_disable_smt: false
 kernel_tuning_disable_deep_cstates: true
 
 # Ulimits Configuration


### PR DESCRIPTION
SMT has been re-enabled in BIOS now that system stability has been
confirmed. Change kernel_tuning_disable_smt to false so the 'nosmt'
kernel parameter is no longer added to boot configuration.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-enables SMT in boot parameters by setting `kernel_tuning_disable_smt` to `false` in `proxmox.yml`.
> 
>   - **Behavior**:
>     - Re-enables SMT in boot parameters by setting `kernel_tuning_disable_smt` to `false` in `proxmox.yml`.
>     - Removes `nosmt` kernel parameter from boot configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-proxmox&utm_source=github&utm_medium=referral)<sup> for b8cc127174e1e3cdbe6ce77c85bcc2e48a85c8fd. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->