### PR TITLE
feat(pve_cluster): add pve3 as cluster member, decoupled from storage

### DIFF
--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -21,12 +21,20 @@ all:
           ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') | default(omit, true) }}"
           proxmox_node_name: pve3
           # terraform `nodes.pve3.commissioned = false` (bad drive) — excluded
-          # from cluster_members and storage registration until commissioned.
+          # from STORAGE registration (zfs_pools keys off this flag + terraform
+          # node_storage, so bulk-pool is never created here) until commissioned.
+          # Corosync membership is decoupled from storage: pve3 IS a cluster
+          # member below while its storage stays uncommissioned (joined the
+          # 3-node homelab-cluster 2026-05-31).
           pve_node_commissioned: false
       children:
-        # Nodes eligible to form/join the cluster. pve3 is intentionally NOT
-        # here while uncommissioned; add it once its hardware is ready.
+        # Nodes eligible to form/join the cluster. Corosync membership is
+        # decoupled from storage commissioning: pve3 is a member (joined the
+        # 3-node homelab-cluster 2026-05-31) even though its `bulk-pool` is
+        # still uncommissioned — zfs_pools gates pool creation on
+        # pve_node_commissioned + terraform node_storage, not on this group.
         pve_cluster_members:
           hosts:
             pve1: {}
             pve2: {}
+            pve3: {}

--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -2,8 +2,10 @@
 # Form the Proxmox VE cluster.
 #
 # Two ordered plays guarantee the primary creates the cluster BEFORE any
-# secondary tries to join. Both target the `pve_cluster_members` group only, so
-# uncommissioned nodes (e.g. pve3 while its drive is bad) are never touched.
+# secondary tries to join. Both target the `pve_cluster_members` group only.
+# Cluster membership is decoupled from storage commissioning: pve3 is a member
+# while its `bulk-pool` stays uncommissioned (storage is gated separately by
+# `pve_node_commissioned` in the zfs_pools role).
 #
 # The role is inert unless enabled, so formation is an explicit, deliberate run:
 #

--- a/roles/pve_cluster/README.md
+++ b/roles/pve_cluster/README.md
@@ -65,8 +65,11 @@ or a SOPS-encrypted var.
 ## Usage
 
 The cluster is formed by `playbooks/cluster.yml`, which targets the primary
-first (creates) then secondaries (join). `pve3` is excluded while its
-terraform `commissioned` flag is `false` (bad drive).
+first (creates) then secondaries (join). `pve3` is a cluster member even though
+its terraform `commissioned` flag is `false` (bad drive): corosync membership is
+decoupled from storage commissioning, so `pve3` joins the cluster while its
+`bulk-pool` stays uncommissioned (`zfs_pools` gates pool creation on
+`pve_node_commissioned`, not on cluster-group membership).
 
 ```bash
 # Form the cluster (enable + allow-list supplied at run time, fingerprint via -e)


### PR DESCRIPTION
## What

Adds `pve3` to the `pve_cluster_members` inventory group so the codified
inventory matches live reality: the `homelab-cluster` is now a 3-node quorate
cluster (pve1/pve2/pve3) as of 2026-05-31.

## Why

Criterion: the Proxmox cluster must span all 3 nodes. pve3 was previously
excluded from `pve_cluster_members` because its terraform `commissioned` flag
is `false` (bad/absent drive for `bulk-pool`). That conflated two independent
concerns:

- **Corosync membership** — pve3 can and should be a cluster member now.
- **Storage commissioning** — pve3's `bulk-pool` stays uncommissioned.

These are decoupled in the codebase: `zfs_pools` gates pool creation on
`pve_node_commissioned` + terraform `node_storage`, **not** on cluster-group
membership. So adding pve3 to the cluster group does **not** attempt to create
the absent `bulk-pool`. `cluster.yml` is a standalone play and never invokes
`zfs_pools`.

## Changes

- `inventory/hosts.yml`: add `pve3: {}` to `pve_cluster_members`; keep
  `pve_node_commissioned: false` (still gates storage). Comments updated.
- `playbooks/cluster.yml` + `roles/pve_cluster/README.md`: docs now describe
  membership-vs-storage decoupling instead of "pve3 excluded".

## Secrets / no-committed-IPs

No IPs are committed. `ansible_host` still resolves from `PVE*_VE_HOSTNAME`
env (Doppler); this PR only adds a group-membership line.

## Live state (already applied out-of-band, this PR codifies it)

`pvecm status` on pve1: Name `homelab-cluster`, Nodes 3, Quorate Yes,
Expected/Total votes 3/3. `/etc/pve/nodes/` = pve1, pve2, pve3. pve1's 35
guests intact and running throughout. pve3 zpools = `rpool` only (bulk-pool
still uncommissioned, as intended).

## Validation

- `ansible-inventory --graph` shows pve3 under `pve_cluster_members`.
- pre-commit (yamllint, ansible-lint, markdownlint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)