### PR TITLE
feat(zfs_pools): codify per-node ZFS storage from terraform node_storage

### DIFF
--- a/molecule/zfs_pools/converge.yml
+++ b/molecule/zfs_pools/converge.yml
@@ -1,0 +1,27 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    # Mirrors terraform-proxmox ansible_inventory.node_storage["pve2"], the
+    # live pve2 contract (tank raidz1 + tank/backups). ZFS/pvesm tasks are
+    # skipped under Docker; this proves the role converges and the contract
+    # plumbing resolves.
+    zfs_pools_from_terraform:
+      pools:
+        tank:
+          type: zfspool
+          raid: raidz1
+          protected: true
+          register: true
+          content:
+            - images
+            - rootdir
+          datasets:
+            backups:
+              quota: "1T"
+
+  roles:
+    - role: zfs_pools

--- a/molecule/zfs_pools/molecule.yml
+++ b/molecule/zfs_pools/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-zfs-pools-test
+    image: debian:12-slim
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/zfs_pools/prepare.yml
+++ b/molecule/zfs_pools/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Install Python and system utilities
+      ansible.builtin.raw: |
+        apt-get update && apt-get install -y python3 procps
+      changed_when: true

--- a/molecule/zfs_pools/verify.yml
+++ b/molecule/zfs_pools/verify.yml
@@ -1,0 +1,40 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    zfs_pools_from_terraform:
+      pools:
+        tank:
+          datasets:
+            backups:
+              quota: "1T"
+
+  tasks:
+    - name: Re-derive pools from the injected node_storage contract
+      ansible.builtin.set_fact:
+        zfs_pools_check: "{{ zfs_pools_from_terraform.pools | default({}) }}"
+
+    - name: Assert the contract exposes tank/backups with a 1T quota
+      ansible.builtin.assert:
+        that:
+          - "'tank' in zfs_pools_check"
+          - zfs_pools_check.tank.datasets.backups.quota == '1T'
+          # Confirms the byte-comparison used for idempotent quota drift.
+          - (zfs_pools_check.tank.datasets.backups.quota | human_to_bytes) == 1099511627776
+        fail_msg: "node_storage contract did not resolve as expected"
+
+    - name: Probe for ZFS pools (should be absent in the molecule container)
+      ansible.builtin.command:
+        cmd: zpool list
+      register: zfs_pools_zpool_probe
+      changed_when: false
+      failed_when: false
+
+    - name: Assert the role skipped ZFS under Docker (no pool created)
+      ansible.builtin.assert:
+        that:
+          - zfs_pools_zpool_probe.rc != 0
+        fail_msg: "Unexpected zpool present — Docker skip guard may be broken"

--- a/playbooks/load_terraform.yml
+++ b/playbooks/load_terraform.yml
@@ -60,3 +60,15 @@
         name: "{{ item }}"
         nas_storage_from_terraform: "{{ terraform_data.host_services.nas }}"
       loop: "{{ groups['proxmox'] | default([]) }}"
+
+    # Per-node ZFS storage (node_storage) is optional — present only once the
+    # terraform-proxmox multi-node contract is applied. Keyed by each host's
+    # `proxmox_node_name` (the terraform node name; e.g. an inventory host
+    # `node-a` maps to terraform node `pve2`), defaulting to inventory_hostname.
+    - name: Inject Terraform per-node ZFS storage onto proxmox hosts
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        zfs_pools_from_terraform: >-
+          {{ (terraform_data.node_storage | default({}))[hostvars[item].proxmox_node_name | default(item)] | default({}) }}
+        cluster_nodes_from_terraform: "{{ terraform_data.nodes | default({}) }}"
+      loop: "{{ groups['proxmox'] | default([]) }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -46,6 +46,10 @@
       tags:
         - nas_storage
 
+    - role: zfs_pools
+      tags:
+        - zfs_pools
+
     - role: ntp
       tags:
         - ntp

--- a/roles/zfs_pools/README.md
+++ b/roles/zfs_pools/README.md
@@ -1,0 +1,82 @@
+# zfs_pools
+
+Manages ZFS **datasets, quotas, and Proxmox storage registration** for the
+per-node pools declared in `terraform-proxmox`'s `node_storage` output.
+
+## Installation
+
+This role ships in the `ansible-proxmox` repository and is applied via
+`playbooks/site.yml`. No separate installation is required beyond cloning the
+repo and installing collection dependencies:
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
+## Scope (and what it deliberately does NOT do)
+
+`terraform-proxmox` declares storage; `ansible-proxmox` realizes it. The
+Proxmox API cannot create ZFS pools (`zpool create` is an OS operation), so the
+contract is split:
+
+| Layer | Owns |
+| --- | --- |
+| Host commissioning (auto-install / manual) | `zpool create` from physical devices |
+| **this role** | datasets, quotas, `pvesm` storage registration |
+| terraform-proxmox | references the datastore by `id` on VM/LXC disks |
+
+**Pool creation is opt-in and off by default.** Creating a pool needs the
+host-specific device list (`by-id` paths), which is not in the committed
+contract, and getting it wrong destroys data. By default the role asserts a
+`register=true` pool already exists and manages datasets within it. To allow
+creation, set in untracked `host_vars`:
+
+```yaml
+zfs_pools_allow_create: true
+zfs_pools_devices:
+  tank: ["/dev/disk/by-id/...", "/dev/disk/by-id/...", "/dev/disk/by-id/..."]
+```
+
+## Inputs
+
+`inventory/load_terraform.yml` injects `zfs_pools_from_terraform` onto each
+proxmox host: the `node_storage[<node>]` entry for that host, keyed by the
+host's `proxmox_node_name` (defaults to the inventory hostname). Set
+`proxmox_node_name` in `host_vars` when the inventory name differs from the
+terraform node name (e.g. inventory `node-a` → terraform `pve2`).
+
+Shape (`zfs_pools_map`):
+
+```yaml
+zfs_pools_map:
+  tank:
+    type: zfspool
+    raid: raidz1          # informational
+    protected: true       # storage-safety (hold/readonly enforcement: design pending)
+    register: true        # run `pvesm add zfspool` if not already registered
+    content: [images, rootdir]
+    datasets:
+      backups: { quota: "1T" }
+```
+
+## Usage
+
+```bash
+# Dry run — storage tasks only
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags zfs_pools --check
+# Apply
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags zfs_pools
+```
+
+## Idempotency
+
+- Pools: checked with `zpool list`; only created when explicitly allowed.
+- Datasets: checked with `zfs list`; created with `zfs create -p` when absent.
+- Quotas: compared in **bytes** (`zfs get -Hp` vs `human_to_bytes(desired)`), so
+  `1T` and `1024G` do not cause spurious changes.
+- Registration: `pvesm status --storage <pool>` gates `pvesm add`.
+
+All ZFS / `pvesm` tasks are skipped under Docker (`ansible_virtualization_type
+== 'docker'`) for molecule testing.

--- a/roles/zfs_pools/defaults/main.yml
+++ b/roles/zfs_pools/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+# zfs_pools role defaults
+#
+# Consumes the per-node ZFS storage declaration produced by terraform-proxmox
+# (ansible_inventory.node_storage[<node>]) and injected onto the host by
+# inventory/load_terraform.yml as `zfs_pools_from_terraform`.
+
+zfs_pools_config: >-
+  {{
+    zfs_pools_from_terraform
+    | default(hostvars[inventory_hostname].zfs_pools_from_terraform | default({}), true)
+  }}
+
+# Map of pools for this node, keyed by pool name. Shape per pool:
+#   { type, raid, protected, register, content, datasets: { <name>: { quota, mountpoint } } }
+zfs_pools_map: "{{ zfs_pools_config.pools | default({}) }}"
+
+# SAFETY: creating a zpool from raw devices is a destructive commissioning step
+# and the device list is host-specific (by-id paths), so it is NOT part of the
+# committed terraform contract. By default this role only manages datasets,
+# quotas, and Proxmox storage registration on pools that ALREADY exist, and
+# asserts presence for pools marked register=true.
+#
+# To let the role create a missing pool, set both (in untracked host_vars):
+#   zfs_pools_allow_create: true
+#   zfs_pools_devices: { "<pool>": ["/dev/disk/by-id/...", ...] }
+zfs_pools_allow_create: false
+zfs_pools_devices: {}

--- a/roles/zfs_pools/tasks/datasets.yml
+++ b/roles/zfs_pools/tasks/datasets.yml
@@ -1,0 +1,55 @@
+---
+# Manage datasets within a single pool.
+# Included per-pool from main.yml with loop_var `zfs_pool`
+# (a dict2items entry: { key: <pool>, value: { datasets: {...}, ... } }).
+# Quotas are compared in bytes (zfs -p) against human_to_bytes(desired) so the
+# tasks are idempotent regardless of unit formatting (1T vs 1024G).
+
+- name: "Check datasets exist in pool {{ zfs_pool.key }}"
+  ansible.builtin.command:
+    cmd: "zfs list -H -o name {{ zfs_pool.key }}/{{ item.key }}"
+  register: zfs_pools_ds_check
+  changed_when: false
+  failed_when: false
+  loop: "{{ zfs_pool.value.datasets | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ zfs_pool.key }}/{{ item.key }}"
+  tags:
+    - zfs_pools
+
+- name: "Create missing datasets in pool {{ zfs_pool.key }}"
+  ansible.builtin.command:
+    cmd: "zfs create -p {{ zfs_pool.key }}/{{ item.key }}"
+  loop: "{{ zfs_pool.value.datasets | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ zfs_pool.key }}/{{ item.key }}"
+    index_var: zfs_pools_ds_idx
+  when: zfs_pools_ds_check.results[zfs_pools_ds_idx].rc != 0
+  changed_when: true
+  tags:
+    - zfs_pools
+
+- name: "Read current dataset quotas in pool {{ zfs_pool.key }}"
+  ansible.builtin.command:
+    cmd: "zfs get -Hp -o value quota {{ zfs_pool.key }}/{{ item.key }}"
+  register: zfs_pools_ds_quota
+  changed_when: false
+  loop: "{{ zfs_pool.value.datasets | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ zfs_pool.key }}/{{ item.key }}"
+  tags:
+    - zfs_pools
+
+- name: "Set dataset quotas in pool {{ zfs_pool.key }}"
+  ansible.builtin.command:
+    cmd: "zfs set quota={{ item.value.quota }} {{ zfs_pool.key }}/{{ item.key }}"
+  loop: "{{ zfs_pool.value.datasets | default({}) | dict2items }}"
+  loop_control:
+    label: "{{ zfs_pool.key }}/{{ item.key }}={{ item.value.quota | default('none') }}"
+    index_var: zfs_pools_ds_idx
+  when:
+    - item.value.quota | default('') | length > 0
+    - zfs_pools_ds_quota.results[zfs_pools_ds_idx].stdout | int != item.value.quota | human_to_bytes
+  changed_when: true
+  tags:
+    - zfs_pools

--- a/roles/zfs_pools/tasks/main.yml
+++ b/roles/zfs_pools/tasks/main.yml
@@ -1,0 +1,115 @@
+---
+# zfs_pools role tasks
+#
+# Manages ZFS datasets, quotas, and Proxmox storage registration for the pools
+# declared in terraform-proxmox `node_storage`. zpool CREATION is a host
+# commissioning step (device-specific, destructive) and is opt-in only — by
+# default the role asserts the pool exists and manages datasets within it.
+# All ZFS / pvesm / systemd tasks are skipped under Docker (molecule testing).
+
+- name: Check which declared ZFS pools exist
+  ansible.builtin.command:
+    cmd: "zpool list -H -o name {{ item.key }}"
+  register: zfs_pools_existing
+  changed_when: false
+  failed_when: false
+  loop: "{{ zfs_pools_map | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: ansible_virtualization_type != 'docker'
+  tags:
+    - zfs_pools
+
+- name: Build set of present pools
+  ansible.builtin.set_fact:
+    zfs_pools_present: >-
+      {{
+        zfs_pools_existing.results | default([])
+        | selectattr('rc', 'defined')
+        | selectattr('rc', 'equalto', 0)
+        | map(attribute='item.key') | list
+      }}
+  when: ansible_virtualization_type != 'docker'
+  tags:
+    - zfs_pools
+
+- name: Create missing pools (opt-in, guarded by zfs_pools_allow_create + devices)
+  ansible.builtin.command:
+    cmd: >-
+      zpool create -o ashift=12 {{ item.key }}
+      {{ item.value.raid | default('') }}
+      {{ zfs_pools_devices[item.key] | default([]) | join(' ') }}
+  loop: "{{ zfs_pools_map | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - ansible_virtualization_type != 'docker'
+    - item.key not in zfs_pools_present
+    - zfs_pools_allow_create | bool
+    - zfs_pools_devices[item.key] | default([]) | length > 0
+  changed_when: true
+  tags:
+    - zfs_pools
+
+- name: Assert registerable pools exist (creation is a commissioning step)
+  ansible.builtin.assert:
+    that:
+      - item.key in zfs_pools_present or zfs_pools_allow_create | bool
+    fail_msg: >-
+      ZFS pool '{{ item.key }}' does not exist on {{ inventory_hostname }} and
+      zfs_pools_allow_create is false. Create it during host commissioning
+      (zpool create with the correct by-id devices), or set
+      zfs_pools_allow_create + zfs_pools_devices.{{ item.key }} in host_vars.
+  loop: "{{ zfs_pools_map | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - ansible_virtualization_type != 'docker'
+    - item.value.register | default(true) | bool
+  tags:
+    - zfs_pools
+
+- name: Manage datasets for each present pool
+  ansible.builtin.include_tasks: datasets.yml
+  loop: "{{ zfs_pools_map | dict2items }}"
+  loop_control:
+    loop_var: zfs_pool
+    label: "{{ zfs_pool.key }}"
+  when:
+    - ansible_virtualization_type != 'docker'
+    - zfs_pool.key in zfs_pools_present
+  tags:
+    - zfs_pools
+
+- name: Check existing Proxmox storage registrations
+  ansible.builtin.command:
+    cmd: "pvesm status --storage {{ item.key }}"
+  register: zfs_pools_pvesm_check
+  changed_when: false
+  failed_when: false
+  loop: "{{ zfs_pools_map | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - ansible_virtualization_type != 'docker'
+    - item.key in zfs_pools_present
+    - item.value.register | default(true) | bool
+  tags:
+    - zfs_pools
+
+- name: Register pools as Proxmox ZFS storage (node-scoped)
+  ansible.builtin.command:
+    cmd: >-
+      pvesm add zfspool {{ item.item.key }} -pool {{ item.item.key }}
+      -content {{ item.item.content | default(['images', 'rootdir']) | join(',') }}
+      -nodes {{ proxmox_node_name | default(inventory_hostname) }}
+  loop: "{{ zfs_pools_pvesm_check.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.key | default('') }}"
+  when:
+    - ansible_virtualization_type != 'docker'
+    - item.rc is defined
+    - item.rc != 0
+  changed_when: true
+  tags:
+    - zfs_pools


### PR DESCRIPTION
## Summary

Realizes the `terraform-proxmox` `node_storage` contract on Proxmox hosts — the Ansible half of the pve2/pve3 storage codification. Pairs with `dryvist/terraform-proxmox#325`.

## New `zfs_pools` role
Modeled on `nas_storage` / `zfs_swap`.
- Manages ZFS **datasets, quotas, and Proxmox storage registration** for the pools in `ansible_inventory.node_storage[<node>]`.
- **Idempotent**: `zpool`/`zfs list` existence checks; quotas compared in **bytes** (`zfs -Hp` vs `human_to_bytes`) so `1T` vs `1024G` doesn't churn; `pvesm` registration gated by `pvesm status`.
- Skips all ZFS/`pvesm` under Docker (molecule).

### Honest scope: Ansible manages datasets, commissioning creates the pool
`zpool create` needs host-specific `by-id` devices (not in the committed contract) and is destructive, so it's a **commissioning step**, opt-in only (`zfs_pools_allow_create` + `zfs_pools_devices` in untracked host_vars). By default the role **asserts** a `register=true` pool exists and manages datasets within it. pve2's live `tank` already exists — this manages `tank/backups` + registration.

## Wiring
- `load_terraform.yml` injects `zfs_pools_from_terraform` (the `node_storage[node]` entry, keyed by each host's `proxmox_node_name`, defaulting to the inventory hostname) and the cluster `nodes` map. Non-fatal when absent (older inventories).
- `site.yml` runs `zfs_pools` after `nas_storage`.
- `molecule/zfs_pools` scenario mirrors `nas_storage` (asserts the contract math + that the Docker skip guard holds).

## Notes
- **Multi-host inventory already exists** (`rack_servers` group + `commission_rack_server.yml` + untracked `host_vars`) — no inventory change needed.
- **Host serial console deferred** to a focused follow-up: it must integrate with `kernel_tuning`'s `/etc/kernel/cmdline` / GRUB management (which `crash_diagnostics` also touches) to avoid boot-param conflicts. iDRAC cipher-0/IPMI recovery stays in private `int_homelab` runbooks.

## Test plan
- [x] `ansible-lint` — **production** profile, 0 failures
- [x] `pre-commit run` — trailing-whitespace, EOF, check-yaml, yamllint, ansible-lint, markdownlint all pass
- [x] `ansible-playbook --syntax-check` — converge + site.yml parse clean
- [ ] `molecule test -s zfs_pools` — **could not run locally** (the nix `shells/ansible` devshell lacks the python `docker` SDK → molecule-plugins docker driver `UnboundLocalError`). Runs in CI. Consider adding the `docker` SDK to `nix-devenv` `shells/ansible`.
- [ ] Live run on pve2 after cluster-join: `doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags zfs_pools --check`

Refs: dryvist/terraform-proxmox#325

🤖 Generated with [Claude Code](https://claude.com/claude-code)