### PR TITLE
chore(gitignore): ignore .ansible/ runtime cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ ENV/
 # Ansible
 *.retry
 .cache/
+.ansible/
 
 # Molecule
 .molecule/


### PR DESCRIPTION
## Summary

Adds `.ansible/` to `.gitignore`. The directory is created by `ansible-playbook` for local fact caching and runtime state; it surfaced as untracked in `main` during recent NTP role work and was never intended to be committed.

## Changes

- `.gitignore`: one line under the existing "# Ansible" section, alongside the existing `*.retry` and `.cache/` entries.

## Test Plan

- [x] Pre-commit hooks pass locally (ansible-lint, yamllint, markdownlint)
- [x] `git status` clean after `mkdir -p .ansible && touch .ansible/test` (verified empty status)

Assisted-by: Claude <noreply@anthropic.com>