### PR TITLE
🤖 Fix #29: Add molecule verify playbook with comprehensive assertions

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,6 +5,12 @@
   become: false
   gather_facts: true
 
+  # Load role defaults so the crash_diagnostics_* variables referenced below
+  # resolve. verify.yml runs as a standalone play and does not inherit
+  # role vars unless explicitly imported.
+  vars_files:
+    - ../../roles/crash_diagnostics/defaults/main.yml
+
   tasks:
     - name: Verify sysctl configuration file exists
       ansible.builtin.stat:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -45,38 +45,42 @@
 
     # --- crash_diagnostics role assertions ---
 
-    - name: Verify memory-config log directory exists
+    - name: Verify memory-config log directory
       ansible.builtin.stat:
-        path: /var/log/memory-config
+        path: "{{ crash_diagnostics_memory_log_dir }}"
       register: crash_diag_memory_log_dir
-      failed_when: not crash_diag_memory_log_dir.stat.exists
 
-    - name: Verify memory-config-logger script exists
+    - name: Assert memory-config log directory is valid
+      ansible.builtin.assert:
+        that:
+          - crash_diag_memory_log_dir.stat.exists
+          - crash_diag_memory_log_dir.stat.isdir
+        fail_msg: "{{ crash_diagnostics_memory_log_dir }} is missing or not a directory"
+
+    - name: Verify memory-config-logger script
       ansible.builtin.stat:
-        path: /usr/local/bin/memory-config-logger.sh
+        path: "{{ crash_diagnostics_memory_logger_script }}"
       register: crash_diag_memory_logger
-      failed_when: not crash_diag_memory_logger.stat.exists
 
-    - name: Assert memory-config-logger script is executable
+    - name: Assert memory-config-logger script is valid
       ansible.builtin.assert:
         that:
+          - crash_diag_memory_logger.stat.exists
           - crash_diag_memory_logger.stat.executable
-        fail_msg: "/usr/local/bin/memory-config-logger.sh exists but is not executable"
+        fail_msg: "{{ crash_diagnostics_memory_logger_script }} is missing or not executable"
 
-    - name: Verify mce-monitor script exists
+    - name: Verify mce-monitor script
       ansible.builtin.stat:
-        path: /usr/local/bin/mce-monitor.sh
+        path: "{{ crash_diagnostics_mce_monitor_script }}"
       register: crash_diag_mce_monitor
-      failed_when: not crash_diag_mce_monitor.stat.exists
 
-    - name: Assert mce-monitor script is executable
+    - name: Assert mce-monitor script is valid
       ansible.builtin.assert:
         that:
+          - crash_diag_mce_monitor.stat.exists
           - crash_diag_mce_monitor.stat.executable
-        fail_msg: "/usr/local/bin/mce-monitor.sh exists but is not executable"
+        fail_msg: "{{ crash_diagnostics_mce_monitor_script }} is missing or not executable"
 
     - name: Verify strace is installed (crash_diagnostics package)
-      ansible.builtin.stat:
-        path: /usr/bin/strace
-      register: crash_diag_strace
-      failed_when: not crash_diag_strace.stat.exists
+      ansible.builtin.command: which strace
+      changed_when: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -42,3 +42,41 @@
       ansible.builtin.debug:
         msg: "Kernel cmdline found (requires Proxmox): {{ kernel_cmdline_file.stat.exists }}"
       changed_when: false
+
+    # --- crash_diagnostics role assertions ---
+
+    - name: Verify memory-config log directory exists
+      ansible.builtin.stat:
+        path: /var/log/memory-config
+      register: crash_diag_memory_log_dir
+      failed_when: not crash_diag_memory_log_dir.stat.exists
+
+    - name: Verify memory-config-logger script exists
+      ansible.builtin.stat:
+        path: /usr/local/bin/memory-config-logger.sh
+      register: crash_diag_memory_logger
+      failed_when: not crash_diag_memory_logger.stat.exists
+
+    - name: Assert memory-config-logger script is executable
+      ansible.builtin.assert:
+        that:
+          - crash_diag_memory_logger.stat.executable
+        fail_msg: "/usr/local/bin/memory-config-logger.sh exists but is not executable"
+
+    - name: Verify mce-monitor script exists
+      ansible.builtin.stat:
+        path: /usr/local/bin/mce-monitor.sh
+      register: crash_diag_mce_monitor
+      failed_when: not crash_diag_mce_monitor.stat.exists
+
+    - name: Assert mce-monitor script is executable
+      ansible.builtin.assert:
+        that:
+          - crash_diag_mce_monitor.stat.executable
+        fail_msg: "/usr/local/bin/mce-monitor.sh exists but is not executable"
+
+    - name: Verify strace is installed (crash_diagnostics package)
+      ansible.builtin.stat:
+        path: /usr/bin/strace
+      register: crash_diag_strace
+      failed_when: not crash_diag_strace.stat.exists


### PR DESCRIPTION
Closes #29

## Problem

Current tests only verify convergence (no errors). The `molecule/default` scenario covers three roles — `kernel_tuning`, `ulimits`, and `crash_diagnostics` — but `verify.yml` had zero assertions for `crash_diagnostics`, leaving its outcomes untested.

## Approach

Add 6 comprehensive assertions for the `crash_diagnostics` role to the existing `molecule/default/verify.yml`:

1. Memory-config log directory (`/var/log/memory-config`) created
2. `memory-config-logger.sh` script deployed
3. `memory-config-logger.sh` is executable
4. `mce-monitor.sh` script deployed
5. `mce-monitor.sh` is executable
6. `strace` package installed (representative crash_diagnostics package)

All assertions use container-safe checks (file/stat — no systemd or hardware dependencies), consistent with the existing verify.yml style.

## Files changed

- `molecule/default/verify.yml` — add 6 crash_diagnostics role assertions

## CI status

none — no CI workflows triggered on feature branches

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
