### PR TITLE
feat(playbooks): add PVE point-upgrade play (snapshot + repos + upgrade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,36 @@ Wiring `terraform-proxmox`'s `rack_servers` output into Ansible host_vars
 is a forward-looking enhancement — the existing `load_terraform.yml` only
 injects the NAS `host_services` contract today.
 
+### Upgrading a node to the latest point release (PVE 9.x)
+
+`playbooks/upgrade.yml` brings a node to the current point release on its
+channel (`apt full-upgrade`), then reboots for the new kernel and verifies
+`pveversion`. It first imports `playbooks/snapshot.yml`, which snapshots the
+ZFS root (boot environment) dataset as a restore point — instant and near-zero
+space. An OS upgrade does not touch guest disks (separate datasets), so the
+root snapshot, not a guest backup, is the right rollback artifact. It then
+applies the `pve_repositories` role, which keeps the node on the
+no-subscription channel (deb822 `.sources`, enterprise repo disabled) without
+touching the Debian base repos. If `pve_repositories_apt_proxy` is set (real URL
+injected via the `APT_PROXY_URL` env var, e.g. an apt-cacher-ng instance), apt
+`http://` fetches are routed through that caching proxy. Run it with console
+access available; the node reboots.
+
+```bash
+# Test (snapshot and reboot are skipped in check mode):
+./scripts/run-ansible.sh playbooks/upgrade.yml -l pve --check --diff
+
+# Apply:
+./scripts/run-ansible.sh playbooks/upgrade.yml -l pve
+```
+
+`playbooks/snapshot.yml` is also runnable on its own. If a node's root layout
+differs from the `rpool/ROOT/pve-1` default, override `pve_snapshot_dataset`.
+The upgrade assumes the node already has working apt repos for its channel
+(`apt update` fails loudly otherwise). To upgrade now and reboot later, pass
+`-e pve_upgrade_reboot=false`. Roll back a bad upgrade from a rescue boot with
+`zfs rollback <snapshot>`.
+
 ## Customization
 
 All settings have sensible defaults. Override them in

--- a/inventory/group_vars/proxmox.yml
+++ b/inventory/group_vars/proxmox.yml
@@ -46,3 +46,8 @@ common_packages:
   - iotop
   - lm-sensors
   - rasdaemon
+
+# apt caching proxy (apt-cacher-ng) for Proxmox nodes. The real URL is injected
+# via the APT_PROXY_URL env var (e.g. from Doppler), like http://<acng>:3142, so
+# no environment-specific address is committed. Empty disables the proxy.
+pve_repositories_apt_proxy: "{{ lookup('env', 'APT_PROXY_URL') | default('', true) }}"

--- a/playbooks/snapshot.yml
+++ b/playbooks/snapshot.yml
@@ -1,0 +1,19 @@
+---
+# Take a ZFS snapshot of the root (boot environment) dataset on Proxmox VE nodes.
+#
+# Standalone-runnable, and imported by playbooks/upgrade.yml as a pre-change
+# restore point. Override pve_snapshot_dataset if the node's root layout differs
+# from the rpool/ROOT/pve-1 default.
+#
+# Usage:
+#   ./scripts/run-ansible.sh playbooks/snapshot.yml -l pve
+
+- name: Snapshot Proxmox VE root dataset
+  hosts: proxmox
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: pve_snapshot
+      tags:
+        - pve_snapshot

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -1,0 +1,30 @@
+---
+# Upgrade Proxmox VE nodes to the latest point release on their channel.
+#
+# Composes the snapshot play first (ZFS root restore point) — mirroring how
+# site.yml imports load_terraform.yml — then normalizes the apt repositories to
+# the no-subscription channel (pve_repositories), runs apt full-upgrade, reboots
+# for the new kernel, and verifies the version. Deliberately does NOT import
+# load_terraform.yml (NAS-focused; irrelevant to an OS upgrade), matching
+# commission_rack_server.yml.
+#
+# Usage (test — snapshot and reboot are skipped in check mode):
+#   ./scripts/run-ansible.sh playbooks/upgrade.yml -l pve --check --diff
+# Usage (apply — run with console access available; the node reboots):
+#   ./scripts/run-ansible.sh playbooks/upgrade.yml -l pve
+
+- name: Snapshot the root dataset before upgrading
+  import_playbook: snapshot.yml
+
+- name: Upgrade Proxmox VE nodes
+  hosts: proxmox
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: pve_repositories
+      tags:
+        - pve_repositories
+    - role: pve_upgrade
+      tags:
+        - pve_upgrade

--- a/roles/pve_repositories/defaults/main.yml
+++ b/roles/pve_repositories/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# pve_repositories role defaults
+
+# Master switch. Set false to leave the node's apt repositories untouched.
+pve_repositories_manage: true
+
+# Ceph repo channel codename used in the no-subscription Ceph repository URI.
+pve_repositories_ceph_release: squid
+
+# Keyring that signs the Proxmox repositories (PVE 9 / Debian 13 default).
+pve_repositories_keyring: /usr/share/keyrings/proxmox-archive-keyring.gpg
+
+# Optional apt caching proxy (e.g. apt-cacher-ng) for HTTP repositories. Empty
+# disables it. When set, apt routes http:// fetches through this proxy, which
+# caches packages and can reach upstream mirrors more reliably than each node.
+# Real value is injected per environment (see group_vars), never hardcoded here.
+pve_repositories_apt_proxy: ""

--- a/roles/pve_repositories/tasks/main.yml
+++ b/roles/pve_repositories/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+# pve_repositories role tasks — keep the Proxmox apt repositories on the
+# no-subscription channel using the deb822 .sources format (PVE 9 default),
+# idempotently. Each Proxmox repo is its own .sources file, so this manages them
+# individually via ansible.builtin.deb822_repository and leaves the Debian base
+# repositories (debian.sources) untouched.
+
+- name: Ensure the PVE no-subscription repository is enabled
+  ansible.builtin.deb822_repository:
+    name: proxmox
+    types: deb
+    uris: http://download.proxmox.com/debian/pve
+    suites: "{{ ansible_distribution_release }}"
+    components: pve-no-subscription
+    signed_by: "{{ pve_repositories_keyring }}"
+    enabled: true
+    state: present
+  when: pve_repositories_manage | bool
+  tags:
+    - pve_repositories
+    - repositories
+
+- name: Ensure the Ceph no-subscription repository is enabled
+  ansible.builtin.deb822_repository:
+    name: ceph
+    types: deb
+    uris: "http://download.proxmox.com/debian/ceph-{{ pve_repositories_ceph_release }}"
+    suites: "{{ ansible_distribution_release }}"
+    components: no-subscription
+    signed_by: "{{ pve_repositories_keyring }}"
+    enabled: true
+    state: present
+  when: pve_repositories_manage | bool
+  tags:
+    - pve_repositories
+    - repositories
+
+- name: Ensure the PVE enterprise repository is present but disabled
+  ansible.builtin.deb822_repository:
+    name: pve-enterprise
+    types: deb
+    uris: https://enterprise.proxmox.com/debian/pve
+    suites: "{{ ansible_distribution_release }}"
+    components: pve-enterprise
+    signed_by: "{{ pve_repositories_keyring }}"
+    enabled: false
+    state: present
+  when: pve_repositories_manage | bool
+  tags:
+    - pve_repositories
+    - repositories
+
+- name: Configure apt to use the caching proxy
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/00acng-proxy
+    content: |
+      // Ansible managed - pve_repositories role
+      // Route apt http:// fetches through the caching proxy (apt-cacher-ng).
+      Acquire::http::Proxy "{{ pve_repositories_apt_proxy }}";
+    owner: root
+    group: root
+    mode: "0644"
+  when:
+    - pve_repositories_manage | bool
+    - pve_repositories_apt_proxy | length > 0
+  tags:
+    - pve_repositories
+    - repositories
+
+- name: Remove the apt caching proxy config when unset
+  ansible.builtin.file:
+    path: /etc/apt/apt.conf.d/00acng-proxy
+    state: absent
+  when:
+    - pve_repositories_manage | bool
+    - pve_repositories_apt_proxy | length == 0
+  tags:
+    - pve_repositories
+    - repositories

--- a/roles/pve_snapshot/defaults/main.yml
+++ b/roles/pve_snapshot/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# pve_snapshot role defaults
+
+# Master switch. Set false to skip the pre-change snapshot.
+pve_snapshot_enabled: true
+
+# ZFS root (boot environment) dataset to snapshot before a change. The default
+# matches a standard PVE ZFS-on-root install (rpool/ROOT/pve-1). Override per
+# host if the layout differs (check `zfs list -o name,mountpoint`).
+pve_snapshot_dataset: rpool/ROOT/pve-1
+
+# Snapshot tag prefix. A UTC timestamp is appended for uniqueness, so each run
+# leaves its own restore point (e.g. rpool/ROOT/pve-1@pre-upgrade-20260529T...).
+pve_snapshot_prefix: pre-upgrade

--- a/roles/pve_snapshot/tasks/main.yml
+++ b/roles/pve_snapshot/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# pve_snapshot role tasks — take a ZFS snapshot of the root (boot environment)
+# dataset as a pre-change restore point. Instant and near-zero space. If an
+# upgrade leaves the node unbootable, roll back with `zfs rollback <snap>` from a
+# rescue boot. This protects the host OS only; guest disks are separate datasets.
+
+- name: Verify the root dataset exists
+  ansible.builtin.command:
+    cmd: "zfs list -H -o name {{ pve_snapshot_dataset }}"
+  register: pve_snapshot_dataset_check
+  changed_when: false
+  check_mode: false
+  when: pve_snapshot_enabled | bool
+  tags:
+    - pve_snapshot
+
+- name: Build the snapshot name
+  ansible.builtin.set_fact:
+    # Use now() (evaluated at runtime) rather than ansible_date_time, which is a
+    # fact and gets stale under fact caching — two runs would collide on the same
+    # timestamped snapshot name. Folded scalar keeps the line under 120 chars.
+    pve_snapshot_name: >-
+      {{ pve_snapshot_dataset }}@{{ pve_snapshot_prefix }}-{{ now(utc=true, fmt='%Y%m%dT%H%M%S') }}
+  when: pve_snapshot_enabled | bool
+  tags:
+    - pve_snapshot
+
+- name: Snapshot the root dataset
+  ansible.builtin.command:
+    cmd: "zfs snapshot {{ pve_snapshot_name }}"
+  register: pve_snapshot_result
+  changed_when: pve_snapshot_result.rc == 0
+  when: pve_snapshot_enabled | bool
+  tags:
+    - pve_snapshot
+
+- name: Report the restore point
+  ansible.builtin.debug:
+    msg: >-
+      Created restore point {{ pve_snapshot_name }}
+      (roll back from a rescue boot with: zfs rollback {{ pve_snapshot_name }})
+  when:
+    - pve_snapshot_enabled | bool
+    - not ansible_check_mode
+  tags:
+    - pve_snapshot

--- a/roles/pve_upgrade/defaults/main.yml
+++ b/roles/pve_upgrade/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# pve_upgrade role defaults
+
+# Reboot the node after the upgrade when packages changed — a new kernel only
+# takes effect after a reboot. Set false to upgrade now and reboot manually in
+# a chosen window.
+pve_upgrade_reboot: true
+
+# Seconds to wait for the node to come back after the reboot.
+pve_upgrade_reboot_timeout: 600
+
+# Substring asserted in `pveversion` output after the upgrade. The role does not
+# pin an exact build: the no-subscription channel always serves the latest 9.x
+# point release, so the node lands on current 9.2.x.
+pve_upgrade_expected_version: "9.2"
+
+# This role runs the upgrade only. Repository normalization (keeping the node on
+# the no-subscription channel) is handled by the pve_repositories role, which
+# playbooks/upgrade.yml applies first.

--- a/roles/pve_upgrade/tasks/main.yml
+++ b/roles/pve_upgrade/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+# pve_upgrade role tasks — bring a Proxmox VE node to the latest point release on
+# its channel (apt full-upgrade), reboot for the new kernel, and verify the
+# version. Assumes working apt repos for the channel (see defaults).
+
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+  tags:
+    - pve_upgrade
+
+- name: Perform full distribution upgrade (apt full-upgrade)
+  ansible.builtin.apt:
+    upgrade: dist
+  register: pve_upgrade_result
+  tags:
+    - pve_upgrade
+
+- name: Remove now-unused packages (apt autoremove)
+  ansible.builtin.apt:
+    autoremove: true
+  tags:
+    - pve_upgrade
+
+- name: Reboot when packages changed (new kernel takes effect on reboot)
+  ansible.builtin.reboot:
+    reboot_timeout: "{{ pve_upgrade_reboot_timeout | int }}"
+    msg: Reboot triggered by ansible pve_upgrade role
+  when:
+    - pve_upgrade_reboot | bool
+    - pve_upgrade_result is changed
+  tags:
+    - pve_upgrade
+
+# pveversion is read-only, but skip the verify in check mode: a dry run has not
+# actually upgraded anything, so asserting the new version would falsely fail.
+- name: Query Proxmox VE version
+  ansible.builtin.command:
+    cmd: pveversion
+  register: pve_upgrade_pveversion
+  changed_when: false
+  when: not ansible_check_mode
+  tags:
+    - pve_upgrade
+
+- name: Assert the node is on the expected PVE version
+  ansible.builtin.assert:
+    that:
+      - pve_upgrade_expected_version in pve_upgrade_pveversion.stdout
+    success_msg: "pveversion reports {{ pve_upgrade_pveversion.stdout }}"
+    fail_msg: >-
+      Expected '{{ pve_upgrade_expected_version }}' in pveversion output but got:
+      {{ pve_upgrade_pveversion.stdout | default('(pveversion not run)') }}
+  when: not ansible_check_mode
+  tags:
+    - pve_upgrade


### PR DESCRIPTION
## What

Adds a reusable, idempotent point-upgrade path for PVE 9.x nodes. Previously
neither this repo nor `terraform-proxmox` had any `apt full-upgrade` capability —
node OS upgrades were unmanaged.

New roles:

- **`pve_snapshot`** — snapshots the ZFS root/boot-environment dataset
  (`rpool/ROOT/pve-1` by default) as a pre-change restore point: instant,
  near-zero space. An OS upgrade does not touch guest disks (separate datasets),
  so the root snapshot — not a guest backup — is the correct rollback artifact.
  Names the snapshot with `now()` (not the cached `ansible_date_time` fact) so it
  stays unique under this repo's fact caching.
- **`pve_repositories`** — keeps Proxmox apt repos on the **no-subscription**
  channel via deb822 `.sources` (`ansible.builtin.deb822_repository`): `proxmox`
  + `ceph` no-subscription enabled, `pve-enterprise` present but disabled. Manages
  each Proxmox `.sources` file individually and leaves `debian.sources` untouched.
  Optional `pve_repositories_apt_proxy` (real URL injected via `APT_PROXY_URL`
  env var — no environment address committed) routes apt `http://` fetches
  through a caching proxy such as apt-cacher-ng.
- **`pve_upgrade`** — `apt update` → `apt full-upgrade` → `autoremove` → reboot
  (only when packages changed) → assert `pveversion`. Reboot/verify are skipped
  in check mode so dry runs don't falsely fail.

New playbooks:

- **`playbooks/snapshot.yml`** — standalone root snapshot.
- **`playbooks/upgrade.yml`** — imports `snapshot.yml` first (mirroring how
  `site.yml` imports `load_terraform.yml`), then applies `pve_repositories` then
  `pve_upgrade`. Deliberately does **not** import `load_terraform.yml`
  (NAS-focused), matching `commission_rack_server.yml`.

## Validation

- `yamllint`, `ansible-lint` (profile `production`), and `--syntax-check` all pass.
- Dry-run (`--check --diff`) and a full live run validated end-to-end against a
  real PVE node: **pve-manager 9.1.4 → 9.2.3**, kernel `7.0.2-7-pve`, clean
  reboot + reconnect, `pveversion` assert green (`failed=0`).

## Testing notes

These roles act on a live PVE host (snapshot, repo writes, `full-upgrade`,
reboot), which can't be meaningfully exercised in the container-based molecule
scenarios — so they are intentionally not wired into them; full integration runs
on real hosts, consistent with the existing `zfs_swap`/`nas_storage` note in
`molecule/default/converge.yml`.

## Usage

```bash
# test (snapshot/reboot skipped in check mode)
./scripts/run-ansible.sh playbooks/upgrade.yml -l pve --check --diff
# apply (node reboots; run with console access available)
./scripts/run-ansible.sh playbooks/upgrade.yml -l pve
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)