### PR TITLE
feat(pve_node_rename): idempotent standalone pre-cluster node rename

### DIFF
--- a/molecule/pve_node_rename/converge.yml
+++ b/molecule/pve_node_rename/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    # Test fixtures only. Addresses are RFC 5737 documentation ranges
+    # (TEST-NET) so nothing real is implied. The live homelab supplies the
+    # real compute-VLAN IP + node name from inventory/SOPS, never literals.
+    pve_node_rename_from: oldnode
+    pve_node_rename_to: newnode
+    pve_node_rename_ip: "203.0.113.10"
+    pve_node_rename_fqdn: newnode.example.invalid
+    pve_node_rename_stale_ips:
+      - "198.51.100.14"
+
+  roles:
+    - role: pve_node_rename

--- a/molecule/pve_node_rename/molecule.yml
+++ b/molecule/pve_node_rename/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-node-rename-test
+    image: debian:12-slim
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/pve_node_rename/prepare.yml
+++ b/molecule/pve_node_rename/prepare.yml
@@ -1,0 +1,22 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Install Python and system utilities
+      ansible.builtin.raw: |
+        apt-get update && apt-get install -y python3 procps hostname
+      changed_when: true
+
+    # Seed /etc/hosts with a pre-rename identity: a stale address line plus the
+    # old short name, so the role has real content to clean up. Addresses are
+    # RFC 5737 documentation ranges (TEST-NET) — never real infrastructure.
+    - name: Seed a stale-identity /etc/hosts
+      ansible.builtin.copy:
+        dest: /etc/hosts
+        mode: "0644"
+        content: |
+          127.0.0.1 localhost
+          198.51.100.14 oldnode.example.invalid oldnode
+          203.0.113.10 oldnode.example.invalid oldnode

--- a/molecule/pve_node_rename/verify.yml
+++ b/molecule/pve_node_rename/verify.yml
@@ -1,0 +1,27 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Read /etc/hosts
+      ansible.builtin.slurp:
+        src: /etc/hosts
+      register: pve_node_rename_hosts
+
+    - name: Decode /etc/hosts
+      ansible.builtin.set_fact:
+        pve_node_rename_hosts_text: "{{ pve_node_rename_hosts.content | b64decode }}"
+
+    - name: Assert the renamed node identity is present and stale identity is gone
+      ansible.builtin.assert:
+        that:
+          # New identity line written with FQDN + new short name.
+          - "'203.0.113.10 newnode.example.invalid newnode' in pve_node_rename_hosts_text"
+          # Stale address line removed.
+          - "'198.51.100.14' not in pve_node_rename_hosts_text"
+          # Old short name no longer present anywhere.
+          - "'oldnode' not in pve_node_rename_hosts_text"
+        fail_msg: "/etc/hosts was not rewritten to the new node identity"
+        success_msg: "/etc/hosts reflects the renamed node and stale identity is cleaned"

--- a/playbooks/rename_node.yml
+++ b/playbooks/rename_node.yml
@@ -1,0 +1,23 @@
+---
+# Rename a STANDALONE (pre-cluster) Proxmox VE node.
+#
+# This is a deliberate, one-off, pre-cluster operation — it is NOT part of
+# `site.yml` (which targets the whole cluster). Run it against a single
+# standalone node only, AFTER taking a snapshot, BEFORE cluster formation
+# (`pve_cluster` role). The role hard-refuses to run on a clustered node.
+#
+# The new node name and the compute-VLAN IP come from inventory / SOPS /
+# Doppler — never pass literal IPs on the command line.
+#
+# Usage:
+#   doppler run -- ansible-playbook -i inventory playbooks/rename_node.yml -l <node>
+
+- name: Rename standalone Proxmox VE node
+  hosts: proxmox
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: pve_node_rename
+      tags:
+        - pve_node_rename

--- a/roles/pve_node_rename/README.md
+++ b/roles/pve_node_rename/README.md
@@ -1,0 +1,77 @@
+# pve_node_rename
+
+Idempotently rename a **standalone** (pre-cluster) Proxmox VE node — hostname,
+`/etc/hosts`, and the pmxcfs node directory under `/etc/pve` — and strip the
+node's stale pre-rename identity addresses.
+
+## When to use this
+
+A node rename is **only safe while standalone**. Renaming a node that is already
+part of a cluster corrupts pmxcfs and quorum (see ADR-0001 in `int_homelab`).
+This role therefore **hard-refuses to run** when it detects corosync
+configuration or a quorate corosync membership.
+
+The homelab use case is the one-time `pve` → `pve1` rename, performed *before*
+cluster formation (`pve_cluster` role), as part of moving the node's identity
+from the legacy `net` VLAN onto the `compute` VLAN. The role itself is
+host-agnostic.
+
+## Installation
+
+This role ships in the `ansible-proxmox` repository. No separate installation is
+required beyond cloning the repo and installing collection dependencies:
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
+## What it does
+
+| Step | Action | Idempotence |
+| --- | --- | --- |
+| Preflight | Assert the node is standalone (no corosync) | Read-only gate |
+| Hostname | `ansible.builtin.hostname` to the new name | Skipped when already set |
+| `/etc/hosts` cleanup | Remove `pve_node_rename_stale_ips` lines | `lineinfile state=absent` |
+| `/etc/hosts` rename | Replace old short name with new | Skipped when names equal |
+| `/etc/hosts` identity | Ensure mgmt IP → renamed node line | Managed by `regexp` |
+| pmxcfs | `mv /etc/pve/nodes/<old> <new>` | Only when src exists, dst absent |
+| corosync | Fix single-node `nodename` if file present | Only when file references old name |
+
+All pmxcfs / `/etc/pve` operations are skipped under Docker
+(`ansible_virtualization_type == 'docker'`) so the role is molecule-testable in
+containers.
+
+## Inputs
+
+No literal IPs are baked in — supply real addresses from inventory / SOPS /
+Doppler.
+
+```yaml
+pve_node_rename_to: pve1                 # new node name (default)
+pve_node_rename_from: "{{ ansible_hostname }}"  # defaults to live hostname
+pve_node_rename_ip: "{{ ansible_host }}" # compute-VLAN mgmt IP for /etc/hosts
+pve_node_rename_stale_ips: []            # old VLAN IP(s) to strip, e.g. the legacy net-VLAN address
+pve_node_rename_fqdn: ""                 # optional FQDN for the /etc/hosts entry
+pve_node_rename_force_when_clustered: false  # escape hatch; leave false
+```
+
+## Usage
+
+```bash
+# Dry run (rename tasks only)
+doppler run -- ./scripts/run-ansible.sh playbooks/rename_node.yml --check --diff
+
+# Apply — STANDALONE node only, take a snapshot first
+doppler run -- ./scripts/run-ansible.sh playbooks/rename_node.yml
+```
+
+After applying, verify the API/UI shows the new node name and the old name is
+gone from `pvecm nodes` / the node tree, then proceed to cluster formation.
+
+## Safety
+
+- Refuses to run on a clustered node (corosync detected).
+- Every mutating step is guarded so a second run is a no-op.
+- Takes no backups itself — snapshot the node before running.

--- a/roles/pve_node_rename/defaults/main.yml
+++ b/roles/pve_node_rename/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+# pve_node_rename role defaults
+#
+# Renames a STANDALONE (pre-cluster) Proxmox VE node — the only window in which
+# a node rename is safe. Renaming a *clustered* node is high-risk and this role
+# refuses to run when corosync/quorum is present (see ADR-0001 in int_homelab).
+#
+# All real addresses come from inventory / SOPS / Doppler — never hardcode an IP
+# here. The current homelab use is `pve` -> `pve1`, moving its identity from the
+# legacy `net` VLAN to the `compute` VLAN, but the role is host-agnostic.
+
+# Target node name to rename TO (the new pmxcfs node identity + hostname).
+pve_node_rename_to: pve1
+
+# Source node name to rename FROM. Defaults to the live hostname so a re-run
+# after a successful rename is a no-op (source == target -> nothing to do).
+pve_node_rename_from: "{{ ansible_hostname }}"
+
+# Management/compute IP the renamed node should resolve to in /etc/hosts.
+# Supply from inventory (e.g. ansible_host) or a SOPS/Doppler-injected var.
+# Leave empty to skip the /etc/hosts address rewrite (hostname/pmxcfs only).
+pve_node_rename_ip: "{{ ansible_host | default('') }}"
+
+# Stale identity addresses to strip from /etc/hosts (the old VLAN IP[s] the
+# node used before the rename, e.g. the legacy net-VLAN 10.0.1.x address).
+# Supply from inventory/SOPS — no literal default so nothing is baked in here.
+pve_node_rename_stale_ips: []
+
+# Fully-qualified domain name for the renamed node's /etc/hosts entry. When
+# empty, only the short name is written.
+pve_node_rename_fqdn: ""
+
+# SAFETY GATE. The role hard-refuses to touch a node that looks clustered
+# (corosync config present or a quorate corosync membership). Renaming a
+# clustered node corrupts pmxcfs. Only set true if you have independently
+# confirmed the node is standalone and the detection is a false positive.
+pve_node_rename_force_when_clustered: false

--- a/roles/pve_node_rename/meta/main.yml
+++ b/roles/pve_node_rename/meta/main.yml
@@ -1,0 +1,23 @@
+---
+# pve_node_rename role metadata
+
+galaxy_info:
+  role_name: pve_node_rename
+  author: ansible-proxmox
+  description: Idempotently rename a standalone (pre-cluster) Proxmox VE node
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - proxmox
+    - cluster
+    - rename
+    - hostname
+
+dependencies: []

--- a/roles/pve_node_rename/tasks/main.yml
+++ b/roles/pve_node_rename/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+# pve_node_rename role tasks
+#
+# Idempotently rename a STANDALONE Proxmox VE node: hostname, /etc/hosts (new
+# identity + stale-IP cleanup), and the pmxcfs node directory under /etc/pve.
+# corosync.conf nodename is fixed up only if a single-node config happens to
+# exist. The preflight gate refuses to run on a clustered node.
+#
+# All ZFS/pmxcfs/systemd-touching steps are skipped under Docker so the role can
+# be molecule-tested in containers without a live Proxmox host.
+
+- name: Run preflight safety gates
+  ansible.builtin.include_tasks: preflight.yml
+  tags:
+    - pve_node_rename
+
+- name: Set the system hostname
+  ansible.builtin.hostname:
+    name: "{{ pve_node_rename_to }}"
+  when: ansible_hostname != pve_node_rename_to
+  tags:
+    - pve_node_rename
+
+- name: Remove stale identity addresses from /etc/hosts
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: "^{{ item | regex_escape }}\\s"
+    state: absent
+  loop: "{{ pve_node_rename_stale_ips }}"
+  loop_control:
+    label: "{{ item }}"
+  tags:
+    - pve_node_rename
+
+- name: Remove old short hostname from any /etc/hosts line (pre-rename identity)
+  ansible.builtin.replace:
+    path: /etc/hosts
+    regexp: '(?<=\s){{ pve_node_rename_from | regex_escape }}(?=\s|$)'
+    replace: "{{ pve_node_rename_to }}"
+  when: pve_node_rename_from != pve_node_rename_to
+  tags:
+    - pve_node_rename
+
+- name: Ensure /etc/hosts maps the management IP to the renamed node
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: "^{{ pve_node_rename_ip | regex_escape }}\\s"
+    line: "{{ pve_node_rename_ip }} {{ (pve_node_rename_fqdn | length > 0) | ternary(pve_node_rename_fqdn ~ ' ', '') }}{{ pve_node_rename_to }}"
+    state: present
+  when: pve_node_rename_ip | length > 0
+  tags:
+    - pve_node_rename
+
+# pmxcfs stores node state under /etc/pve/nodes/<nodename>. On a standalone node
+# the rename is completed by moving that directory to the new name. /etc/pve is a
+# FUSE mount (pmxcfs), so a plain move is the documented approach; guard it so it
+# only runs when the source exists, the target does not, and names differ.
+- name: Stat current pmxcfs node directory
+  ansible.builtin.stat:
+    path: "/etc/pve/nodes/{{ pve_node_rename_from }}"
+  register: pve_node_rename_src_dir
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - pve_node_rename
+
+- name: Stat target pmxcfs node directory
+  ansible.builtin.stat:
+    path: "/etc/pve/nodes/{{ pve_node_rename_to }}"
+  register: pve_node_rename_dst_dir
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - pve_node_rename
+
+- name: Rename pmxcfs node directory to the new node name
+  ansible.builtin.command:
+    cmd: "mv /etc/pve/nodes/{{ pve_node_rename_from }} /etc/pve/nodes/{{ pve_node_rename_to }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - pve_node_rename_from != pve_node_rename_to
+    - pve_node_rename_src_dir.stat.exists | default(false)
+    - not (pve_node_rename_dst_dir.stat.exists | default(false))
+  changed_when: true
+  tags:
+    - pve_node_rename
+
+# Single-node corosync config (rare on a standalone box, but the legacy `pve`
+# carried one). Fix the nodename only if the file exists AND still references the
+# old name — never create one here (cluster formation is the pve_cluster role).
+- name: Update single-node corosync nodename if present
+  ansible.builtin.replace:
+    path: /etc/pve/corosync.conf
+    regexp: '(?<=\s)name:\s*{{ pve_node_rename_from | regex_escape }}(?=\s|$)'
+    replace: "name: {{ pve_node_rename_to }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - pve_node_rename_from != pve_node_rename_to
+    - pve_node_rename_corosync_stat.stat.exists | default(false)
+  tags:
+    - pve_node_rename

--- a/roles/pve_node_rename/tasks/preflight.yml
+++ b/roles/pve_node_rename/tasks/preflight.yml
@@ -1,0 +1,58 @@
+---
+# pve_node_rename preflight — safety gates.
+#
+# A node rename is ONLY safe while standalone. These checks refuse to proceed on
+# anything that looks clustered (corosync config present or a quorate corosync
+# membership), because renaming a clustered node corrupts pmxcfs/quorum.
+
+- name: Stat corosync configuration
+  ansible.builtin.stat:
+    path: /etc/pve/corosync.conf
+  register: pve_node_rename_corosync_stat
+  tags:
+    - pve_node_rename
+
+- name: Probe corosync quorum status
+  ansible.builtin.command:
+    cmd: corosync-quorumtool -s
+  register: pve_node_rename_quorum
+  changed_when: false
+  failed_when: false
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - pve_node_rename
+
+- name: Determine whether the node appears clustered
+  ansible.builtin.set_fact:
+    pve_node_rename_is_clustered: >-
+      {{
+        (pve_node_rename_corosync_stat.stat.exists | default(false))
+        or ((pve_node_rename_quorum.rc | default(1)) == 0)
+      }}
+  tags:
+    - pve_node_rename
+
+- name: Refuse to rename a clustered node (safety gate)
+  ansible.builtin.assert:
+    that:
+      - (not pve_node_rename_is_clustered) or (pve_node_rename_force_when_clustered | bool)
+    fail_msg: >-
+      {{ inventory_hostname }} appears to be part of a Proxmox cluster
+      (corosync.conf present or quorum reported). Renaming a clustered node
+      corrupts pmxcfs — aborting. Renames are only safe while STANDALONE
+      (pre-cluster). If this is a false positive and the node is genuinely
+      standalone, set pve_node_rename_force_when_clustered=true.
+    success_msg: "Node is standalone — safe to rename."
+  tags:
+    - pve_node_rename
+
+- name: Validate rename target
+  ansible.builtin.assert:
+    that:
+      - pve_node_rename_to | length > 0
+      - pve_node_rename_to is match('^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$')
+    fail_msg: >-
+      pve_node_rename_to ('{{ pve_node_rename_to }}') is not a valid hostname
+      label.
+  tags:
+    - pve_node_rename


### PR DESCRIPTION
## Summary

Phase 1 of the homelab re-architecture (plan: *we-finally-have-pv1*). Adds an idempotent `pve_node_rename` role that renames a **standalone, pre-cluster** Proxmox VE node and cleans its stale pre-rename identity. The homelab use is the one-off `pve` -> `pve1` rename, done before cluster formation, moving identity from the legacy `net` VLAN onto the `compute` VLAN.

- **Renames** hostname, `/etc/hosts` (new identity line + stale-IP cleanup + old-shortname rewrite), the pmxcfs node dir (`/etc/pve/nodes/<old>` -> `<new>`), and a single-node `corosync.conf` nodename if present.
- **Safety gate**: a preflight `assert` hard-refuses to run on a clustered node (corosync.conf present or quorum reported), because renaming a clustered node corrupts pmxcfs. This honors ADR-0001's concern while doing the rename in the only safe window (standalone).
- **No magic numbers**: mgmt IP, node name, and stale addresses come from inventory / SOPS — nothing literal in the role.
- Ships `playbooks/rename_node.yml` (a deliberate one-off play, **not** wired into `site.yml`) and a molecule scenario proving the `/etc/hosts` rewrite + idempotence. All pmxcfs/corosync steps skip under Docker.

## Guardrails honored

Authoring only. No playbook was run against any live host; no `pvecm`/ssh against 10.0.10.x.

## Test plan

- [x] `ansible-lint` (production profile): **passes**, 0 failures/0 warnings.
- [x] `ansible-playbook --syntax-check` on `rename_node.yml`: passes.
- [x] Preflight/guard logic exercised on a local control node (correctly reports "standalone — safe to rename", validation passes).
- [ ] `molecule test -s pve_node_rename` — **could not run locally** (no Docker daemon available in this environment). Needs a host with Docker to validate the container converge + idempotence.