### PR TITLE
fix(nas_storage): wrap testparm validate in sh -c so redirection works

### DIFF
--- a/roles/nas_storage/defaults/main.yml
+++ b/roles/nas_storage/defaults/main.yml
@@ -11,6 +11,14 @@ nas_storage_smb_share_name: "nas"
 nas_storage_smb_workgroup: "WORKGROUP"
 nas_storage_smb_valid_users: "@nas"
 
+# Samba config validation command. Wrapped in `sh -c` because Ansible's
+# template `validate:` parameter runs via shlex.split (no shell), so a bare
+# `testparm -s %s 2>/dev/null` would treat `2>/dev/null` as a positional
+# hostname argument and fail with
+# "ERROR: You must specify both a machine name and an IP address."
+# The `%s` is double-quoted to handle Ansible temp paths containing spaces.
+nas_storage_smb_validate_cmd: 'sh -c "testparm -s \"%s\" 2>/dev/null"'
+
 # Subdirectories to create under mount point
 nas_storage_directories:
   - "huggingface/hub"

--- a/roles/nas_storage/tasks/main.yml
+++ b/roles/nas_storage/tasks/main.yml
@@ -137,7 +137,11 @@
     owner: root
     group: root
     mode: "0644"
-    validate: 'testparm -s %s 2>/dev/null'
+    # Wrap in `sh -c` because Ansible's validate runs via shlex.split (no shell),
+    # so a bare `testparm -s %s 2>/dev/null` would treat `2>/dev/null` as a
+    # positional hostname argument and fail with
+    # "ERROR: You must specify both a machine name and an IP address."
+    validate: 'sh -c "testparm -s %s 2>/dev/null"'
   notify: Restart smbd
   tags:
     - nas_storage
@@ -150,7 +154,11 @@
     owner: root
     group: root
     mode: "0644"
-    validate: 'testparm -s %s 2>/dev/null'
+    # Wrap in `sh -c` because Ansible's validate runs via shlex.split (no shell),
+    # so a bare `testparm -s %s 2>/dev/null` would treat `2>/dev/null` as a
+    # positional hostname argument and fail with
+    # "ERROR: You must specify both a machine name and an IP address."
+    validate: 'sh -c "testparm -s %s 2>/dev/null"'
   notify: Restart smbd
   tags:
     - nas_storage

--- a/roles/nas_storage/tasks/main.yml
+++ b/roles/nas_storage/tasks/main.yml
@@ -137,11 +137,7 @@
     owner: root
     group: root
     mode: "0644"
-    # Wrap in `sh -c` because Ansible's validate runs via shlex.split (no shell),
-    # so a bare `testparm -s %s 2>/dev/null` would treat `2>/dev/null` as a
-    # positional hostname argument and fail with
-    # "ERROR: You must specify both a machine name and an IP address."
-    validate: 'sh -c "testparm -s %s 2>/dev/null"'
+    validate: "{{ nas_storage_smb_validate_cmd }}"
   notify: Restart smbd
   tags:
     - nas_storage
@@ -154,11 +150,7 @@
     owner: root
     group: root
     mode: "0644"
-    # Wrap in `sh -c` because Ansible's validate runs via shlex.split (no shell),
-    # so a bare `testparm -s %s 2>/dev/null` would treat `2>/dev/null` as a
-    # positional hostname argument and fail with
-    # "ERROR: You must specify both a machine name and an IP address."
-    validate: 'sh -c "testparm -s %s 2>/dev/null"'
+    validate: "{{ nas_storage_smb_validate_cmd }}"
   notify: Restart smbd
   tags:
     - nas_storage


### PR DESCRIPTION
## Summary

Fixes Phase 2 of the E2E deployment pipeline (ansible-proxmox site.yml) which was failing on \`nas_storage : Template smb.conf\` with:

\`\`\`
ERROR: You must specify both a machine name and an IP address.
\`\`\`

## Root cause

Ansible's template \`validate:\` parameter runs the command via \`shlex.split\` (no shell interpretation). The existing line:

\`\`\`yaml
validate: 'testparm -s %s 2>/dev/null'
\`\`\`

was being parsed into \`['testparm', '-s', '<file>', '2>/dev/null']\`. testparm interpreted the \`2>/dev/null\` token as a positional **hostname** argument (testparm's positional args are \`[smb.conf-path] [hostname IP]\`) and failed because no paired IP was provided. The error message is misleading — the rendered config is correct.

## Fix

Wrap in \`sh -c \"...\"\` so the inner shell handles the redirection. After substitution shlex-splits to \`['sh', '-c', 'testparm -s /path/to/file 2>/dev/null']\` which the shell parses correctly.

## Verification

- Reproduced the failure: ran \`testparm -s /tmp/render.conf 2>/dev/null\` directly (succeeds, exit 0) vs \`testparm -s /tmp/render.conf '2>/dev/null'\` (fails with the exact error).
- After fix: \`ansible-lint roles/nas_storage\` passes under production profile.

## Test plan

- [x] ansible-lint passes
- [ ] \`ansible-playbook playbooks/site.yml --tags nas_storage\` succeeds end-to-end on pve