### PR TITLE
chore(renovate): route preset through dryvist/.github entry point

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "local>JacobPEvans/.github:renovate-presets"
+    "local>dryvist/.github"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Point this repo's Renovate extends at local>dryvist/.github so the org's single entry point composes the shared preset, instead of referencing the upstream preset directly. Behavior is unchanged (dryvist/.github re-extends the same upstream); this just makes dryvist/.github the chokepoint for future policy.

Refs: dryvist/terraform-github#6

Assisted-by: Claude:claude-opus-4-8

