### PR TITLE
🤖 Fix #28: Add enterprise subscription config to common role

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -8,8 +8,12 @@ common_packages:
   - rasdaemon
 
 # Proxmox enterprise subscription key. Leave null to use no-subscription repo (default).
-# When set, enables enterprise repos and optionally removes the no-subscription repo.
+# When set, activates the subscription via `pvesubscription set` and enables
+# both the PVE and Ceph enterprise repositories.
 common_proxmox_subscription_key: null
 
-# Set false to keep no-subscription repo alongside enterprise repo
+# Set false to keep no-subscription repos alongside enterprise repos
 common_proxmox_remove_nosubscription_repo: true
+
+# Ceph release codename used in repository URLs (e.g. "squid", "reef", "quincy")
+common_proxmox_ceph_release: squid

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -6,3 +6,10 @@ common_packages:
   - iotop
   - lm-sensors
   - rasdaemon
+
+# Proxmox enterprise subscription key. Leave null to use no-subscription repo (default).
+# When set, enables enterprise repos and optionally removes the no-subscription repo.
+proxmox_subscription_key: null
+
+# Set false to keep no-subscription repo alongside enterprise repo
+proxmox_remove_nosubscription_repo: true

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -9,7 +9,7 @@ common_packages:
 
 # Proxmox enterprise subscription key. Leave null to use no-subscription repo (default).
 # When set, enables enterprise repos and optionally removes the no-subscription repo.
-proxmox_subscription_key: null
+common_proxmox_subscription_key: null
 
 # Set false to keep no-subscription repo alongside enterprise repo
-proxmox_remove_nosubscription_repo: true
+common_proxmox_remove_nosubscription_repo: true

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,33 +1,73 @@
 ---
 # Common role tasks
 
-- name: Proxmox no-subscription repository
+# Subscription activation must happen first so that any later `apt update`
+# against the enterprise repos can authenticate. `/etc/pve` is a FUSE-mounted
+# pmxcfs filesystem; the subscription record is managed by the `pvesubscription`
+# CLI rather than by writing files directly.
+- name: Activate Proxmox subscription
+  ansible.builtin.command:
+    cmd: "pvesubscription set {{ common_proxmox_subscription_key }}"
+  when: common_proxmox_subscription_key is not none
+  register: common_pvesubscription_set
+  changed_when: common_pvesubscription_set.rc == 0
+  no_log: true
+  tags:
+    - common
+    - repositories
+
+- name: Refresh Proxmox subscription status
+  ansible.builtin.command:
+    cmd: pvesubscription update
+  when:
+    - common_proxmox_subscription_key is not none
+    - common_pvesubscription_set is succeeded
+  register: common_pvesubscription_update
+  changed_when: common_pvesubscription_update.rc == 0
+  tags:
+    - common
+    - repositories
+
+# Repository state is gated on successful subscription activation so we never
+# enable an authenticated repo that the host cannot reach. `update_cache: false`
+# avoids redundant intermediate `apt update` runs; the dedicated cache-update
+# task below performs the single refresh.
+- name: Proxmox PVE no-subscription repository
   ansible.builtin.apt_repository:
     repo: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
     state: "{{ 'absent' if (common_proxmox_subscription_key is not none and common_proxmox_remove_nosubscription_repo | bool) else 'present' }}"
     filename: pve-no-subscription
+    update_cache: false
   tags:
     - common
     - repositories
 
-- name: Proxmox enterprise repository
+- name: Proxmox Ceph no-subscription repository
+  ansible.builtin.apt_repository:
+    repo: "deb http://download.proxmox.com/debian/ceph-{{ common_proxmox_ceph_release }} {{ ansible_distribution_release }} no-subscription"
+    state: "{{ 'absent' if (common_proxmox_subscription_key is not none and common_proxmox_remove_nosubscription_repo | bool) else 'present' }}"
+    filename: ceph-no-subscription
+    update_cache: false
+  tags:
+    - common
+    - repositories
+
+- name: Proxmox PVE enterprise repository
   ansible.builtin.apt_repository:
     repo: "deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise"
-    state: "{{ 'present' if common_proxmox_subscription_key is not none else 'absent' }}"
+    state: "{{ 'present' if (common_proxmox_subscription_key is not none and (common_pvesubscription_update is succeeded)) else 'absent' }}"
     filename: pve-enterprise
+    update_cache: false
   tags:
     - common
     - repositories
 
-- name: Store Proxmox subscription key
-  ansible.builtin.copy:
-    content: "{{ common_proxmox_subscription_key }}"
-    dest: /etc/pve/subscription
-    owner: root
-    group: root
-    mode: "0600"
-  when: common_proxmox_subscription_key is not none
-  no_log: true
+- name: Proxmox Ceph enterprise repository
+  ansible.builtin.apt_repository:
+    repo: "deb https://enterprise.proxmox.com/debian/ceph-{{ common_proxmox_ceph_release }} {{ ansible_distribution_release }} enterprise"
+    state: "{{ 'present' if (common_proxmox_subscription_key is not none and (common_pvesubscription_update is succeeded)) else 'absent' }}"
+    filename: ceph-enterprise
+    update_cache: false
   tags:
     - common
     - repositories

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Proxmox no-subscription repository
   ansible.builtin.apt_repository:
     repo: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
-    state: "{{ 'absent' if (proxmox_subscription_key is not none and proxmox_remove_nosubscription_repo | bool) else 'present' }}"
+    state: "{{ 'absent' if (common_proxmox_subscription_key is not none and common_proxmox_remove_nosubscription_repo | bool) else 'present' }}"
     filename: pve-no-subscription
   tags:
     - common
@@ -13,7 +13,7 @@
 - name: Proxmox enterprise repository
   ansible.builtin.apt_repository:
     repo: "deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise"
-    state: "{{ 'present' if proxmox_subscription_key is not none else 'absent' }}"
+    state: "{{ 'present' if common_proxmox_subscription_key is not none else 'absent' }}"
     filename: pve-enterprise
   tags:
     - common
@@ -21,12 +21,12 @@
 
 - name: Store Proxmox subscription key
   ansible.builtin.copy:
-    content: "{{ proxmox_subscription_key }}"
+    content: "{{ common_proxmox_subscription_key }}"
     dest: /etc/pve/subscription
     owner: root
     group: root
     mode: "0600"
-  when: proxmox_subscription_key is not none
+  when: common_proxmox_subscription_key is not none
   no_log: true
   tags:
     - common

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,6 +1,37 @@
 ---
 # Common role tasks
 
+- name: Proxmox no-subscription repository
+  ansible.builtin.apt_repository:
+    repo: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription"
+    state: "{{ 'absent' if (proxmox_subscription_key is not none and proxmox_remove_nosubscription_repo | bool) else 'present' }}"
+    filename: pve-no-subscription
+  tags:
+    - common
+    - repositories
+
+- name: Proxmox enterprise repository
+  ansible.builtin.apt_repository:
+    repo: "deb https://enterprise.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-enterprise"
+    state: "{{ 'present' if proxmox_subscription_key is not none else 'absent' }}"
+    filename: pve-enterprise
+  tags:
+    - common
+    - repositories
+
+- name: Store Proxmox subscription key
+  ansible.builtin.copy:
+    content: "{{ proxmox_subscription_key }}"
+    dest: /etc/pve/subscription
+    owner: root
+    group: root
+    mode: "0600"
+  when: proxmox_subscription_key is not none
+  no_log: true
+  tags:
+    - common
+    - repositories
+
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: true


### PR DESCRIPTION
Closes #28

## Problem

The `common` role currently has no support for Proxmox enterprise repository configuration. Enterprise users need a way to optionally configure the enterprise APT repository when a subscription key is provided, while keeping the no-subscription repository as the default for open-source users.

## Approach

Added two new variables to `roles/common/defaults/main.yml`:
- `proxmox_subscription_key: null` — set to your Proxmox subscription key to enable enterprise repos
- `proxmox_remove_nosubscription_repo: true` — controls whether the no-subscription repo is removed

Added three new tasks to `roles/common/tasks/main.yml` (before the `apt cache update`):
- Manage no-subscription repo state (present when no key; absent when key provided and flag set)
- Manage enterprise PVE repo state (present when key provided; absent otherwise)
- Store subscription key at `/etc/pve/subscription` (0600, `no_log: true` to keep key out of logs)

Default behavior is unchanged: `proxmox_subscription_key: null` means the no-subscription repo is ensured present, enterprise repo is absent — identical to current behavior.

## Files changed

- `roles/common/defaults/main.yml` — add `proxmox_subscription_key` and `proxmox_remove_nosubscription_repo` defaults
- `roles/common/tasks/main.yml` — add repo management tasks with conditional logic and `no_log: true` for key security

## CI status

none — CI check-runs not yet triggered; will update once PR CI runs complete.

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
