### PR TITLE
fix(nas_storage): correct Jinja syntax error blocking Samba share validation

### DIFF
--- a/roles/nas_storage/tasks/main.yml
+++ b/roles/nas_storage/tasks/main.yml
@@ -97,7 +97,7 @@
       - (nas_storage_shares | map(attribute='path') | list | unique | length) == (nas_storage_shares | length)
       - item.valid_users is defined and item.valid_users | length > 0
       - item.path is defined
-      - "'..'' not in item.path"
+      - "'..' not in item.path"
       - item.path == nas_storage_mount_point or item.path.startswith(nas_storage_mount_point ~ "/")
     fail_msg: "Invalid Samba share definition: {{ item | to_nice_json }}"
   loop: "{{ nas_storage_shares }}"


### PR DESCRIPTION
## Summary

Closes #148. The path-traversal guard `'..' not in item.path` had a stray single quote (`'..'' not in item.path`), which Jinja parsed as a malformed string literal followed by an unmatched quote. Result: every CI run of `molecule test -s nas_storage` failed at converge with `Syntax error in expression: unexpected char "'" at 4`.

One character delete; lint clean; full molecule cycle passes locally.

## Root cause

`roles/nas_storage/tasks/main.yml:100` was `- "'..'' not in item.path"`. Inside a YAML double-quoted scalar, single quotes are literal — Jinja received the expression `'..'' not in item.path` (closing-then-opening unmatched quote), not the intended `'..' not in item.path`.

## Verification

```
nix develop github:JacobPEvans/nix-devenv?dir=shells/ansible
ANSIBLE_ALLOW_BROKEN_CONDITIONALS=1 \
NAS_HOMEASSISTANT_SMB_PASSWORD=molecule-pass \
molecule test -s nas_storage
```

Result: prepare, converge, verify, destroy all pass. `proxmox-nas-test` host: `ok=12 changed=0 failed=0 skipped=0` for verify. `testparm -s` validates clean. Samba password fingerprints persist and per-share configs render correctly.

`ansible-lint roles/nas_storage/`: 0 failures, 0 warnings, profile `production` passes.

## Test plan

- [x] `ansible-playbook --syntax-check molecule/nas_storage/converge.yml` — clean
- [x] `ansible-lint roles/nas_storage/` — clean
- [x] `molecule test -s nas_storage` — full cycle pass
- [ ] CI `Molecule Test` workflow turns green (verifies on this PR)

## Related

- Blocks ansible-proxmox CI gate green status
- Required dependency for the larger end-to-end deploy validation effort

(claude)