### PR TITLE
fix(ci): move pip pins to requirements-ci.txt for Renovate tracking

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci.txt
+          python -m pip install -r requirements-ci.txt
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml
       - name: Run molecule test

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Run molecule test
         run: molecule test
         env:
+          ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
 

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install 'molecule>=25.0.0' 'molecule-docker>=2.1.0' 'ansible-core>=2.18.0,<2.19.0'
+          pip install -r requirements-ci.txt
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml
       - name: Run molecule test

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install 'molecule>=25.0.0' 'molecule-docker>=2.1.0' 'ansible-core>=2.18.0,<2.19.0'
+          pip install -r requirements-ci.txt
 
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci.txt
+          python -m pip install -r requirements-ci.txt
 
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,3 @@
+ansible-core>=2.20.3,<2.21.0
+molecule>=25.0.0
+molecule-docker>=2.1.0


### PR DESCRIPTION
## Summary

- Create `requirements-ci.txt` with pinned `ansible-core`, `molecule`, `molecule-docker`
- Switch both workflow `pip install` commands to `pip install -r requirements-ci.txt`
- Seed `ansible-core>=2.20.3,<2.21.0` to align with `.pre-commit-config.yaml` and clear Python 3.14's `>=2.20.0` requirement
- Add `ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"` to `ci-gate.yml` molecule step (workaround for molecule-docker 2.1.0 bug with ansible-core 2.20 strict conditionals)

## Why

Renovate's built-in `github-actions` manager tracks `python-version` on `actions/setup-python` natively, so PR #142 bumped Python `3.12 → 3.14`. But the three `pip install` pins in shell `run:` blocks are **invisible to Renovate** — no built-in manager parses pip arguments from arbitrary shell commands.

The fix feeds Renovate the format it already understands: `requirements.txt`. The built-in `pip_requirements` manager detects this file with zero config and proposes PEP 440-aware updates going forward. No custom regex manager needed in `JacobPEvans/.github`.

Deduplicates the identical pip install line that existed in both `ci-gate.yml` and `molecule.yml`.

### molecule-docker conditional bug

ansible-core 2.20 tightened conditional evaluation: `when: (lookup('env', 'HOME'))` now fails because `lookup('env', ...)` returns a string, not a bool. molecule-docker 2.1.0 (latest) has this pattern in its `destroy.yml`. The workaround (`ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"`) was already present in `molecule.yml` — this PR adds it to `ci-gate.yml` for consistency.

## After this merges

Comment `@renovate rebase` on PR #142. Renovate will re-scan, find `requirements-ci.txt`, see that `ansible-core>=2.20.3` already satisfies Python 3.14's `>=2.20.0` requirement, and PR #142 should go green on rebase.

## Changes

- `requirements-ci.txt` — new file; Renovate `pip_requirements` manager entry point
- `.github/workflows/ci-gate.yml` — `pip install -r requirements-ci.txt` + `ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"`
- `.github/workflows/molecule.yml` — `pip install -r requirements-ci.txt`

## Test plan

- [x] All pre-commit hooks pass (yamllint, ansible-lint, cspell)
- [x] `Molecule Test` CI passes on Python 3.12 with ansible-core 2.20
- [x] `Ansible Lint` and `CodeQL` green
- [ ] After merge, Renovate dashboard shows `ansible-core`, `molecule`, `molecule-docker` under "Detected dependencies → pip_requirements"
- [ ] PR #142 CI goes green after `@renovate rebase`

Related: #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)