### PR TITLE
fix(ci): add scheduled workflow to retrigger CI on bot PRs

### DIFF
--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -7,9 +7,9 @@ name: Retrigger PR Checks
 
 on:
   schedule:
-    - cron: "0 10 * * *"  # 6 AM ET (UTC-4)
-    - cron: "0 20 * * *"  # 4 PM ET (UTC-4)
-    - cron: "0 0 * * *"   # 8 PM ET (UTC-4)
+    - cron: "0 10 * * *"  # 6 AM EDT
+    - cron: "0 20 * * *"  # 4 PM EDT
+    - cron: "0 0 * * *"   # 8 PM EDT
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -1,0 +1,24 @@
+---
+name: Retrigger PR Checks
+
+# Ensures bot-created PRs (GITHUB_TOKEN) get the Merge Gate check.
+# Calls shared logic from JacobPEvans/.github.
+# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans/.github
+
+on:
+  schedule:
+    - cron: "0 10 * * *"  # 6 AM ET (UTC-4)
+    - cron: "0 20 * * *"  # 4 PM ET (UTC-4)
+    - cron: "0 0 * * *"   # 8 PM ET (UTC-4)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  retrigger:
+    uses: JacobPEvans/.github/.github/workflows/_retrigger-pr-checks.yml@main
+    secrets:
+      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -7,9 +7,9 @@ name: Retrigger PR Checks
 
 on:
   schedule:
-    - cron: "0 10 * * *"  # 6 AM EDT
-    - cron: "0 20 * * *"  # 4 PM EDT
-    - cron: "0 0 * * *"   # 8 PM EDT
+    - cron: "0 10 * * *"  # 10:00 UTC (6 AM EDT / 5 AM EST)
+    - cron: "0 20 * * *"  # 20:00 UTC (4 PM EDT / 3 PM EST)
+    - cron: "0 0 * * *"   # 00:00 UTC (8 PM EDT / 7 PM EST)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Bot-created PRs (`GITHUB_TOKEN` actor) don't emit `pull_request` events, so `ci-gate.yml` never runs and the required **Merge Gate** check is permanently missing, blocking those PRs indefinitely.

Adds `retrigger-pr-checks.yml` — a thin caller to the shared `JacobPEvans/.github/_retrigger-pr-checks.yml` reusable workflow. Runs 3×/day on a schedule to find bot-authored open PRs missing CI Gate runs and close/reopen them, triggering `ci-gate.yml` via `pull_request: reopened`.

## Changes

- `.github/workflows/retrigger-pr-checks.yml` — scheduled caller to shared reusable workflow
  - Cron schedule: 10:00 UTC / 20:00 UTC / 00:00 UTC (3× daily)
  - Passes `GH_ACTION_JACOBPEVANS_APP_ID` + `GH_APP_PRIVATE_KEY` secrets to shared workflow
  - `pull-requests: read` is sufficient — the shared workflow uses a GitHub App token for close/reopen writes

## How it works

1. Shared workflow generates a short-lived GitHub App token (`actions/create-github-app-token`)
2. Queries open bot-authored PRs missing CI Gate workflow runs for their HEAD SHA
3. Uses the App token to close then reopen each affected PR — triggers `pull_request: reopened`
4. Safety constraints: skips drafts, skips commits < 5 min old, caps at 5 PRs/run

## Test plan

- [x] CI passes: Ansible Lint ✅, Molecule Test ✅, CodeQL ✅, Merge Gate ✅
- [ ] Merge this PR
- [ ] Run `gh workflow run retrigger-pr-checks.yml --repo JacobPEvans/ansible-proxmox` to validate manually
- [ ] Verify bot PR #142 or similar gets a Merge Gate check on next run

Related: JacobPEvans/.github#207 (shared workflow — already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)