### PR TITLE
fix(ntp): role hardening from downstream review feedback

### DIFF
--- a/roles/ntp/README.md
+++ b/roles/ntp/README.md
@@ -32,14 +32,32 @@ The combination of `ntp_servers` and `ntp_serve` selects the mode:
 - **Client (default)** — `ntp_servers: []`, `ntp_serve: false`. Syncs from
   `ntp_pools` (public Debian pool).
 - **Internal client** — `ntp_servers` non-empty, `ntp_serve: false`. Syncs
-  from `ntp_servers`; `ntp_pools` is ignored.
+  from `ntp_servers` plus `ntp_pools` (public pool kept as additional
+  sources for resilience).
 - **Server** — `ntp_servers: []`, `ntp_serve: true`. Syncs from `ntp_pools`,
   serves to `ntp_allow_cidrs`.
 - **Hybrid** — `ntp_servers` non-empty, `ntp_serve: true`. Syncs from
-  `ntp_servers`, serves to `ntp_allow_cidrs`.
+  `ntp_servers` plus `ntp_pools`, serves to `ntp_allow_cidrs`.
 
-`server <addr> iburst` lines take precedence over `pool` lines: when
-`ntp_servers` is non-empty, the pool block is skipped entirely.
+### Source selection
+
+Both `ntp_servers` entries (rendered as `server` directives) and `ntp_pools`
+entries (rendered as `pool` directives) are always included in the chrony
+configuration. Chrony picks the best source automatically by stratum and
+jitter — it does not strictly prefer earlier-listed entries.
+
+To make chrony **strictly prefer** internal entries over public pool
+members (e.g., to keep traffic on-LAN whenever an internal server is
+reachable), include the `prefer` keyword in each `ntp_servers` entry:
+
+```yaml
+ntp_servers:
+  - "192.168.0.10 iburst prefer"
+  - "192.168.0.11 iburst prefer"
+```
+
+When all internal `prefer`-marked entries become unreachable, chrony falls
+back to selecting among the remaining sources (the public pool).
 
 ### Variables
 

--- a/roles/ntp/defaults/main.yml
+++ b/roles/ntp/defaults/main.yml
@@ -1,13 +1,16 @@
 ---
 # NTP role defaults
 
-# Internal NTP servers to sync from. When non-empty, takes precedence over
-# ntp_pools (which is then ignored). Use this on clients to point at the
-# Proxmox stratum-2 servers; leave empty on the Proxmox hosts themselves
-# so they continue syncing from the public Debian pool.
+# Internal NTP servers to sync from. Rendered alongside ntp_pools so chrony
+# always has the public pool available as additional sources. Chrony picks
+# the best source by stratum and jitter — to *prefer* internal entries
+# strictly, include the `prefer` keyword in the entry itself (e.g.,
+# "192.168.0.10 iburst prefer"). Use this on clients to point at the
+# Proxmox stratum-2 servers; leave empty on the Proxmox hosts themselves.
 ntp_servers: []
 
-# Public NTP pool fallback. Used only when ntp_servers is empty.
+# Public NTP pool. Always rendered into chrony.conf alongside ntp_servers
+# so public sources stay reachable if internal stratum-2 servers go down.
 ntp_pools:
   - "0.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"
   - "1.debian.pool.ntp.org iburst minpoll 5 maxpoll 7"

--- a/roles/ntp/handlers/main.yml
+++ b/roles/ntp/handlers/main.yml
@@ -5,5 +5,5 @@
   ansible.builtin.systemd:
     name: chrony
     state: restarted
-  when: ansible_virtualization_type != 'docker'
+  when: ansible_virtualization_type | default('') != 'docker'
   listen: Restart chrony

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
 # NTP time synchronization role using chrony
 
-- name: Install chrony
+- name: Install chrony and tzdata
   ansible.builtin.apt:
-    name: chrony
+    name:
+      - chrony
+      - tzdata
     state: present
     update_cache: true
     cache_valid_time: 3600
@@ -27,6 +29,6 @@
     name: chrony
     state: "{{ ntp_service_state }}"
     enabled: "{{ ntp_service_enabled }}"
-  when: ansible_virtualization_type != 'docker'
+  when: ansible_virtualization_type | default('') != 'docker'
   tags:
     - ntp

--- a/roles/ntp/templates/chrony.conf.j2
+++ b/roles/ntp/templates/chrony.conf.j2
@@ -1,21 +1,18 @@
 # {{ ansible_managed }}
-{% if ntp_servers | length > 0 %}
 {% for server in ntp_servers %}
 server {{ server }}
 {% endfor %}
-{% else %}
 {% for pool in ntp_pools %}
 pool {{ pool }}
 {% endfor %}
-{% endif %}
 driftfile /var/lib/chrony/chrony.drift
 logdir /var/log/chrony
 leapsectz right/UTC
-hwtimestamp *
-local stratum 10
 allow 127.0.0.1
 allow ::1
 {% if ntp_serve %}
+local stratum 10
+hwtimestamp *
 {% for cidr in ntp_allow_cidrs %}
 allow {{ cidr }}
 {% endfor %}


### PR DESCRIPTION
## Summary

Applies the same role-level fixes upstream that the vendored copies in [ansible-proxmox-apps#253](https://github.com/JacobPEvans/ansible-proxmox-apps/pull/253) and [ansible-splunk#203](https://github.com/JacobPEvans/ansible-splunk/pull/203) received during review. Keeps the three copies of `roles/ntp/` in sync.

## Changes

- `roles/ntp/handlers/main.yml` + `roles/ntp/tasks/main.yml`: replace `ansible_virtualization_type != 'docker'` with `ansible_virtualization_type | default('') != 'docker'`. Prevents `AnsibleUndefinedVariable` errors on bare-metal hosts or where the virtualization fact subset is restricted.
- `roles/ntp/tasks/main.yml`: install `tzdata` alongside `chrony`. The `leapsectz right/UTC` directive in the template requires the tzdata source files; explicit install defends against minimal base images.
- `roles/ntp/templates/chrony.conf.j2`:
  - Always emit `pool` directives even when `ntp_servers` is non-empty. The public Debian pool now acts as a reachable fallback when internal stratum-2 servers go offline.
  - Wrap `local stratum 10` and `hwtimestamp *` in `{% if ntp_serve %}`. The Proxmox cluster (server mode, ntp_serve=true) keeps both active. Pure clients no longer claim false synchronization and don't log hwtimestamp errors on virtio NICs.

## Test Plan

- [x] `ansible-lint` clean (production profile, 0 failures)
- [x] Pre-commit hooks (yamllint, ansible-lint, markdownlint) pass
- [ ] After merge: `doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags ntp --check --diff` (then real run). Existing `ntp_serve=true` config on the proxmox group preserves current behavior; clients change only in that they stop falsely advertising sync.

## Related

- Source of the feedback: ansible-proxmox-apps#253 (T3/T5/T6, copilot + gemini), ansible-splunk#203 (S1/S2, gemini)
- Vendored copies already received these fixes in apps#253 commit \`d4a0c20\` and splunk#203 commit \`c44f32f\`

Assisted-by: Claude <noreply@anthropic.com>