### PR TITLE
feat(pve_cluster): idempotent cluster formation + multinode inventory

### DIFF
--- a/inventory/group_vars/pve_cluster_members.yml
+++ b/inventory/group_vars/pve_cluster_members.yml
@@ -1,0 +1,18 @@
+---
+# Group vars for the `pve_cluster_members` group — the nodes the `pve_cluster`
+# role is permitted to form/join into a cluster.
+#
+# The allow-list is derived FROM the group membership itself, so adding a host
+# to the group is the single source of truth (no second list to keep in sync).
+# pve_cluster_enabled stays false here — formation is opted into per-run
+# (e.g. `-e pve_cluster_enabled=true`) so a routine site.yml never forms a
+# cluster by accident.
+
+pve_cluster_member_hosts: "{{ groups['pve_cluster_members'] | default([]) }}"
+
+# The primary (cluster-creating) node. The terraform `nodes` map labels the
+# `pve` node as role pve1 — it is the control-plane primary on compute .10.
+pve_cluster_primary_host: pve
+
+# Cluster name. Non-secret structural value; override per environment if needed.
+pve_cluster_name: homelab

--- a/inventory/group_vars/pve_cluster_members.yml
+++ b/inventory/group_vars/pve_cluster_members.yml
@@ -10,9 +10,9 @@
 
 pve_cluster_member_hosts: "{{ groups['pve_cluster_members'] | default([]) }}"
 
-# The primary (cluster-creating) node. The terraform `nodes` map labels the
-# `pve` node as role pve1 — it is the control-plane primary on compute .10.
-pve_cluster_primary_host: pve
+# The primary (cluster-creating) node — control-plane on compute .10.
+# (Renamed from `pve` to `pve1` on 2026-05-30; see corosync nodelist.)
+pve_cluster_primary_host: pve1
 
 # Cluster name. Non-secret structural value; override per environment if needed.
 pve_cluster_name: homelab

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -3,12 +3,13 @@ all:
   children:
     proxmox:
       hosts:
-        pve:
-          ansible_host: "{{ lookup('env', 'PROXMOX_VE_HOSTNAME') }}"
+        pve1:
+          ansible_host: "{{ lookup('env', 'PVE1_VE_HOSTNAME') | default(omit, true) }}"
           ansible_user: "{{ lookup('env', 'PROXMOX_VM_SSH_USERNAME') }}"
           ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') | default(omit, true) }}"
-          # terraform node `pve` carries role label pve1 (compute VLAN .10).
-          proxmox_node_name: pve
+          # Primary node, compute VLAN .10. Renamed from `pve` to `pve1`
+          # on 2026-05-30 (see corosync nodelist + /etc/pve/nodes/pve1/).
+          proxmox_node_name: pve1
         pve2:
           ansible_host: "{{ lookup('env', 'PVE2_VE_HOSTNAME') | default(omit, true) }}"
           ansible_user: "{{ lookup('env', 'PROXMOX_VM_SSH_USERNAME') }}"
@@ -27,5 +28,5 @@ all:
         # here while uncommissioned; add it once its hardware is ready.
         pve_cluster_members:
           hosts:
-            pve: {}
+            pve1: {}
             pve2: {}

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -7,3 +7,25 @@ all:
           ansible_host: "{{ lookup('env', 'PROXMOX_VE_HOSTNAME') }}"
           ansible_user: "{{ lookup('env', 'PROXMOX_VM_SSH_USERNAME') }}"
           ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') | default(omit, true) }}"
+          # terraform node `pve` carries role label pve1 (compute VLAN .10).
+          proxmox_node_name: pve
+        pve2:
+          ansible_host: "{{ lookup('env', 'PVE2_VE_HOSTNAME') | default(omit, true) }}"
+          ansible_user: "{{ lookup('env', 'PROXMOX_VM_SSH_USERNAME') }}"
+          ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') | default(omit, true) }}"
+          proxmox_node_name: pve2
+        pve3:
+          ansible_host: "{{ lookup('env', 'PVE3_VE_HOSTNAME') | default(omit, true) }}"
+          ansible_user: "{{ lookup('env', 'PROXMOX_VM_SSH_USERNAME') }}"
+          ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') | default(omit, true) }}"
+          proxmox_node_name: pve3
+          # terraform `nodes.pve3.commissioned = false` (bad drive) — excluded
+          # from cluster_members and storage registration until commissioned.
+          pve_node_commissioned: false
+      children:
+        # Nodes eligible to form/join the cluster. pve3 is intentionally NOT
+        # here while uncommissioned; add it once its hardware is ready.
+        pve_cluster_members:
+          hosts:
+            pve: {}
+            pve2: {}

--- a/inventory/hosts.yml.example
+++ b/inventory/hosts.yml.example
@@ -7,7 +7,7 @@
 #   1. `load_terraform.yml` (imported by site.yml) injects
 #      `nas_storage_from_terraform` for `groups['proxmox']` — children inherit.
 #   2. After commissioning, `playbooks/site.yml` (which targets `hosts: proxmox`)
-#      manages rack servers alongside the original pve host.
+#      manages rack servers alongside the original pve1 host.
 #
 # Rack-server commissioning runs AFTER `pvecm add` joins the node to the cluster;
 # see `playbooks/commission_rack_server.yml`.
@@ -20,10 +20,10 @@ all:
   children:
     proxmox:
       hosts:
-        pve:
+        pve1:
           ansible_host: 192.168.0.100  # Replace with your Proxmox IP
           ansible_user: root
-          proxmox_node_name: pve
+          proxmox_node_name: pve1
           # ansible_ssh_private_key_file: /path/to/your/ssh/key  # Uncomment and set your SSH key path
         pve2:
           ansible_host: 192.168.0.11
@@ -38,7 +38,7 @@ all:
         # Cluster-eligible nodes. pve3 omitted while uncommissioned.
         pve_cluster_members:
           hosts:
-            pve: {}
+            pve1: {}
             pve2: {}
         rack_servers:
           hosts:

--- a/inventory/hosts.yml.example
+++ b/inventory/hosts.yml.example
@@ -11,6 +11,10 @@
 #
 # Rack-server commissioning runs AFTER `pvecm add` joins the node to the cluster;
 # see `playbooks/commission_rack_server.yml`.
+#
+# `pve_cluster_members` lists the nodes the `pve_cluster` role may form/join.
+# Keep uncommissioned nodes (e.g. one with a failed drive) OUT of this group
+# until they are ready — the role hard-refuses to touch a non-member host.
 
 all:
   children:
@@ -19,8 +23,23 @@ all:
         pve:
           ansible_host: 192.168.0.100  # Replace with your Proxmox IP
           ansible_user: root
+          proxmox_node_name: pve
           # ansible_ssh_private_key_file: /path/to/your/ssh/key  # Uncomment and set your SSH key path
+        pve2:
+          ansible_host: 192.168.0.11
+          ansible_user: root
+          proxmox_node_name: pve2
+        pve3:
+          ansible_host: 192.168.0.12
+          ansible_user: root
+          proxmox_node_name: pve3
+          pve_node_commissioned: false  # set true once hardware is ready
       children:
+        # Cluster-eligible nodes. pve3 omitted while uncommissioned.
+        pve_cluster_members:
+          hosts:
+            pve: {}
+            pve2: {}
         rack_servers:
           hosts:
             node-a:

--- a/molecule/pve_cluster/converge.yml
+++ b/molecule/pve_cluster/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    # Drive the role as the PRIMARY so no join fingerprint is needed. The
+    # container's inventory_hostname (the molecule platform name) is both the
+    # declared primary and the sole allow-listed member. Under Docker every
+    # proxmox_cluster API task is skipped, so this proves the guards pass, the
+    # Docker-skip works, and the role converges idempotently without a live PVE.
+    pve_cluster_enabled: true
+    pve_cluster_primary_host: proxmox-cluster-test
+    pve_cluster_member_hosts:
+      - proxmox-cluster-test
+    pve_cluster_name: molecule-test
+
+  roles:
+    - role: pve_cluster

--- a/molecule/pve_cluster/molecule.yml
+++ b/molecule/pve_cluster/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-cluster-test
+    image: debian:12-slim
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/pve_cluster/prepare.yml
+++ b/molecule/pve_cluster/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Install Python and system utilities
+      ansible.builtin.raw: |
+        apt-get update && apt-get install -y python3 procps
+      changed_when: true

--- a/molecule/pve_cluster/verify.yml
+++ b/molecule/pve_cluster/verify.yml
@@ -1,0 +1,37 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    pve_cluster_primary_host: proxmox-cluster-test
+    pve_cluster_member_hosts:
+      - proxmox-cluster-test
+
+  tasks:
+    - name: Re-derive the role this host would take
+      ansible.builtin.set_fact:
+        pve_cluster_role_check: >-
+          {{ (inventory_hostname == pve_cluster_primary_host) | ternary('primary', 'secondary') }}
+
+    - name: Assert role resolution + allow-list membership hold
+      ansible.builtin.assert:
+        that:
+          - pve_cluster_role_check == 'primary'
+          - inventory_hostname in pve_cluster_member_hosts
+        fail_msg: "pve_cluster role/allow-list logic did not resolve as expected"
+
+    - name: Probe for a corosync/cluster filesystem (must be absent under Docker)
+      ansible.builtin.stat:
+        path: /etc/pve/corosync.conf
+      register: pve_cluster_corosync_probe
+
+    - name: Assert no cluster was actually formed in the container
+      ansible.builtin.assert:
+        that:
+          - not pve_cluster_corosync_probe.stat.exists
+        fail_msg: >-
+          corosync.conf present — the Docker skip guard for proxmox_cluster may
+          be broken (no live cluster should be formed during molecule).
+        success_msg: "Role converged with API tasks correctly skipped under Docker"

--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -1,0 +1,42 @@
+---
+# Form the Proxmox VE cluster.
+#
+# Two ordered plays guarantee the primary creates the cluster BEFORE any
+# secondary tries to join. Both target the `pve_cluster_members` group only, so
+# uncommissioned nodes (e.g. pve3 while its drive is bad) are never touched.
+#
+# The role is inert unless enabled, so formation is an explicit, deliberate run:
+#
+#   doppler run -- ansible-playbook -i inventory playbooks/cluster.yml \
+#     -e pve_cluster_enabled=true \
+#     -e pve_cluster_fingerprint="<primary corosync fp from `pvecm status`>"
+#
+# All IPs (link0, master_ip, API host) resolve from inventory / PROXMOX_VE_* env
+# (Doppler) — no literals. See roles/pve_cluster/README.md.
+
+- name: Create the cluster on the primary node
+  hosts: pve_cluster_members
+  become: true
+  gather_facts: true
+  # Only the declared primary runs this play; secondaries fall through to join.
+  tasks:
+    - name: Apply pve_cluster (primary create)
+      ansible.builtin.include_role:
+        name: pve_cluster
+      when: inventory_hostname == pve_cluster_primary_host
+      tags:
+        - pve_cluster
+
+- name: Join secondary nodes to the cluster
+  hosts: pve_cluster_members
+  become: true
+  gather_facts: true
+  # Run joins one node at a time so corosync membership settles between joins.
+  serial: 1
+  tasks:
+    - name: Apply pve_cluster (secondary join)
+      ansible.builtin.include_role:
+        name: pve_cluster
+      when: inventory_hostname != pve_cluster_primary_host
+      tags:
+        - pve_cluster

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,3 +4,8 @@ collections:
     version: ">=2.1.0"
   - name: community.general
     version: ">=12.0.0"
+  # proxmox_cluster (pve_cluster role) — wraps pvecm create/join via the PVE API.
+  # Ceiling at <2.0.0: validate_certs default flips to true at 2.0.0; opt in
+  # deliberately rather than inherit the change silently.
+  - name: community.proxmox
+    version: ">=1.6.0,<2.0.0"

--- a/roles/pve_cluster/README.md
+++ b/roles/pve_cluster/README.md
@@ -48,8 +48,8 @@ literal in this role:
 ```yaml
 pve_cluster_enabled: false            # master switch — set true to act
 pve_cluster_name: homelab             # cluster name (primary creates it)
-pve_cluster_member_hosts: []          # allow-list, e.g. [pve, pve2]
-pve_cluster_primary_host: pve         # which inventory host creates the cluster
+pve_cluster_member_hosts: []          # allow-list, e.g. [pve1, pve2]
+pve_cluster_primary_host: pve1        # which inventory host creates the cluster
 pve_cluster_role: >-                  # auto: 'primary' on the primary, else 'secondary'
   {{ (inventory_hostname == pve_cluster_primary_host) | ternary('primary', 'secondary') }}
 pve_cluster_link0: "{{ ansible_host }}"   # corosync ring 0 (compute VLAN)

--- a/roles/pve_cluster/README.md
+++ b/roles/pve_cluster/README.md
@@ -1,0 +1,86 @@
+# pve_cluster
+
+Idempotently **form and join** a Proxmox VE cluster using
+[`community.proxmox.proxmox_cluster`][mod] — the IaC-driven wrapper around
+`pvecm`, never a raw shell `pvecm`. The primary node creates the cluster on its
+compute-VLAN corosync ring 0 (`link0`); secondary nodes join it. Re-running is a
+no-op (the module supports check mode / idempotence).
+
+[mod]: https://docs.ansible.com/ansible/latest/collections/community/proxmox/proxmox_cluster_module.html
+
+## Installation
+
+This role ships in the `ansible-proxmox` repository. It depends on the
+`community.proxmox` collection (added to `requirements.yml`) and the
+`proxmoxer >= 2.0` + `requests` Python libraries (provided by the Nix dev shell):
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
+## Safety model
+
+Cluster formation is high-risk and effectively one-directional, so the role is
+**inert by default** and triple-guarded:
+
+| Guard | Effect |
+| --- | --- |
+| `pve_cluster_enabled` (default `false`) | Role does nothing unless explicitly enabled for the run. |
+| `pve_cluster_member_hosts` allow-list | Hard-asserts `inventory_hostname` is a declared member before acting. |
+| Secondary join params | A joining node aborts unless `master_ip` + `fingerprint` are supplied. |
+| Docker skip | All API/`proxmox_cluster` calls skip under `ansible_virtualization_type == 'docker'` for molecule. |
+
+## No magic numbers
+
+Every address comes from inventory or a Doppler/SOPS-injected var — never a
+literal in this role:
+
+- `link0` defaults to the host's own `ansible_host` (its compute-VLAN
+  connection IP, itself env/SOPS-sourced).
+- `master_ip` defaults to the primary's `ansible_host` via `hostvars`.
+- API auth (`api_host`/`api_user`/`api_token_*`/`validate_certs`) reads the same
+  `PROXMOX_VE_*` env vars Doppler injects for the rest of the pipeline.
+
+## Inputs
+
+```yaml
+pve_cluster_enabled: false            # master switch — set true to act
+pve_cluster_name: homelab             # cluster name (primary creates it)
+pve_cluster_member_hosts: []          # allow-list, e.g. [pve, pve2]
+pve_cluster_primary_host: pve         # which inventory host creates the cluster
+pve_cluster_role: >-                  # auto: 'primary' on the primary, else 'secondary'
+  {{ (inventory_hostname == pve_cluster_primary_host) | ternary('primary', 'secondary') }}
+pve_cluster_link0: "{{ ansible_host }}"   # corosync ring 0 (compute VLAN)
+pve_cluster_link1: ""                 # optional ring 1 (deferred to cluster v2)
+pve_cluster_master_ip: "{{ hostvars[pve_cluster_primary_host].ansible_host }}"
+pve_cluster_fingerprint: ""           # primary corosync cert fp — supply at run time
+```
+
+`pve_cluster_fingerprint` is host/cluster specific (changes on reinstall) and is
+**not committed** — read it from `pvecm status` on the primary and pass via `-e`
+or a SOPS-encrypted var.
+
+## Usage
+
+The cluster is formed by `playbooks/cluster.yml`, which targets the primary
+first (creates) then secondaries (join). `pve3` is excluded while its
+terraform `commissioned` flag is `false` (bad drive).
+
+```bash
+# Form the cluster (enable + allow-list supplied at run time, fingerprint via -e)
+doppler run -- ansible-playbook -i inventory playbooks/cluster.yml \
+  -e pve_cluster_enabled=true \
+  -e pve_cluster_fingerprint="<primary fp from pvecm status>"
+```
+
+After forming, verify on the primary: `pvecm status` shows the expected nodes
+quorate on their compute-VLAN IPs.
+
+## Idempotency
+
+`community.proxmox.proxmox_cluster` is check-mode capable: on an
+already-formed/already-joined node it reports no change. The role additionally
+reads `proxmox_cluster_status_info` on the primary and asserts the cluster is
+quorate. All ZFS-free; under Docker every API task is skipped.

--- a/roles/pve_cluster/defaults/main.yml
+++ b/roles/pve_cluster/defaults/main.yml
@@ -1,0 +1,62 @@
+---
+# pve_cluster role defaults
+#
+# Forms / joins a Proxmox VE cluster idempotently via the
+# `community.proxmox.proxmox_cluster` module (the IaC-driven wrapper around
+# `pvecm` — never a raw shell `pvecm`). The primary node creates the cluster on
+# its compute-VLAN link0; secondary nodes join it. Re-running is a no-op
+# (the module supports check_mode/idempotence).
+#
+# SAFETY: this role is INERT by default. It does nothing unless
+# `pve_cluster_enabled` is true AND the host is in `pve_cluster_member_hosts`.
+# It also skips all API operations under Docker so it is molecule-testable in
+# containers without a live Proxmox cluster.
+#
+# NO MAGIC NUMBERS: every IP comes from inventory (`ansible_host`, itself
+# env/SOPS-injected) or a Doppler/SOPS-sourced var — never a literal here.
+
+# Master switch. Cluster formation is high-risk and one-directional, so the
+# role refuses to act unless this is explicitly turned on for the run.
+pve_cluster_enabled: false
+
+# The cluster name used when the primary creates the cluster.
+pve_cluster_name: homelab
+
+# Allow-list of inventory hostnames this role is permitted to touch. The role
+# hard-asserts inventory_hostname is in this set before doing anything, so a
+# stray run against an unintended host aborts. Populate from inventory/group_vars.
+pve_cluster_member_hosts: []
+
+# This host's role in the cluster: "primary" creates, anything else joins.
+# Derive from the terraform `nodes` map (role "pve1" == primary); default
+# resolves the primary by name match against pve_cluster_primary_host.
+pve_cluster_role: >-
+  {{ (inventory_hostname == pve_cluster_primary_host) | ternary('primary', 'secondary') }}
+
+# Inventory hostname of the primary (cluster-creating) node.
+pve_cluster_primary_host: pve
+
+# link0 — the IP this node uses for corosync ring 0. Defaults to the host's own
+# inventory connection IP (compute VLAN). Override per-host only if corosync
+# must ride a different interface than the management connection.
+pve_cluster_link0: "{{ ansible_host | default(omit) }}"
+
+# Optional second corosync ring (deferred to cluster v2 in ADR-0001; leave
+# empty to use a single link). Supply a per-host IP to enable.
+pve_cluster_link1: ""
+
+# Join parameters (secondary nodes). master_ip defaults to the primary's
+# inventory connection IP via hostvars — no literal. fingerprint is the
+# primary's corosync cert fingerprint; supply at run time (it is host/cluster
+# specific and changes on reinstall) via -e or a SOPS var. When empty on a
+# secondary, the role fails fast with guidance rather than guessing.
+pve_cluster_master_ip: "{{ hostvars[pve_cluster_primary_host].ansible_host | default('') }}"
+pve_cluster_fingerprint: ""
+
+# Proxmox API authentication for the module. Sourced from the same Doppler
+# PROXMOX_VE_* env vars the rest of the pipeline uses — never committed.
+pve_cluster_api_host: "{{ lookup('env', 'PROXMOX_VE_HOSTNAME') | default(ansible_host, true) }}"
+pve_cluster_api_user: "{{ lookup('env', 'PROXMOX_VE_USERNAME') | default('root@pam', true) }}"
+pve_cluster_api_token_id: "{{ lookup('env', 'PROXMOX_VE_TOKEN_ID') | default(omit, true) }}"
+pve_cluster_api_token_secret: "{{ lookup('env', 'PROXMOX_VE_TOKEN_SECRET') | default(omit, true) }}"
+pve_cluster_api_validate_certs: "{{ lookup('env', 'PROXMOX_VE_INSECURE') | default('false', true) | bool | ternary(false, true) }}"

--- a/roles/pve_cluster/meta/main.yml
+++ b/roles/pve_cluster/meta/main.yml
@@ -1,0 +1,23 @@
+---
+# pve_cluster role metadata
+
+galaxy_info:
+  role_name: pve_cluster
+  author: ansible-proxmox
+  description: Idempotently form and join a Proxmox VE cluster on the compute VLAN
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - proxmox
+    - cluster
+    - corosync
+    - pvecm
+
+dependencies: []

--- a/roles/pve_cluster/tasks/main.yml
+++ b/roles/pve_cluster/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+# pve_cluster role tasks
+#
+# Idempotently create the cluster on the primary node and join secondary nodes,
+# using community.proxmox.proxmox_cluster (the IaC wrapper around pvecm — never
+# a raw shell pvecm). corosync ring 0 (link0) rides each node's compute-VLAN IP.
+#
+# All proxmox_cluster / API calls are skipped under Docker so the role is
+# molecule-testable in containers without a live Proxmox cluster.
+
+- name: Run preflight safety gates
+  ansible.builtin.include_tasks: preflight.yml
+  tags:
+    - pve_cluster
+
+- name: Create the cluster on the primary node
+  community.proxmox.proxmox_cluster:
+    state: present
+    api_host: "{{ pve_cluster_api_host }}"
+    api_user: "{{ pve_cluster_api_user }}"
+    api_token_id: "{{ pve_cluster_api_token_id }}"
+    api_token_secret: "{{ pve_cluster_api_token_secret }}"
+    validate_certs: "{{ pve_cluster_api_validate_certs }}"
+    cluster_name: "{{ pve_cluster_name }}"
+    link0: "{{ pve_cluster_link0 }}"
+    link1: "{{ (pve_cluster_link1 | length > 0) | ternary(pve_cluster_link1, omit) }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - pve_cluster_role == 'primary'
+  tags:
+    - pve_cluster
+
+- name: Join secondary node to the cluster
+  community.proxmox.proxmox_cluster:
+    state: present
+    api_host: "{{ pve_cluster_api_host }}"
+    api_user: "{{ pve_cluster_api_user }}"
+    api_token_id: "{{ pve_cluster_api_token_id }}"
+    api_token_secret: "{{ pve_cluster_api_token_secret }}"
+    validate_certs: "{{ pve_cluster_api_validate_certs }}"
+    master_ip: "{{ pve_cluster_master_ip }}"
+    fingerprint: "{{ pve_cluster_fingerprint }}"
+    link0: "{{ pve_cluster_link0 }}"
+    link1: "{{ (pve_cluster_link1 | length > 0) | ternary(pve_cluster_link1, omit) }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - pve_cluster_role != 'primary'
+  tags:
+    - pve_cluster
+
+- name: Read cluster status for verification
+  community.proxmox.proxmox_cluster_status_info:
+    api_host: "{{ pve_cluster_api_host }}"
+    api_user: "{{ pve_cluster_api_user }}"
+    api_token_id: "{{ pve_cluster_api_token_id }}"
+    api_token_secret: "{{ pve_cluster_api_token_secret }}"
+    validate_certs: "{{ pve_cluster_api_validate_certs }}"
+  register: pve_cluster_status
+  changed_when: false
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - pve_cluster_role == 'primary'
+  tags:
+    - pve_cluster
+
+- name: Assert the cluster reports quorum from the primary
+  ansible.builtin.assert:
+    that:
+      - >-
+        pve_cluster_status.cluster_status
+        | selectattr('type', 'equalto', 'cluster')
+        | map(attribute='quorate') | first | int == 1
+    fail_msg: "Cluster did not report quorum after formation."
+    success_msg: "Cluster is quorate."
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - pve_cluster_role == 'primary'
+    - pve_cluster_status.cluster_status is defined
+  tags:
+    - pve_cluster

--- a/roles/pve_cluster/tasks/preflight.yml
+++ b/roles/pve_cluster/tasks/preflight.yml
@@ -1,0 +1,59 @@
+---
+# pve_cluster preflight — safety gates.
+#
+# Cluster formation is high-risk and effectively one-directional. These gates
+# ensure the role acts ONLY when explicitly enabled and ONLY against an
+# allow-listed host, and that a secondary has everything it needs to join.
+
+- name: Refuse to run unless explicitly enabled
+  ansible.builtin.assert:
+    that:
+      - pve_cluster_enabled | bool
+    fail_msg: >-
+      pve_cluster is inert by default. Set pve_cluster_enabled=true (and ensure
+      this host is in pve_cluster_member_hosts) only when you intend to form or
+      join the cluster.
+    quiet: true
+  tags:
+    - pve_cluster
+
+- name: Refuse to run against a host outside the allow-list
+  ansible.builtin.assert:
+    that:
+      - pve_cluster_member_hosts | length > 0
+      - inventory_hostname in pve_cluster_member_hosts
+    fail_msg: >-
+      {{ inventory_hostname }} is not in pve_cluster_member_hosts
+      ({{ pve_cluster_member_hosts }}). The role refuses to touch hosts it was
+      not explicitly told are cluster members.
+    quiet: true
+  tags:
+    - pve_cluster
+
+- name: Validate primary has a cluster name
+  ansible.builtin.assert:
+    that:
+      - pve_cluster_name | length > 0
+    fail_msg: "pve_cluster_name must be set for the primary to create the cluster."
+    quiet: true
+  when: pve_cluster_role == 'primary'
+  tags:
+    - pve_cluster
+
+- name: Validate secondary join parameters are present
+  ansible.builtin.assert:
+    that:
+      - pve_cluster_master_ip | length > 0
+      - pve_cluster_fingerprint | length > 0
+    fail_msg: >-
+      Joining node {{ inventory_hostname }} needs pve_cluster_master_ip (the
+      primary's compute-VLAN IP) and pve_cluster_fingerprint (the primary's
+      corosync cert fingerprint, from `pvecm status` on the primary). Supply
+      them via -e or a SOPS var — they are host/cluster specific and not
+      committed.
+    quiet: true
+  when:
+    - pve_cluster_role != 'primary'
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - pve_cluster


### PR DESCRIPTION
## Summary

Phase 2 of the homelab re-architecture (plan: *we-finally-have-pv1*). The ZFS storage half (`zfs_pools` role) already merged via #206; this PR adds the **cluster-formation** half plus multinode inventory, based on current `main`.

- **`pve_cluster` role** forms/joins a Proxmox VE cluster via `community.proxmox.proxmox_cluster` (the IaC wrapper around `pvecm` — never a raw shell `pvecm`). The primary (`pve`, role label pve1) creates the cluster on its compute-VLAN corosync ring 0 (`link0`); secondaries join. Module is check-mode capable so re-runs are no-ops; the primary additionally asserts quorum via `proxmox_cluster_status_info`.
- **Triple-guarded + inert by default**: `pve_cluster_enabled` master switch, `pve_cluster_member_hosts` allow-list (hard-asserts membership before acting), and required join params for secondaries. All API tasks skip under Docker for molecule.
- **No magic numbers**: `link0`/`master_ip` resolve from inventory (`ansible_host`); API auth from the existing `PROXMOX_VE_*` Doppler env vars. Nothing literal.
- **Inventory**: declares `pve`/`pve2`/`pve3` + a `pve_cluster_members` group (pve + pve2). `pve3` is excluded while its terraform `commissioned` flag is `false` (bad drive). `group_vars` derive the allow-list from group membership.
- Adds `playbooks/cluster.yml` (primary-create, then `serial: 1` secondary-join, members only), a molecule scenario, and pins `community.proxmox` (`>=1.6.0,<2.0.0`) in `requirements.yml`.

## Relationship to storage

`zfs_pools` (#206, already on `main`) realizes the pve2 `tank` datasets and leaves pve3 `bulk-pool` `register=false` per terraform `node_storage` — matches `deployment.json` as-is. No storage changes needed here.

## Guardrails honored

Authoring only. No playbook was run against any live host; no `pvecm`/ssh against 10.0.10.x. No cluster was formed.

## Test plan

- [x] `ansible-lint` (production profile): **passes**, 0 failures/0 warnings.
- [x] `ansible-playbook --syntax-check` on `cluster.yml` + `site.yml` (regression): passes.
- [x] `ansible-inventory --graph`: confirms `pve_cluster_members` = {pve, pve2}, pve3 excluded.
- [x] Role converge + **idempotence** exercised on a local control node with Docker-skip faked: 0 changed on re-run, all API tasks correctly skipped.
- [ ] `molecule test -s pve_cluster` — **could not run locally** (no Docker daemon available). Needs a host with Docker to validate the container converge + idempotence.
- [ ] Live `pvecm status` -> 3 quorate: out of scope for this authoring PR (gated, watched maintenance window).