### PR TITLE
feat(idrac_kiosk): add pve kiosk showing both iDRAC consoles

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -54,3 +54,7 @@
         ntp_allow_cidrs:
           - "192.168.0.0/16"
           - "10.0.0.0/8"
+
+    - role: idrac_kiosk
+      tags:
+        - idrac_kiosk

--- a/roles/idrac_kiosk/README.md
+++ b/roles/idrac_kiosk/README.md
@@ -1,0 +1,117 @@
+# iDRAC Kiosk Role
+
+Runs a minimal Wayland kiosk on the `pve` host that drives a physically
+attached monitor (HDMI/DisplayPort off the AMD iGPU) and displays **both**
+iDRAC6 HTML5 (noVNC) KVM consoles side-by-side, fullscreen.
+
+The page is a local `file://` document with two iframes pointing at the iDRAC6
+viewers served from LXC 251.
+
+## Policy exception
+
+This repository's hosts are otherwise **headless with no extra desktop
+software**. This role is a deliberate, user-approved exception, scoped to the
+single node `pve`:
+
+- It adds a desktop graphics stack (`cage` + `chromium`) to one host only.
+- The kiosk is **read-only** — it shows consoles; it does not control Proxmox.
+- It uses the node's **existing** HDMI/DP output (zero new hardware).
+
+Disable it with `idrac_kiosk_enabled: false` to make the role a no-op without
+removing it from the play.
+
+## Dependencies
+
+The kiosk only shows content if the upstream viewers are live:
+
+- **LXC 251** (`10.0.1.251`) must be serving the two iDRAC6 noVNC viewers:
+  - `http://10.0.1.251:5410/` — Dell R410
+  - `http://10.0.1.251:5710/` — Dell R710
+- That LXC and its ports are provisioned by the companion
+  `terraform-proxmox` and `ansible-proxmox-apps` iDRAC work.
+
+If the viewers are down, the iframes simply fail to load; the kiosk itself
+stays up and retries on the browser's normal schedule.
+
+## Variables
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `idrac_kiosk_enabled` | `true` | Master switch; `false` makes the role a no-op |
+| `idrac_kiosk_kvm_ip` | `10.0.1.251` | LXC serving the noVNC viewers |
+| `idrac_kiosk_r410_port` | `5410` | R410 viewer port |
+| `idrac_kiosk_r710_port` | `5710` | R710 viewer port |
+| `idrac_kiosk_data_dir` | `/opt/idrac-kiosk` | On-host dir for the landing page |
+| `idrac_kiosk_user` | `kiosk` | Unprivileged user running the session |
+
+## Installation
+
+The role is wired into `playbooks/site.yml` and runs against the `proxmox`
+group. No extra installation step is needed beyond the standard play:
+
+```bash
+ansible-playbook playbooks/site.yml --tags idrac_kiosk
+```
+
+## Usage
+
+Override the vars to change targets without editing the template:
+
+```yaml
+- hosts: proxmox
+  roles:
+    - role: idrac_kiosk
+      vars:
+        idrac_kiosk_kvm_ip: "10.0.1.99"
+        idrac_kiosk_r410_port: 6410
+        idrac_kiosk_r710_port: 6710
+```
+
+## How it works
+
+- `seatd` provides seat access without a full login manager.
+- The `kiosk` user is added to `video`, `render`, `input`, and `seat` so it can
+  open the DRM device and input devices directly.
+- A systemd system service (`idrac-kiosk.service`) launches
+  `cage -- chromium --kiosk ... --app=file://.../index.html`.
+- `cage` hosts a single fullscreen Wayland app; `chromium` renders the page.
+- systemd provides a writable `XDG_RUNTIME_DIR` via `RuntimeDirectory=` (logind
+  does not create one for a system service).
+
+## Hardware caveats
+
+Verify on the real host — these are easy to miss on a node that has only ever
+run headless:
+
+- **GPU microcode**: `firmware-amd-graphics` lives in the Debian
+  `non-free-firmware` apt component. The role does **not** silently rewrite
+  your apt sources; it checks availability and warns if the package cannot be
+  installed. Enable `non-free-firmware` yourself, then re-run.
+- **KMS / DRM device**: amdgpu must bind and create a render node. After first
+  installing the firmware on a previously-headless node, a **reboot** may be
+  required. Confirm the device exists:
+
+  ```bash
+  ls -l /dev/dri/card0 /dev/dri/renderD128
+  ```
+
+- **Output**: the iGPU drives both HDMI and DisplayPort; plug the monitor into
+  either.
+
+## iDRAC6 session cap
+
+iDRAC6 vKVM allows roughly **two** concurrent virtual-console sessions per
+server. A permanent kiosk **holds one session per server** for as long as it
+runs. Plan accordingly: if you also open a console from a workstation you may
+hit the limit and need to close the kiosk session (`systemctl stop
+idrac-kiosk` on `pve`) or reset the iDRAC's stuck sessions.
+
+## Operating
+
+```bash
+# On pve:
+systemctl status idrac-kiosk      # service state
+journalctl -u idrac-kiosk -b      # current-boot logs
+systemctl restart idrac-kiosk     # reload after a config/page change
+systemctl stop idrac-kiosk        # free the iDRAC vKVM sessions
+```

--- a/roles/idrac_kiosk/defaults/main.yml
+++ b/roles/idrac_kiosk/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# iDRAC kiosk role defaults
+#
+# Drives a physical monitor on the pve host with a Wayland kiosk browser
+# showing both iDRAC6 HTML5 (noVNC) consoles side-by-side.
+
+# Master switch for the role. When false, no packages, users, or services
+# are touched.
+idrac_kiosk_enabled: true
+
+# LXC 251 serves the two iDRAC6 noVNC viewers (Dell R410 + R710).
+idrac_kiosk_kvm_ip: "10.0.1.251"
+
+# Per-server viewer ports on the LXC.
+idrac_kiosk_r410_port: 5410
+idrac_kiosk_r710_port: 5710
+
+# On-host directory holding the generated kiosk landing page.
+idrac_kiosk_data_dir: /opt/idrac-kiosk
+
+# Unprivileged user that runs the cage + chromium session.
+idrac_kiosk_user: kiosk

--- a/roles/idrac_kiosk/handlers/main.yml
+++ b/roles/idrac_kiosk/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+# iDRAC kiosk role handlers
+
+- name: Restart idrac-kiosk
+  ansible.builtin.systemd:
+    name: idrac-kiosk
+    state: restarted
+    daemon_reload: true
+  # Only meaningful on the physical host running systemd; a headless
+  # container/VM has no DRM device for cage to drive.
+  when:
+    - ansible_service_mgr == 'systemd'
+    - ansible_virtualization_type == 'NA' or ansible_virtualization_role == 'host'

--- a/roles/idrac_kiosk/meta/main.yml
+++ b/roles/idrac_kiosk/meta/main.yml
@@ -1,0 +1,23 @@
+---
+# iDRAC kiosk role metadata
+
+galaxy_info:
+  role_name: idrac_kiosk
+  author: ansible-proxmox
+  description: Host Wayland kiosk showing both iDRAC6 HTML5 consoles side-by-side
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - proxmox
+    - kiosk
+    - idrac
+    - wayland
+
+dependencies: []

--- a/roles/idrac_kiosk/tasks/main.yml
+++ b/roles/idrac_kiosk/tasks/main.yml
@@ -1,0 +1,151 @@
+---
+# iDRAC kiosk role tasks
+#
+# POLICY EXCEPTION: this repo otherwise keeps Proxmox hosts headless with no
+# extra desktop software. This role is a user-approved exception for the single
+# node `pve`: a read-only kiosk on the host's existing HDMI/DP output.
+
+- name: Detect whether the non-free-firmware apt component is enabled
+  # AMD GPU microcode (firmware-amd-graphics) lives in the non-free-firmware
+  # component on Debian 12/13. We do NOT silently rewrite apt sources; we only
+  # check, and warn below if it is missing so the operator can opt in.
+  ansible.builtin.command:
+    cmd: apt-cache policy firmware-amd-graphics
+  register: idrac_kiosk_amd_fw_policy
+  changed_when: false
+  failed_when: false
+  when: idrac_kiosk_enabled | bool
+  tags:
+    - idrac_kiosk
+
+- name: Warn when firmware-amd-graphics is not available
+  ansible.builtin.debug:
+    msg: >-
+      firmware-amd-graphics is not installable. The AMD iGPU on `pve` likely
+      needs the `non-free-firmware` apt component. Add it to your apt sources
+      (e.g. the components list in /etc/apt/sources.list or the relevant
+      .sources file), then re-run. Without GPU microcode the kiosk may fall
+      back to software rendering or fail to drive HDMI/DP.
+  when:
+    - idrac_kiosk_enabled | bool
+    - "'Candidate: (none)' in (idrac_kiosk_amd_fw_policy.stdout | default(''))
+       or idrac_kiosk_amd_fw_policy.rc | default(1) != 0"
+  tags:
+    - idrac_kiosk
+
+- name: Install kiosk packages
+  ansible.builtin.apt:
+    name:
+      - cage                  # minimal Wayland kiosk compositor (single app)
+      - chromium              # Debian browser package name
+      - seatd                 # seat management for the non-logind session
+      - libgl1-mesa-dri       # Mesa DRI drivers (OpenGL on the AMD iGPU)
+      - mesa-vulkan-drivers   # Vulkan drivers for the AMD iGPU
+      - fonts-dejavu-core     # baseline fonts so the noVNC UI renders
+    state: present
+    update_cache: true
+  when: idrac_kiosk_enabled | bool
+  tags:
+    - idrac_kiosk
+
+- name: Install AMD GPU firmware
+  # Separate task: this package only exists once non-free-firmware is enabled.
+  # Do not fail the play if it is unavailable; the warning above covers it.
+  ansible.builtin.apt:
+    name: firmware-amd-graphics
+    state: present
+    update_cache: true
+  when:
+    - idrac_kiosk_enabled | bool
+    - "'Candidate: (none)' not in (idrac_kiosk_amd_fw_policy.stdout | default(''))"
+    - idrac_kiosk_amd_fw_policy.rc | default(1) == 0
+  tags:
+    - idrac_kiosk
+
+- name: Enable and start seatd
+  ansible.builtin.systemd:
+    name: seatd
+    enabled: true
+    state: started
+  # seatd needs a real init; skip the start in containers without systemd.
+  when:
+    - idrac_kiosk_enabled | bool
+    - ansible_service_mgr == 'systemd'
+  tags:
+    - idrac_kiosk
+
+- name: Discover supplementary groups present on the host
+  ansible.builtin.getent:
+    database: group
+  when: idrac_kiosk_enabled | bool
+  tags:
+    - idrac_kiosk
+
+- name: Create the kiosk user
+  # video/render/input grant DRM + evdev access; seat (created by seatd) grants
+  # seatd access. Only request groups that actually exist on this host so the
+  # play does not fail if seatd has not created its group yet.
+  ansible.builtin.user:
+    name: "{{ idrac_kiosk_user }}"
+    state: present
+    system: true
+    create_home: true
+    home: "/home/{{ idrac_kiosk_user }}"
+    shell: /usr/sbin/nologin
+    groups: "{{ ['video', 'render', 'input', 'seat']
+                | select('in', ansible_facts.getent_group | default({}))
+                | list }}"
+    append: true
+  when: idrac_kiosk_enabled | bool
+  tags:
+    - idrac_kiosk
+
+- name: Create the kiosk data directory
+  ansible.builtin.file:
+    path: "{{ idrac_kiosk_data_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: idrac_kiosk_enabled | bool
+  tags:
+    - idrac_kiosk
+
+- name: Deploy the kiosk landing page
+  ansible.builtin.template:
+    src: index.html.j2
+    dest: "{{ idrac_kiosk_data_dir }}/index.html"
+    owner: root
+    group: root
+    mode: "0644"
+  when: idrac_kiosk_enabled | bool
+  notify: Restart idrac-kiosk
+  tags:
+    - idrac_kiosk
+
+- name: Deploy the kiosk systemd service
+  ansible.builtin.template:
+    src: idrac-kiosk.service.j2
+    dest: /etc/systemd/system/idrac-kiosk.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: idrac_kiosk_enabled | bool
+  notify: Restart idrac-kiosk
+  tags:
+    - idrac_kiosk
+
+- name: Enable and start the kiosk service
+  ansible.builtin.systemd:
+    name: idrac-kiosk
+    enabled: true
+    state: started
+    daemon_reload: true
+  # Real hardware only: a headless container/VM has no DRM device to drive, so
+  # only enable+start on the physical Proxmox host running systemd.
+  when:
+    - idrac_kiosk_enabled | bool
+    - ansible_service_mgr == 'systemd'
+    - ansible_virtualization_type == 'NA' or ansible_virtualization_role == 'host'
+  tags:
+    - idrac_kiosk

--- a/roles/idrac_kiosk/templates/idrac-kiosk.service.j2
+++ b/roles/idrac_kiosk/templates/idrac-kiosk.service.j2
@@ -1,0 +1,23 @@
+{# Managed by Ansible (idrac_kiosk role). Do not edit on the host. #}
+[Unit]
+Description=iDRAC kiosk (cage + chromium) showing both iDRAC6 consoles
+Documentation=https://github.com/dryvist/ansible-proxmox
+After=seatd.service systemd-user-sessions.service
+Wants=seatd.service
+
+[Service]
+Type=simple
+User={{ idrac_kiosk_user }}
+# systemd creates /run/user-style runtime dir owned by the service user and
+# tears it down on stop. cage/wlroots and chromium both require a writable
+# XDG_RUNTIME_DIR; logind does not create one for a system service.
+RuntimeDirectory=idrac-kiosk
+Environment=XDG_RUNTIME_DIR=/run/idrac-kiosk
+Environment=WLR_RENDERER=gles2
+# cage hosts a single Wayland app fullscreen; chromium runs as the kiosk app.
+ExecStart=/usr/bin/cage -- /usr/bin/chromium --kiosk --ozone-platform=wayland --noerrdialogs --disable-infobars --incognito --no-first-run --app=file://{{ idrac_kiosk_data_dir }}/index.html
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/idrac_kiosk/templates/index.html.j2
+++ b/roles/idrac_kiosk/templates/index.html.j2
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!-- Managed by Ansible (idrac_kiosk role). Do not edit on the host. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>iDRAC consoles</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+        overflow: hidden;
+        background: #000;
+      }
+      .console-grid {
+        display: flex;
+        height: 100vh;
+        width: 100vw;
+      }
+      .console-grid iframe {
+        flex: 1 1 50%;
+        height: 100%;
+        width: 50%;
+        border: 0;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="console-grid">
+      <iframe src="http://{{ idrac_kiosk_kvm_ip }}:{{ idrac_kiosk_r410_port }}/" title="Dell R410 iDRAC6"></iframe>
+      <iframe src="http://{{ idrac_kiosk_kvm_ip }}:{{ idrac_kiosk_r710_port }}/" title="Dell R710 iDRAC6"></iframe>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Add an idrac_kiosk role that runs a minimal Wayland kiosk (cage + chromium)
on the single node `pve`, driving its existing HDMI/DP output to show both
iDRAC6 HTML5 (noVNC) consoles side-by-side, fullscreen.

POLICY EXCEPTION: this repo otherwise keeps Proxmox hosts headless with no
extra desktop software. This is a deliberate, user-approved exception scoped
to `pve`: a read-only kiosk on existing hardware (zero new hardware). The
role is gated behind idrac_kiosk_enabled and the README documents the
exception, the amdgpu/firmware-amd-graphics + non-free-firmware caveat, and
the iDRAC6 ~2-session vKVM cap (a permanent kiosk holds one session/server).

Depends on LXC 251 (10.0.1.251) serving the two viewers on ports 5410 (R410)
and 5710 (R710); pairs with the companion terraform-proxmox and
ansible-proxmox-apps iDRAC PRs.

Assisted-by: Claude <noreply@anthropic.com>
