### PR TITLE
feat(media_lxc_features): apply root-only LXC features (bind-mounts, keyctl, /dev/net/tun) as root

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -51,3 +51,10 @@ jobs:
           ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
+
+      - name: Run media_lxc_features molecule test
+        run: molecule test -s media_lxc_features
+        env:
+          ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"

--- a/molecule/media_lxc_features/converge.yml
+++ b/molecule/media_lxc_features/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  roles:
+    # Under Docker the role short-circuits every `pct`/blockinfile task
+    # (ansible_virtualization_type == 'docker'). This proves the role converges
+    # cleanly, the default feature map loads, and the skip guards hold.
+    - role: media_lxc_features

--- a/molecule/media_lxc_features/molecule.yml
+++ b/molecule/media_lxc_features/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-media-lxc-features-test
+    image: debian:12-slim
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/media_lxc_features/prepare.yml
+++ b/molecule/media_lxc_features/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Install Python and system utilities
+      ansible.builtin.raw: |
+        apt-get update && apt-get install -y python3 procps
+      changed_when: true

--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -1,0 +1,107 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: true
+
+  tasks:
+    - name: Load the role defaults (feature map)
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../../roles/media_lxc_features/defaults/main.yml"
+
+    - name: Assert the media feature map covers vmids 210-214
+      ansible.builtin.assert:
+        that:
+          - "'210' in media_lxc_features_map"
+          - "'211' in media_lxc_features_map"
+          - "'212' in media_lxc_features_map"
+          - "'213' in media_lxc_features_map"
+          - "'214' in media_lxc_features_map"
+        fail_msg: "media_lxc_features_map is missing one of the media vmids"
+
+    - name: Assert download-vpn (210) gets both mounts, keyctl, and tun
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_map['210'].mounts | length == 2
+          - >-
+            (media_lxc_features_map['210'].mounts
+             | selectattr('src', 'equalto', '/rpool/data/downloads')
+             | map(attribute='dst') | first) == '/mnt/downloads'
+          - >-
+            (media_lxc_features_map['210'].mounts
+             | selectattr('src', 'equalto', '/rpool/data/media')
+             | map(attribute='dst') | first) == '/mnt/media'
+          - media_lxc_features_map['210'].keyctl | bool
+          - media_lxc_features_map['210'].tun | bool
+        fail_msg: "download-vpn (210) feature contract did not resolve as expected"
+
+    - name: Assert sonarr/radarr (211/212) get both mounts, no keyctl, no tun
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_map['211'].mounts | length == 2
+          - media_lxc_features_map['212'].mounts | length == 2
+          - not (media_lxc_features_map['211'].keyctl | bool)
+          - not (media_lxc_features_map['212'].keyctl | bool)
+          - not (media_lxc_features_map['211'].tun | bool)
+          - not (media_lxc_features_map['212'].tun | bool)
+        fail_msg: "sonarr/radarr (211/212) feature contract did not resolve as expected"
+
+    - name: Assert plex (213) gets the media mount only, read-write
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_map['213'].mounts | length == 1
+          - media_lxc_features_map['213'].mounts[0].src == '/rpool/data/media'
+          - media_lxc_features_map['213'].mounts[0].dst == '/mnt/media'
+          - not (media_lxc_features_map['213'].mounts[0].ro | default(false))
+        fail_msg: "plex (213) feature contract did not resolve as expected"
+
+    - name: Assert jellyseerr (214) gets keyctl only, no bind-mounts
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_map['214'].mounts | default([]) | length == 0
+          - media_lxc_features_map['214'].keyctl | bool
+          - not (media_lxc_features_map['214'].tun | bool)
+        fail_msg: "jellyseerr (214) feature contract did not resolve as expected"
+
+    - name: Assert the tun device numbers are the TUN/TAP allocation (10:200)
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_tun_major == 10
+          - media_lxc_features_tun_minor == 200
+        fail_msg: "/dev/net/tun device numbers are not the expected 10:200"
+
+    # Guards the keyctl feature-merge logic (the load-bearing expression the role
+    # uses to build `pct set --features` and gate its idempotent `when`). Proves
+    # keyctl=1 is merged in WITHOUT dropping a terraform-set nesting=1, the result
+    # is sorted (stable), and an already-converged host yields no change.
+    - name: Merge keyctl into a nesting-only feature set (as the role does)
+      ansible.builtin.set_fact:
+        media_lxc_features_verify_cur: ["nesting=1"]
+        media_lxc_features_verify_merged: >-
+          {{ ((['nesting=1'] | reject('match', '^keyctl=') | list) + ['keyctl=1']) | sort }}
+        media_lxc_features_verify_converged: >-
+          {{ ((['keyctl=1', 'nesting=1'] | reject('match', '^keyctl=') | list) + ['keyctl=1']) | sort }}
+
+    - name: Assert keyctl-merge preserves nesting, sorts, and is idempotent
+      ansible.builtin.assert:
+        that:
+          # nesting preserved, keyctl added, sorted for a stable pct-set string
+          - media_lxc_features_verify_merged == ['keyctl=1', 'nesting=1']
+          # a nesting-only container would change (keyctl is added)
+          - (media_lxc_features_verify_cur | sort) != media_lxc_features_verify_merged
+          # an already-converged container yields no change (idempotent)
+          - (['keyctl=1', 'nesting=1'] | sort) == media_lxc_features_verify_converged
+        fail_msg: "keyctl feature-merge logic regressed (drop, order, or idempotency)"
+
+    - name: Probe for the pct CLI (must be absent in the molecule container)
+      ansible.builtin.command:
+        cmd: which pct
+      register: media_lxc_features_pct_probe
+      changed_when: false
+      failed_when: false
+
+    - name: Assert the role skipped pct under Docker (no pct present)
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_pct_probe.rc != 0
+        fail_msg: "Unexpected pct present — Docker skip guard may be broken"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -50,6 +50,14 @@
       tags:
         - zfs_pools
 
+    # Root-only media LXC features (bind-mounts, keyctl, /dev/net/tun) that the
+    # BPG provider's API token cannot set. Runs AFTER terraform creates the
+    # media LXC shells and zfs_pools manages the /rpool/data datasets, and
+    # BEFORE ansible-proxmox-apps converges the services. See the role README.
+    - role: media_lxc_features
+      tags:
+        - media_lxc_features
+
     - role: ntp
       tags:
         - ntp

--- a/roles/media_lxc_features/README.md
+++ b/roles/media_lxc_features/README.md
@@ -1,0 +1,95 @@
+# media_lxc_features
+
+Applies the **root-only LXC features** for the media stack that the BPG Proxmox
+Terraform provider's **API token cannot set**: host bind-mounts (`mp`), the
+`keyctl` feature, and `/dev/net/tun` device passthrough. Proxmox restricts all
+three to `root@pam` **ticket** authentication, so a BPG API token receives HTTP
+403. This role does them natively as `root` over SSH, idempotently.
+
+## Installation
+
+This role ships in the `ansible-proxmox` repository and is applied via
+`playbooks/site.yml`. No separate installation is required beyond cloning the
+repo and installing collection dependencies:
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
+## Why this role exists (the contract split)
+
+`terraform-proxmox` creates the media LXCs (210-214) as **plain shells**. The
+root-only bits are deliberately removed from Terraform because the API token
+cannot apply them. This role realizes them after creation.
+
+| Layer | Owns |
+| --- | --- |
+| terraform-proxmox | Create the media LXCs (CPU, RAM, disk, network, `nesting`) |
+| **this role** | Bind-mounts (`mp`), `keyctl` (merged), `/dev/net/tun` passthrough |
+| ansible-proxmox-apps | Converge the services inside each LXC |
+
+`nesting=1` stays **Terraform-managed**. This role never drops it: `keyctl=1` is
+**merged** into the live `features` string (existing tokens preserved), not
+written wholesale.
+
+## Ordering
+
+```text
+terraform-proxmox (shells)  ->  media_lxc_features  ->  ansible-proxmox-apps
+```
+
+Run this role **after** the LXCs exist and **before** the apps converge. In
+`playbooks/site.yml` it runs after `lxc_features` and after `zfs_pools` (the
+bind-mount sources are ZFS datasets under `/rpool/data`).
+
+## Feature map (replicates terraform-proxmox `deployment.json`)
+
+Fixed, non-secret, committed in `defaults/main.yml` as `media_lxc_features_map`:
+
+| vmid | name | bind-mounts (host -> container) | keyctl | /dev/net/tun |
+| --- | --- | --- | --- | --- |
+| 210 | download-vpn | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | yes | yes |
+| 211 | sonarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
+| 212 | radarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
+| 213 | plex | `/rpool/data/media`->`/mnt/media` | no | no |
+| 214 | jellyseerr | (none) | yes | no |
+
+All bind-mounts are **read-write** (no `ro=1`), matching the live deployment.
+`/dev/net/tun` is char device **10:200** (verified on pve1).
+
+## Idempotency
+
+Every change is gated on a config diff read from `pct config` / the live
+`.conf` file *before* acting:
+
+- **Bind-mounts**: the desired `mpN: <src>,mp=<dst>[,ro=1]` string is compared
+  against the current value of that `mpN` slot; `pct set --mpN` runs only on a
+  miss or mismatch.
+- **keyctl**: current `features` tokens are parsed, any `keyctl=*` dropped,
+  `keyctl=1` appended, sorted; `pct set --features` runs only when the token set
+  differs. Terraform-set `nesting=1` is preserved.
+- **/dev/net/tun**: a marker-guarded `blockinfile` writes the two raw LXC lines
+  to `/etc/pve/lxc/<vmid>.conf`; reports changed only on an actual edit.
+
+A container is **restarted only if its config changed** (handler `pct reboot`,
+notified by the mutating tasks). A fully converged host performs **zero**
+restarts.
+
+## Guards
+
+- Only vmids in `media_lxc_features_map` that are **actually present** on the
+  host (per `pct list`) are touched — absent vmids (not yet created by
+  Terraform) are skipped silently.
+- All tasks are skipped under Docker (`ansible_virtualization_type == 'docker'`)
+  for molecule testing.
+
+## Usage
+
+```bash
+# Dry run
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags media_lxc_features --check
+# Apply (after terraform creates the LXCs, before apps converge)
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags media_lxc_features
+```

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -1,0 +1,58 @@
+---
+# media_lxc_features role defaults
+#
+# Root-only LXC features for the media stack that the BPG Proxmox provider's
+# API token CANNOT set: host bind-mounts (mp), the keyctl feature, and
+# /dev/net/tun device passthrough. Proxmox restricts all three to root@pam
+# *ticket* auth, so the API token gets HTTP 403. Terraform creates the media
+# LXCs as plain shells; this role applies the root-only bits over native root
+# SSH, idempotently.
+#
+# The map is keyed by container ID (string). Each entry is a fixed, non-secret
+# vmid -> feature declaration replicating the live terraform-proxmox
+# deployment.json media stack (download-vpn, sonarr, radarr, plex, jellyseerr).
+# No IPs, no secrets — safe to commit.
+#
+# Per-vmid shape:
+#   mounts:     list of { src: <host path>, dst: <in-container path>, ro: <bool, default false> }
+#   keyctl:     bool — ensure features contains keyctl=1, MERGED into existing
+#               features (terraform-set nesting=1 is preserved, never dropped)
+#   tun:        bool — passthrough /dev/net/tun (char 10:200) into the container
+#
+# Only vmids that actually exist on the target host are acted on; absent vmids
+# are skipped (terraform may not have created them yet). All tasks are skipped
+# under Docker virtualization (molecule).
+media_lxc_features_map:
+  "210":  # download-vpn — qBittorrent + Prowlarr behind Proton WireGuard
+    mounts:
+      - { src: /rpool/data/downloads, dst: /mnt/downloads }
+      - { src: /rpool/data/media, dst: /mnt/media }
+    keyctl: true
+    tun: true
+  "211":  # sonarr — TV PVR
+    mounts:
+      - { src: /rpool/data/downloads, dst: /mnt/downloads }
+      - { src: /rpool/data/media, dst: /mnt/media }
+    keyctl: false
+    tun: false
+  "212":  # radarr — movie PVR
+    mounts:
+      - { src: /rpool/data/downloads, dst: /mnt/downloads }
+      - { src: /rpool/data/media, dst: /mnt/media }
+    keyctl: false
+    tun: false
+  "213":  # plex — media streaming
+    mounts:
+      - { src: /rpool/data/media, dst: /mnt/media }
+    keyctl: false
+    tun: false
+  "214":  # jellyseerr — request UI (Docker-in-LXC); no bind-mounts
+    mounts: []
+    keyctl: true
+    tun: false
+
+# /dev/net/tun device numbers (char major:minor). Stable Linux allocation for
+# the TUN/TAP driver. Verified on pve1: `stat -c %t:%T /dev/net/tun` -> a:c8
+# (hex) == 10:200 (decimal).
+media_lxc_features_tun_major: 10
+media_lxc_features_tun_minor: 200

--- a/roles/media_lxc_features/handlers/main.yml
+++ b/roles/media_lxc_features/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+# media_lxc_features handlers
+#
+# Bind-mount, feature, and device-passthrough changes only take effect after the
+# container is restarted. Tasks that mutate a container's config notify this
+# handler and append the vmid to `media_lxc_features_changed`. The handler
+# restarts ONLY those containers (running ones), so an already-converged host
+# performs zero restarts.
+
+- name: Restart changed media containers
+  ansible.builtin.command:
+    cmd: "pct reboot {{ item }}"
+  loop: "{{ media_lxc_features_changed | default([]) | unique }}"
+  loop_control:
+    label: "container {{ item }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - media_lxc_features_changed | default([]) | length > 0
+  changed_when: true

--- a/roles/media_lxc_features/tasks/configure_container.yml
+++ b/roles/media_lxc_features/tasks/configure_container.yml
@@ -1,0 +1,139 @@
+---
+# Apply root-only features to a single media LXC container.
+# media_ct.key   = container ID (string)
+# media_ct.value = { mounts: [...], keyctl: bool, tun: bool }
+#
+# Idempotency strategy: read the live config with `pct config` FIRST, then make
+# each change only when the desired state is absent/different. Any task that
+# mutates config appends the vmid to media_lxc_features_changed and notifies the
+# restart handler.
+
+- name: "Read current config for container {{ media_ct.key }}"
+  ansible.builtin.command:
+    cmd: "pct config {{ media_ct.key }}"
+  register: media_lxc_features_cfg
+  changed_when: false
+  tags:
+    - media_lxc_features
+
+# ---------------------------------------------------------------------------
+# Bind-mounts (mp0, mp1, ...) — host path -> in-container target, optional ro
+# ---------------------------------------------------------------------------
+# Desired line shape (matches `pct config` readback, e.g. CT 252):
+#   mpN: <host>,mp=<target>[,ro=1]
+# We compare the desired mp string against the current value of that exact mpN
+# slot and only `pct set` when missing or different.
+
+- name: "Set bind-mounts on container {{ media_ct.key }}"
+  ansible.builtin.command:
+    cmd: >-
+      pct set {{ media_ct.key }}
+      --mp{{ media_mp_idx }}
+      {{ media_mp.src }},mp={{ media_mp.dst }}{{ ',ro=1' if (media_mp.ro | default(false)) else '' }}
+  loop: "{{ media_ct.value.mounts | default([]) }}"
+  loop_control:
+    loop_var: media_mp
+    index_var: media_mp_idx
+    label: "{{ media_ct.key }} mp{{ media_mp_idx }}: {{ media_mp.src }} -> {{ media_mp.dst }}"
+  vars:
+    media_mp_desired: >-
+      {{ media_mp.src }},mp={{ media_mp.dst }}{{ ',ro=1' if (media_mp.ro | default(false)) else '' }}
+    media_mp_current: >-
+      {{
+        media_lxc_features_cfg.stdout_lines
+        | select('match', '^mp' ~ media_mp_idx ~ ':')
+        | map('regex_replace', '^mp' ~ media_mp_idx ~ ':\s*', '')
+        | list | first | default('')
+      }}
+  when: media_mp_current != media_mp_desired
+  changed_when: true
+  notify: Restart changed media containers
+  register: media_lxc_features_mp_set
+  tags:
+    - media_lxc_features
+
+- name: "Record bind-mount change for container {{ media_ct.key }}"
+  ansible.builtin.set_fact:
+    media_lxc_features_changed: "{{ media_lxc_features_changed | default([]) + [media_ct.key] }}"
+  when: media_lxc_features_mp_set is defined and media_lxc_features_mp_set.changed
+  tags:
+    - media_lxc_features
+
+# ---------------------------------------------------------------------------
+# keyctl feature — MERGE into existing features (preserve terraform-set nesting)
+# ---------------------------------------------------------------------------
+# Parse the current `features:` line into a key=val map, add keyctl=1 if absent,
+# and only `pct set --features` when the merged set differs from the current.
+
+- name: "Ensure keyctl feature on container {{ media_ct.key }}"
+  when: media_ct.value.keyctl | default(false)
+  tags:
+    - media_lxc_features
+  block:
+    - name: "Parse current features into a token set for {{ media_ct.key }}"
+      ansible.builtin.set_fact:
+        # `features:` value (e.g. "nesting=1") -> ["nesting=1"]. Empty list when
+        # the container has no features line yet.
+        media_lxc_features_cur_tokens: >-
+          {{
+            media_lxc_features_cfg.stdout_lines
+            | select('match', '^features:')
+            | map('regex_replace', '^features:\s*', '')
+            | list | first | default('')
+            | split(',') | select('truthy') | list
+          }}
+
+    - name: "Compute merged feature tokens (keyctl added, nesting preserved) for {{ media_ct.key }}"
+      ansible.builtin.set_fact:
+        # Drop any existing keyctl=* token, append keyctl=1, sort for stability.
+        # Every other token (e.g. terraform-set nesting=1) is preserved verbatim.
+        media_lxc_features_merged_tokens: >-
+          {{
+            (
+              (media_lxc_features_cur_tokens | reject('match', '^keyctl=') | list)
+              + ['keyctl=1']
+            ) | sort
+          }}
+
+    - name: "Apply merged features to container {{ media_ct.key }}"
+      ansible.builtin.command:
+        cmd: "pct set {{ media_ct.key }} --features {{ media_lxc_features_merged_tokens | join(',') }}"
+      when: (media_lxc_features_cur_tokens | sort) != media_lxc_features_merged_tokens
+      changed_when: true
+      notify: Restart changed media containers
+      register: media_lxc_features_feat_set
+
+    - name: "Record feature change for container {{ media_ct.key }}"
+      ansible.builtin.set_fact:
+        media_lxc_features_changed: "{{ media_lxc_features_changed | default([]) + [media_ct.key] }}"
+      when: media_lxc_features_feat_set is defined and media_lxc_features_feat_set.changed
+
+# ---------------------------------------------------------------------------
+# /dev/net/tun device passthrough — raw LXC config lines in the .conf file
+# ---------------------------------------------------------------------------
+# `pct set` has no flag for arbitrary device passthrough, so the standard method
+# is two raw lines appended to /etc/pve/lxc/<vmid>.conf:
+#   lxc.cgroup2.devices.allow: c 10:200 rwm
+#   lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
+# blockinfile is idempotent (marker-guarded) and reports changed only on edit.
+
+- name: "Passthrough /dev/net/tun into container {{ media_ct.key }}"
+  ansible.builtin.blockinfile:
+    path: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK media_lxc_features tun"
+    block: |
+      lxc.cgroup2.devices.allow: c {{ media_lxc_features_tun_major }}:{{ media_lxc_features_tun_minor }} rwm
+      lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
+    insertafter: EOF
+  when: media_ct.value.tun | default(false)
+  notify: Restart changed media containers
+  register: media_lxc_features_tun_set
+  tags:
+    - media_lxc_features
+
+- name: "Record tun-passthrough change for container {{ media_ct.key }}"
+  ansible.builtin.set_fact:
+    media_lxc_features_changed: "{{ media_lxc_features_changed | default([]) + [media_ct.key] }}"
+  when: media_lxc_features_tun_set is defined and media_lxc_features_tun_set.changed
+  tags:
+    - media_lxc_features

--- a/roles/media_lxc_features/tasks/main.yml
+++ b/roles/media_lxc_features/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# media_lxc_features role tasks
+#
+# Applies the root-only LXC features (host bind-mounts, keyctl, /dev/net/tun
+# passthrough) that the BPG Proxmox provider's API token cannot set (Proxmox
+# restricts them to root@pam ticket auth -> token gets 403). Runs over native
+# root SSH, idempotently, only on media vmids that actually exist on the host.
+#
+# Ordering: terraform-proxmox creates the media LXCs as plain shells ->
+# THIS role applies root-only features -> ansible-proxmox-apps converges the
+# services. See README.md.
+
+- name: Enumerate LXC containers present on this host
+  ansible.builtin.command:
+    cmd: pct list
+  register: media_lxc_features_pct_list
+  changed_when: false
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - media_lxc_features
+
+- name: Build the set of vmids present on this host
+  ansible.builtin.set_fact:
+    # `pct list` columns: "VMID Status ... Name". Keep only lines beginning with
+    # digits (skips the header), then take the leading vmid token from each.
+    media_lxc_features_present: >-
+      {{
+        media_lxc_features_pct_list.stdout_lines | default([])
+        | map('regex_search', '^\d+')
+        | select('truthy')
+        | list
+      }}
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - media_lxc_features
+
+- name: Reset the changed-container accumulator
+  ansible.builtin.set_fact:
+    media_lxc_features_changed: []
+  tags:
+    - media_lxc_features
+
+- name: Apply root-only features to each present media container
+  ansible.builtin.include_tasks: configure_container.yml
+  loop: "{{ media_lxc_features_map | dict2items }}"
+  loop_control:
+    loop_var: media_ct
+    label: "container {{ media_ct.key }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - media_ct.key in media_lxc_features_present | default([])
+  tags:
+    - media_lxc_features


### PR DESCRIPTION
## Why

Proxmox restricts host bind-mounts (`mp`), the `keyctl` feature, and device passthrough (`/dev/net/tun`) to `root@pam` **ticket** auth. The BPG Proxmox provider's API token therefore gets **HTTP 403** on all three. terraform-proxmox now creates the media LXCs (210-214) as plain shells; this role applies the root-only bits natively as `root` over SSH, idempotently — pairing with the Terraform shell refactor.

## Feature map (replicates live `terraform-proxmox` `deployment.json`)

| vmid | name | bind-mounts (host -> container, rw) | keyctl | /dev/net/tun |
| --- | --- | --- | --- | --- |
| 210 | download-vpn | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | yes | yes |
| 211 | sonarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
| 212 | radarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
| 213 | plex | `/rpool/data/media`->`/mnt/media` | no | no |
| 214 | jellyseerr | (none) | yes | no |

All mounts are **read-write** (no `ro=1`), matching the live deployment. `/dev/net/tun` is char device **10:200** (verified on pve1).

## Idempotency (config-diff guards)

- **Bind-mounts**: desired `mpN: <src>,mp=<dst>` compared against the live `mpN` value from `pct config`; `pct set --mpN` only on miss/mismatch.
- **keyctl**: MERGED into live `features` (drop any `keyctl=*`, add `keyctl=1`, sort) so terraform-set `nesting=1` is never dropped. `pct set --features` only when the token set differs — a converged host yields **zero** change.
- **/dev/net/tun**: marker-guarded `blockinfile` writes the two raw LXC lines to `/etc/pve/lxc/<vmid>.conf`; changed only on real edit.
- **Restart on change**: a handler `pct reboot`s ONLY containers whose config changed. Fully converged host = no restarts.
- **Guards**: only vmids actually present (`pct list`) are touched (absent vmids skipped); all `pct`/blockinfile tasks skipped under Docker (molecule).

## Wiring + ordering

Runs in `playbooks/site.yml` after `lxc_features` + `zfs_pools` (bind-mount sources are `/rpool/data` ZFS datasets) and before the apps converge:

```
terraform shells  ->  media_lxc_features  ->  ansible-proxmox-apps
```

## Validation

- `ansible-lint` (profile **production**): 0 failures, 0 warnings.
- `yamllint`, pre-commit (yamllint + ansible-lint + markdownlint): pass.
- `ansible-playbook --syntax-check` on `site.yml`: pass.
- Local role converge under the Docker guard: RC=0, all 5 vmids correctly skipped.
- Load-bearing keyctl-merge + mp-diff logic proven against realistic `pct config` fixtures (sort correct, nesting preserved, idempotent on converged host, exact mp diff).
- New molecule scenario `media_lxc_features` added and wired into `molecule.yml` CI (the local Nix devshell lacks the `docker` python module that `requirements-ci.txt` provides in CI).

No real IPs or secrets in the diff; the feature map is fixed, non-secret config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)