### PR TITLE
fix(pre-commit): exclude release-please CHANGELOG.md from markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,4 +37,4 @@ repos:
     hooks:
       - id: markdownlint
         args: [--config, .markdownlint.json]
-        exclude: ^\.github/aw/
+        exclude: ^(\.github/aw/|CHANGELOG\.md$)


### PR DESCRIPTION
Closes #200

## Problem

The `markdownlint` pre-commit hook fails on `CHANGELOG.md`, which release-please auto-generates with formatting that violates the project's markdownlint rules:

- `MD012/no-multiple-blanks`: release-please inserts two blank lines between version sections.
- `MD013/line-length`: commit/PR links (e.g., `https://github.com/.../commit/<sha>`) routinely exceed 160 chars.

Every push gets blocked unless the developer uses `--no-verify`, which violates the no-bypass policy.

## Fix

Extend the existing `exclude` regex on the `markdownlint` hook to also match `CHANGELOG.md`:

```yaml
exclude: ^(\.github/aw/|CHANGELOG\.md$)
```

The CHANGELOG is regenerated on every release-please bump, so hand-formatting it is not viable.

## Verification

```
$ pre-commit run markdownlint --all-files
markdownlint.............................................................Passed

$ pre-commit run markdownlint --files CHANGELOG.md
markdownlint.........................................(no files to check)Skipped
```

## Test plan

- [x] `pre-commit run markdownlint --all-files` passes on this branch
- [x] `pre-commit run markdownlint --files CHANGELOG.md` correctly skips
- [x] Commit is GPG-signed