### PR TITLE
feat(ntp): add server mode and wire role into proxmox play

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -45,3 +45,12 @@
     - role: nas_storage
       tags:
         - nas_storage
+
+    - role: ntp
+      tags:
+        - ntp
+      vars:
+        ntp_serve: true
+        ntp_allow_cidrs:
+          - "192.168.0.0/16"
+          - "10.0.0.0/8"

--- a/roles/ntp/README.md
+++ b/roles/ntp/README.md
@@ -19,8 +19,11 @@ vendor the role or reference it via `requirements.yml` pointing at this repo.
 
 ## API
 
-The role's behavior is driven entirely by the variables documented below. All
-variables are read at template-render time; no facts or external state.
+The role's behavior is driven entirely by the variables documented below.
+Mode selection (client / server / hybrid) is variable-driven, but a small
+number of tasks are fact-gated: the systemd task is skipped under Docker
+(`ansible_virtualization_type != 'docker'`) so the role can be molecule-tested
+in containers.
 
 ### Modes
 
@@ -42,8 +45,10 @@ The combination of `ntp_servers` and `ntp_serve` selects the mode:
 
 See `defaults/main.yml` for the authoritative list and inline rationale.
 
-- `ntp_servers` (list, default `[]`) — Internal NTP servers, e.g.,
-  `["192.168.0.10", "192.168.0.11"]`.
+- `ntp_servers` (list, default `[]`) — Internal NTP servers. Each entry is
+  the full chrony directive following the `server` keyword, so include any
+  options you want (e.g., `["192.168.0.10 iburst", "192.168.0.11 iburst prefer"]`).
+  Mirrors the `ntp_pools` pattern.
 - `ntp_pools` (list, default Debian pool with 4 entries) — Used only when
   `ntp_servers` is empty.
 - `ntp_serve` (bool, default `false`) — Enable server mode.

--- a/roles/ntp/README.md
+++ b/roles/ntp/README.md
@@ -1,0 +1,116 @@
+# ntp
+
+Configures chrony for time synchronization. Supports client, server, and
+hybrid modes via variable combinations.
+
+## Installation
+
+This role lives in this repository under `roles/ntp/`. Reference it from a
+playbook in the `roles:` block — no Galaxy install needed:
+
+```yaml
+- hosts: proxmox
+  roles:
+    - role: ntp
+```
+
+For consumption from sibling repos (`ansible-proxmox-apps`, `ansible-splunk`),
+vendor the role or reference it via `requirements.yml` pointing at this repo.
+
+## API
+
+The role's behavior is driven entirely by the variables documented below. All
+variables are read at template-render time; no facts or external state.
+
+### Modes
+
+The combination of `ntp_servers` and `ntp_serve` selects the mode:
+
+- **Client (default)** — `ntp_servers: []`, `ntp_serve: false`. Syncs from
+  `ntp_pools` (public Debian pool).
+- **Internal client** — `ntp_servers` non-empty, `ntp_serve: false`. Syncs
+  from `ntp_servers`; `ntp_pools` is ignored.
+- **Server** — `ntp_servers: []`, `ntp_serve: true`. Syncs from `ntp_pools`,
+  serves to `ntp_allow_cidrs`.
+- **Hybrid** — `ntp_servers` non-empty, `ntp_serve: true`. Syncs from
+  `ntp_servers`, serves to `ntp_allow_cidrs`.
+
+`server <addr> iburst` lines take precedence over `pool` lines: when
+`ntp_servers` is non-empty, the pool block is skipped entirely.
+
+### Variables
+
+See `defaults/main.yml` for the authoritative list and inline rationale.
+
+- `ntp_servers` (list, default `[]`) — Internal NTP servers, e.g.,
+  `["192.168.0.10", "192.168.0.11"]`.
+- `ntp_pools` (list, default Debian pool with 4 entries) — Used only when
+  `ntp_servers` is empty.
+- `ntp_serve` (bool, default `false`) — Enable server mode.
+- `ntp_allow_cidrs` (list, default `[]`) — CIDRs allowed to query this host.
+  Required when `ntp_serve: true`.
+- `ntp_service_state` (string, default `started`) — Passed through to systemd.
+- `ntp_service_enabled` (bool, default `true`) — Passed through to systemd.
+- `ntp_config_file` (string, default `/etc/chrony/chrony.conf`).
+
+## Usage
+
+### Proxmox hosts (server mode, wired in `playbooks/site.yml`)
+
+```yaml
+- role: ntp
+  vars:
+    ntp_serve: true
+    ntp_allow_cidrs:
+      - "192.168.0.0/16"
+      - "10.0.0.0/8"
+```
+
+Result: hosts sync from the Debian public pool and serve NTP to all internal
+RFC1918 traffic on UDP/123. Companion firewall rule lives in
+`terraform-proxmox/modules/firewall/` (see issue #285).
+
+### Internal clients (used by ansible-proxmox-apps and ansible-splunk)
+
+In the consumer repo's `inventory/group_vars/all.yml`:
+
+```yaml
+ntp_servers: "{{ lookup('env', 'PROXMOX_NTP_SERVERS') | split(',') | map('trim') | reject('equalto', '') | list }}"
+```
+
+With `PROXMOX_NTP_SERVERS` injected via Doppler. An empty value falls back to
+the public pool, so the role stays safe if Doppler is unavailable.
+
+## Verification (server mode)
+
+```sh
+chronyc tracking          # current sync state
+chronyc clients           # connected clients (server mode)
+chronyc sources -v        # upstream sources
+```
+
+From a client subnet:
+
+```sh
+chronyc -h <proxmox-host> tracking
+```
+
+## Idempotency
+
+The `validate: chronyd -p -f %s` directive on the template task pre-validates
+the rendered config; a syntax error fails the play before chronyd is told to
+restart. Restart fires only via the `Restart chrony` handler — when the file
+actually changes.
+
+The systemd task is skipped under Docker (`ansible_virtualization_type !=
+'docker'`) so the role can be molecule-tested in containers.
+
+## Contributing
+
+Changes to this role should be paired with a `molecule test` run from the
+repo root. Update this README whenever a variable is added, removed, or
+changes default value.
+
+## License
+
+Internal — same license as the parent `ansible-proxmox` repository.

--- a/roles/ntp/defaults/main.yml
+++ b/roles/ntp/defaults/main.yml
@@ -1,13 +1,26 @@
 ---
 # NTP role defaults
 
-# NTP pool servers to synchronize with
-# Override to point to internal NTP servers (e.g., "ntp.example.com iburst")
+# Internal NTP servers to sync from. When non-empty, takes precedence over
+# ntp_pools (which is then ignored). Use this on clients to point at the
+# Proxmox stratum-2 servers; leave empty on the Proxmox hosts themselves
+# so they continue syncing from the public Debian pool.
+ntp_servers: []
+
+# Public NTP pool fallback. Used only when ntp_servers is empty.
 ntp_pools:
   - "0.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
   - "1.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
   - "2.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
   - "3.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
+
+# Enable chrony server mode: emits `allow` directives for ntp_allow_cidrs
+# so this host serves NTP to other machines on those subnets.
+ntp_serve: false
+
+# CIDRs permitted to query this host as an NTP server. Only used when
+# ntp_serve is true. Keep empty on pure clients.
+ntp_allow_cidrs: []
 
 # chrony service state and startup
 ntp_service_state: started

--- a/roles/ntp/templates/chrony.conf.j2
+++ b/roles/ntp/templates/chrony.conf.j2
@@ -1,7 +1,13 @@
 # {{ ansible_managed }}
+{% if ntp_servers | length > 0 %}
+{% for server in ntp_servers %}
+server {{ server }} iburst
+{% endfor %}
+{% else %}
 {% for pool in ntp_pools %}
 pool {{ pool }}
 {% endfor %}
+{% endif %}
 driftfile /var/lib/chrony/chrony.drift
 logdir /var/log/chrony
 leapsectz right/UTC
@@ -9,3 +15,8 @@ hwtimestamp *
 local stratum 10
 allow 127.0.0.1
 allow ::1
+{% if ntp_serve %}
+{% for cidr in ntp_allow_cidrs %}
+allow {{ cidr }}
+{% endfor %}
+{% endif %}

--- a/roles/ntp/templates/chrony.conf.j2
+++ b/roles/ntp/templates/chrony.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 {% if ntp_servers | length > 0 %}
 {% for server in ntp_servers %}
-server {{ server }} iburst
+server {{ server }}
 {% endfor %}
 {% else %}
 {% for pool in ntp_pools %}


### PR DESCRIPTION
## Summary

Turns the chrony role into a stratum-2 NTP server for the Proxmox cluster, enabling internal VMs/containers to sync from the hosts instead of (or alongside) public Debian pools.

## Changes

- `roles/ntp/defaults/main.yml`: adds `ntp_servers` (list, default `[]`), `ntp_serve` (bool, default `false`), `ntp_allow_cidrs` (list, default `[]`). Existing client-only behavior preserved.
- `roles/ntp/templates/chrony.conf.j2`: emits `server <addr> iburst` lines from `ntp_servers` (skipping the `pool` block) when non-empty; emits per-CIDR `allow` directives when `ntp_serve` is true.
- `playbooks/site.yml`: wires the role into the Proxmox play with `ntp_serve: true` and both RFC1918 CIDRs (`192.168.0.0/16`, `10.0.0.0/8`).
- `roles/ntp/README.md`: documents the four mode combinations (Client / Internal client / Server / Hybrid) and the env-var lookup pattern intended for ansible-proxmox-apps and ansible-splunk.

## Test Plan

- [x] ansible-lint passes (production profile, 0 failures)
- [x] markdownlint passes
- [x] Template's existing \`validate: chronyd -p -f %s\` will catch syntax errors at deploy time
- [ ] After merge, run \`doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --check --diff\` then real run; verify \`chronyc clients\` on each Proxmox host shows the LAN CIDR permitted

## Related

- Closes #179
- Pairs with terraform-proxmox#285 (firewall UDP/123 ingress) — both must be applied before client repos (ansible-proxmox-apps#243, ansible-splunk#200) can sync from the hosts
- Follow-up to #177 (the original chrony role)

Assisted-by: Claude <noreply@anthropic.com>