### PR TITLE
🤖 Fix #21: Add NTP/chrony time synchronization role

### DIFF
--- a/roles/ntp/defaults/main.yml
+++ b/roles/ntp/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# NTP role defaults
+
+# NTP pool servers to synchronize with
+# Override to point to internal NTP servers (e.g., "ntp.example.com iburst")
+ntp_pools:
+  - "0.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
+  - "1.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
+  - "2.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
+  - "3.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
+
+# chrony service state and startup
+ntp_service_state: started
+ntp_service_enabled: true
+
+# Path to the chrony configuration file
+ntp_config_file: /etc/chrony/chrony.conf

--- a/roles/ntp/handlers/main.yml
+++ b/roles/ntp/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# NTP role handlers
+
+- name: Restart chrony
+  ansible.builtin.systemd:
+    name: chrony
+    state: restarted
+  when: ansible_virtualization_type != 'docker'
+  listen: Restart chrony

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+# NTP time synchronization role using chrony
+
+- name: Install chrony
+  ansible.builtin.apt:
+    name: chrony
+    state: present
+    update_cache: false
+  tags:
+    - ntp
+
+- name: Deploy chrony configuration
+  ansible.builtin.copy:
+    dest: "{{ ntp_config_file }}"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by Ansible - ntp role
+      {% for pool in ntp_pools %}
+      pool {{ pool }}
+      {% endfor %}
+      driftfile /var/lib/chrony/chrony.drift
+      logdir /var/log/chrony
+      leapsectz right/UTC
+      hwtimestamp *
+      local stratum 10
+      allow 127.0.0.1
+      allow ::1
+  notify: Restart chrony
+  tags:
+    - ntp
+
+- name: Enable and start chrony service
+  ansible.builtin.systemd:
+    name: chrony
+    state: "{{ ntp_service_state }}"
+    enabled: "{{ ntp_service_enabled }}"
+    daemon_reload: true
+  tags:
+    - ntp

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -5,28 +5,19 @@
   ansible.builtin.apt:
     name: chrony
     state: present
-    update_cache: false
+    update_cache: true
+    cache_valid_time: 3600
   tags:
     - ntp
 
 - name: Deploy chrony configuration
-  ansible.builtin.copy:
+  ansible.builtin.template:
+    src: chrony.conf.j2
     dest: "{{ ntp_config_file }}"
     owner: root
     group: root
     mode: "0644"
-    content: |
-      # Managed by Ansible - ntp role
-      {% for pool in ntp_pools %}
-      pool {{ pool }}
-      {% endfor %}
-      driftfile /var/lib/chrony/chrony.drift
-      logdir /var/log/chrony
-      leapsectz right/UTC
-      hwtimestamp *
-      local stratum 10
-      allow 127.0.0.1
-      allow ::1
+    validate: chronyd -p -f %s
   notify: Restart chrony
   tags:
     - ntp
@@ -36,6 +27,6 @@
     name: chrony
     state: "{{ ntp_service_state }}"
     enabled: "{{ ntp_service_enabled }}"
-    daemon_reload: true
+  when: ansible_virtualization_type != 'docker'
   tags:
     - ntp

--- a/roles/ntp/templates/chrony.conf.j2
+++ b/roles/ntp/templates/chrony.conf.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+{% for pool in ntp_pools %}
+pool {{ pool }}
+{% endfor %}
+driftfile /var/lib/chrony/chrony.drift
+logdir /var/log/chrony
+leapsectz right/UTC
+hwtimestamp *
+local stratum 10
+allow 127.0.0.1
+allow ::1


### PR DESCRIPTION
Closes #21

## Problem

Accurate time synchronization is critical for Proxmox cluster nodes:
- Cluster consensus protocols
- Certificate validation
- Log correlation during incident response
- Ceph clock skew prevention

No `roles/ntp` role existed; nodes had no IaC-managed chrony configuration.

## Approach

Create a minimal `roles/ntp` role following the existing role patterns in the repo.
Installs `chrony`, deploys a configuration file with configurable NTP pool servers,
and ensures the service is running and enabled.

## Files changed

- `roles/ntp/defaults/main.yml` — Default NTP pool servers (Debian public pools) and service config
- `roles/ntp/tasks/main.yml` — Install chrony, deploy config, enable/start service
- `roles/ntp/handlers/main.yml` — Restart chrony handler (skipped inside Docker)

## CI status

none — workflows in this repo only trigger on push to `main` or on PR events.
CI gate will run once this draft PR is reviewed and ready.

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
