### PR TITLE
fix(tests): align inventory_load test with pve→pve1 rename

### DIFF
--- a/tests/inventory_load/verify_inventory.yml
+++ b/tests/inventory_load/verify_inventory.yml
@@ -8,15 +8,15 @@
   gather_facts: false
 
   tasks:
-    - name: Assert pve host received Terraform NAS config
+    - name: Assert pve1 host received Terraform NAS config
       ansible.builtin.assert:
         that:
-          - hostvars['pve'] is defined
-          - hostvars['pve'].nas_storage_from_terraform is defined
-          - hostvars['pve'].nas_storage_from_terraform.zfs_dataset == "rpool/data/nas"
-          - hostvars['pve'].nas_storage_from_terraform.group_name == "nas"
-          - hostvars['pve'].nas_storage_from_terraform.managed_users[0].name == "homeassistant"
-          - hostvars['pve'].nas_storage_from_terraform.managed_users[0].password_secret_env == "NAS_HOMEASSISTANT_SMB_PASSWORD"
-          - "'ha-backups' in (hostvars['pve'].nas_storage_from_terraform.shares | map(attribute='name') | list)"
-          - "'ha-media' in (hostvars['pve'].nas_storage_from_terraform.shares | map(attribute='name') | list)"
-        fail_msg: "load_terraform.yml did not inject the expected NAS contract onto pve"
+          - hostvars['pve1'] is defined
+          - hostvars['pve1'].nas_storage_from_terraform is defined
+          - hostvars['pve1'].nas_storage_from_terraform.zfs_dataset == "rpool/data/nas"
+          - hostvars['pve1'].nas_storage_from_terraform.group_name == "nas"
+          - hostvars['pve1'].nas_storage_from_terraform.managed_users[0].name == "homeassistant"
+          - hostvars['pve1'].nas_storage_from_terraform.managed_users[0].password_secret_env == "NAS_HOMEASSISTANT_SMB_PASSWORD"
+          - "'ha-backups' in (hostvars['pve1'].nas_storage_from_terraform.shares | map(attribute='name') | list)"
+          - "'ha-media' in (hostvars['pve1'].nas_storage_from_terraform.shares | map(attribute='name') | list)"
+        fail_msg: "load_terraform.yml did not inject the expected NAS contract onto pve1"


### PR DESCRIPTION
## Summary

- Commit `88481cd` renamed the inventory host `pve` → `pve1` but `tests/inventory_load/verify_inventory.yml` was not updated alongside it.
- Every CI run since that rename fails on the `hostvars['pve'] is defined` assertion.
- This PR makes the surgical fix: nine `hostvars['pve']` references replaced with `hostvars['pve1']`, plus the task name and `fail_msg` string updated to match.

No other files touched. `--syntax-check` and all pre-commit hooks (yamllint, ansible-lint) pass locally.

Unblocks CI on the upcoming media-stack PRs.

## Test plan

- [ ] CI `ansible-lint` / `yamllint` passes
- [ ] CI `inventory_load` test passes (was failing before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)