### PR TITLE
refactor(media_lxc_features): key features by service so VMID renumber needs no role change

### DIFF
--- a/molecule/media_lxc_features/converge.yml
+++ b/molecule/media_lxc_features/converge.yml
@@ -4,8 +4,22 @@
   become: false
   gather_facts: true
 
+  vars:
+    # Stand in for the terraform inventory's service -> vmid resolution that
+    # playbooks/load_terraform.yml injects on a real host. Uses the NEW media
+    # VMID mapping (210 plex, 211 jellyseerr, 212 sonarr, 213 radarr,
+    # 214 download-vpn) so converge proves the role follows a renumber with no
+    # change to the service-keyed feature map.
+    media_lxc_features_service_vmids_from_terraform:
+      plex: 210
+      jellyseerr: 211
+      sonarr: 212
+      radarr: 213
+      download-vpn: 214
+
   roles:
     # Under Docker the role short-circuits every `pct`/blockinfile task
     # (ansible_virtualization_type == 'docker'). This proves the role converges
-    # cleanly, the default feature map loads, and the skip guards hold.
+    # cleanly, the service-keyed feature map loads, the service -> vmid join
+    # resolves, and the skip guards hold.
     - role: media_lxc_features

--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -4,64 +4,79 @@
   become: false
   gather_facts: true
 
+  vars:
+    # The NEW media VMID mapping (same as converge). Used to prove the
+    # service-keyed feature map resolves onto the renumbered vmids.
+    media_lxc_features_verify_service_vmids:
+      plex: 210
+      jellyseerr: 211
+      sonarr: 212
+      radarr: 213
+      download-vpn: 214
+
   tasks:
-    - name: Load the role defaults (feature map)
+    - name: Load the role defaults (service-keyed feature map)
       ansible.builtin.include_vars:
         file: "{{ playbook_dir }}/../../roles/media_lxc_features/defaults/main.yml"
 
-    - name: Assert the media feature map covers vmids 210-214
+    - name: Assert the feature map is keyed by service, not raw vmid
       ansible.builtin.assert:
         that:
-          - "'210' in media_lxc_features_map"
-          - "'211' in media_lxc_features_map"
-          - "'212' in media_lxc_features_map"
-          - "'213' in media_lxc_features_map"
-          - "'214' in media_lxc_features_map"
-        fail_msg: "media_lxc_features_map is missing one of the media vmids"
+          - "'plex' in media_lxc_features_map"
+          - "'jellyseerr' in media_lxc_features_map"
+          - "'sonarr' in media_lxc_features_map"
+          - "'radarr' in media_lxc_features_map"
+          - "'download-vpn' in media_lxc_features_map"
+          # No raw vmids leaked back in as keys.
+          - "'210' not in media_lxc_features_map"
+          - "'214' not in media_lxc_features_map"
+        fail_msg: "media_lxc_features_map must be keyed by service name, not vmid"
 
-    - name: Assert download-vpn (210) gets both mounts, keyctl, and tun
+    - name: Assert plex gets the media mount only, read-write
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['210'].mounts | length == 2
+          - media_lxc_features_map['plex'].mounts | length == 1
+          - media_lxc_features_map['plex'].mounts[0].src == '/rpool/data/media'
+          - media_lxc_features_map['plex'].mounts[0].dst == '/mnt/media'
+          - not (media_lxc_features_map['plex'].mounts[0].ro | default(false))
+          - not (media_lxc_features_map['plex'].keyctl | bool)
+          - not (media_lxc_features_map['plex'].tun | bool)
+        fail_msg: "plex feature contract did not resolve as expected"
+
+    - name: Assert jellyseerr gets keyctl only, no bind-mounts, no tun
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_map['jellyseerr'].mounts | default([]) | length == 0
+          - media_lxc_features_map['jellyseerr'].keyctl | bool
+          - not (media_lxc_features_map['jellyseerr'].tun | bool)
+        fail_msg: "jellyseerr feature contract did not resolve as expected"
+
+    - name: Assert sonarr/radarr get both mounts, no keyctl, no tun
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_map['sonarr'].mounts | length == 2
+          - media_lxc_features_map['radarr'].mounts | length == 2
+          - not (media_lxc_features_map['sonarr'].keyctl | bool)
+          - not (media_lxc_features_map['radarr'].keyctl | bool)
+          - not (media_lxc_features_map['sonarr'].tun | bool)
+          - not (media_lxc_features_map['radarr'].tun | bool)
+        fail_msg: "sonarr/radarr feature contract did not resolve as expected"
+
+    - name: Assert download-vpn gets both mounts, keyctl, and tun
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_map['download-vpn'].mounts | length == 2
           - >-
-            (media_lxc_features_map['210'].mounts
+            (media_lxc_features_map['download-vpn'].mounts
              | selectattr('src', 'equalto', '/rpool/data/downloads')
              | map(attribute='dst') | first) == '/mnt/downloads'
           - >-
-            (media_lxc_features_map['210'].mounts
+            (media_lxc_features_map['download-vpn'].mounts
              | selectattr('src', 'equalto', '/rpool/data/media')
              | map(attribute='dst') | first) == '/mnt/media'
-          - media_lxc_features_map['210'].keyctl | bool
-          - media_lxc_features_map['210'].tun | bool
-        fail_msg: "download-vpn (210) feature contract did not resolve as expected"
-
-    - name: Assert sonarr/radarr (211/212) get both mounts, no keyctl, no tun
-      ansible.builtin.assert:
-        that:
-          - media_lxc_features_map['211'].mounts | length == 2
-          - media_lxc_features_map['212'].mounts | length == 2
-          - not (media_lxc_features_map['211'].keyctl | bool)
-          - not (media_lxc_features_map['212'].keyctl | bool)
-          - not (media_lxc_features_map['211'].tun | bool)
-          - not (media_lxc_features_map['212'].tun | bool)
-        fail_msg: "sonarr/radarr (211/212) feature contract did not resolve as expected"
-
-    - name: Assert plex (213) gets the media mount only, read-write
-      ansible.builtin.assert:
-        that:
-          - media_lxc_features_map['213'].mounts | length == 1
-          - media_lxc_features_map['213'].mounts[0].src == '/rpool/data/media'
-          - media_lxc_features_map['213'].mounts[0].dst == '/mnt/media'
-          - not (media_lxc_features_map['213'].mounts[0].ro | default(false))
-        fail_msg: "plex (213) feature contract did not resolve as expected"
-
-    - name: Assert jellyseerr (214) gets keyctl only, no bind-mounts
-      ansible.builtin.assert:
-        that:
-          - media_lxc_features_map['214'].mounts | default([]) | length == 0
-          - media_lxc_features_map['214'].keyctl | bool
-          - not (media_lxc_features_map['214'].tun | bool)
-        fail_msg: "jellyseerr (214) feature contract did not resolve as expected"
+          - media_lxc_features_map['download-vpn'].keyctl | bool
+          - media_lxc_features_map['download-vpn'].tun | bool
+        fail_msg: "download-vpn feature contract did not resolve as expected"
 
     - name: Assert the tun device numbers are the TUN/TAP allocation (10:200)
       ansible.builtin.assert:
@@ -69,6 +84,88 @@
           - media_lxc_features_tun_major == 10
           - media_lxc_features_tun_minor == 200
         fail_msg: "/dev/net/tun device numbers are not the expected 10:200"
+
+    # ---------------------------------------------------------------------------
+    # Service -> vmid JOIN: the load-bearing refactor. Re-derive the resolved
+    # vmid-keyed map exactly as roles/.../tasks/main.yml does, against the NEW
+    # mapping, and prove each service's features land on its new vmid. This is
+    # what makes a renumber need no role change.
+    # ---------------------------------------------------------------------------
+    - name: Resolve the service feature map to the NEW vmids (as the role does)
+      ansible.builtin.set_fact:
+        media_lxc_features_verify_selected: >-
+          {{
+            media_lxc_features_map | dict2items
+            | selectattr('key', 'in', media_lxc_features_verify_service_vmids)
+            | list
+          }}
+    - name: Build the resolved vmid-keyed map (as the role does)
+      ansible.builtin.set_fact:
+        media_lxc_features_verify_resolved: >-
+          {{
+            dict(
+              (
+                media_lxc_features_verify_selected
+                | map(attribute='key')
+                | map('extract', media_lxc_features_verify_service_vmids)
+                | map('string') | list
+              )
+              | zip(media_lxc_features_verify_selected | map(attribute='value') | list)
+            )
+          }}
+
+    - name: Assert the join puts each service's features on its NEW vmid
+      ansible.builtin.assert:
+        that:
+          # NEW: 210 plex (media mount only, no keyctl, no tun)
+          - "'210' in media_lxc_features_verify_resolved"
+          - media_lxc_features_verify_resolved['210'].mounts | length == 1
+          - media_lxc_features_verify_resolved['210'].mounts[0].dst == '/mnt/media'
+          - not (media_lxc_features_verify_resolved['210'].keyctl | bool)
+          - not (media_lxc_features_verify_resolved['210'].tun | bool)
+          # NEW: 211 jellyseerr (keyctl only, no mounts, no tun)
+          - media_lxc_features_verify_resolved['211'].mounts | length == 0
+          - media_lxc_features_verify_resolved['211'].keyctl | bool
+          - not (media_lxc_features_verify_resolved['211'].tun | bool)
+          # NEW: 212 sonarr / 213 radarr (both mounts, no keyctl, no tun)
+          - media_lxc_features_verify_resolved['212'].mounts | length == 2
+          - media_lxc_features_verify_resolved['213'].mounts | length == 2
+          - not (media_lxc_features_verify_resolved['212'].keyctl | bool)
+          - not (media_lxc_features_verify_resolved['213'].tun | bool)
+          # NEW: 214 download-vpn (both mounts + keyctl + tun)
+          - media_lxc_features_verify_resolved['214'].mounts | length == 2
+          - media_lxc_features_verify_resolved['214'].keyctl | bool
+          - media_lxc_features_verify_resolved['214'].tun | bool
+        fail_msg: "service -> vmid join did not place features on the new vmids"
+
+    - name: Build a partial resolution (only plex placed) for the absent-skip case
+      ansible.builtin.set_fact:
+        media_lxc_features_verify_partial_sel: >-
+          {{
+            media_lxc_features_map | dict2items
+            | selectattr('key', 'in', {'plex': 210})
+            | list
+          }}
+    - name: Resolve the partial map (as the role does)
+      ansible.builtin.set_fact:
+        media_lxc_features_verify_partial: >-
+          {{
+            dict(
+              (
+                media_lxc_features_verify_partial_sel
+                | map(attribute='key')
+                | map('extract', {'plex': 210})
+                | map('string') | list
+              )
+              | zip(media_lxc_features_verify_partial_sel | map(attribute='value') | list)
+            )
+          }}
+
+    - name: Assert only the resolvable service appears (absent-skip behaviour)
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_verify_partial.keys() | list == ['210']
+        fail_msg: "unresolved services must not appear in the effective map"
 
     # Guards the keyctl feature-merge logic (the load-bearing expression the role
     # uses to build `pct set --features` and gate its idempotent `when`). Proves

--- a/playbooks/load_terraform.yml
+++ b/playbooks/load_terraform.yml
@@ -72,3 +72,27 @@
           {{ (terraform_data.node_storage | default({}))[hostvars[item].proxmox_node_name | default(item)] | default({}) }}
         cluster_nodes_from_terraform: "{{ terraform_data.nodes | default({}) }}"
       loop: "{{ groups['proxmox'] | default([]) }}"
+
+    # Service -> VMID resolution for media_lxc_features. The terraform
+    # `containers` dict is keyed by service hostname and carries each container's
+    # current `vmid`; project it to { service: vmid } so the role can key its
+    # feature map by service and follow any VMID renumber with no role change.
+    # The role only resolves the services it knows about, so the extra
+    # (non-media) entries are harmless.
+    - name: Inject Terraform service -> vmid map onto proxmox hosts
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        media_lxc_features_service_vmids_from_terraform: >-
+          {{
+            dict(
+              (terraform_data.containers | default({})) | dict2items
+              | selectattr('value.vmid', 'defined')
+              | map(attribute='key') | list
+              | zip(
+                  (terraform_data.containers | default({})) | dict2items
+                  | selectattr('value.vmid', 'defined')
+                  | map(attribute='value.vmid') | list
+                )
+            )
+          }}
+      loop: "{{ groups['proxmox'] | default([]) }}"

--- a/roles/media_lxc_features/README.md
+++ b/roles/media_lxc_features/README.md
@@ -20,9 +20,9 @@ ansible-galaxy collection install -r requirements.yml
 
 ## Why this role exists (the contract split)
 
-`terraform-proxmox` creates the media LXCs (210-214) as **plain shells**. The
-root-only bits are deliberately removed from Terraform because the API token
-cannot apply them. This role realizes them after creation.
+`terraform-proxmox` creates the media LXCs as **plain shells**. The root-only
+bits are deliberately removed from Terraform because the API token cannot apply
+them. This role realizes them after creation.
 
 | Layer | Owns |
 | --- | --- |
@@ -44,20 +44,34 @@ Run this role **after** the LXCs exist and **before** the apps converge. In
 `playbooks/site.yml` it runs after `lxc_features` and after `zfs_pools` (the
 bind-mount sources are ZFS datasets under `/rpool/data`).
 
-## Feature map (replicates terraform-proxmox `deployment.json`)
+## Feature map (keyed by service, not VMID)
 
-Fixed, non-secret, committed in `defaults/main.yml` as `media_lxc_features_map`:
+Non-secret, committed in `defaults/main.yml` as `media_lxc_features_map`, keyed
+by **service name**. Each service's bind-mounts / keyctl / tun follow the
+service, never a hardcoded VMID:
 
-| vmid | name | bind-mounts (host -> container) | keyctl | /dev/net/tun |
-| --- | --- | --- | --- | --- |
-| 210 | download-vpn | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | yes | yes |
-| 211 | sonarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
-| 212 | radarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
-| 213 | plex | `/rpool/data/media`->`/mnt/media` | no | no |
-| 214 | jellyseerr | (none) | yes | no |
+| service | bind-mounts (host -> container) | keyctl | /dev/net/tun |
+| --- | --- | --- | --- |
+| plex | `/rpool/data/media`->`/mnt/media` | no | no |
+| jellyseerr | (none) | yes | no |
+| sonarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
+| radarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
+| download-vpn | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | yes | yes |
 
 All bind-mounts are **read-write** (no `ro=1`), matching the live deployment.
 `/dev/net/tun` is char device **10:200** (verified on pve1).
+
+### VMID resolution (renumber-proof)
+
+The role never names a raw VMID. `playbooks/load_terraform.yml` projects the
+terraform inventory's `containers` (keyed by service hostname, each with a
+`vmid`) into `media_lxc_features_service_vmids_from_terraform` —
+`{ service: vmid }` — and injects it onto each proxmox host. The role joins its
+service-keyed feature map against that resolution at run time to build the
+effective `{ vmid: features }` it acts on. A VMID renumber therefore flows in
+through `terraform_inventory.json` and needs **zero** changes here: each service
+keeps its features and follows its new VMID automatically. Services absent from
+the inventory resolve to nothing and are skipped.
 
 ## Idempotency
 
@@ -79,9 +93,10 @@ restarts.
 
 ## Guards
 
-- Only vmids in `media_lxc_features_map` that are **actually present** on the
-  host (per `pct list`) are touched — absent vmids (not yet created by
-  Terraform) are skipped silently.
+- Only vmids resolved from `media_lxc_features_map` (service -> vmid via the
+  terraform inventory) that are **actually present** on the host (per
+  `pct list`) are touched — absent vmids (not yet created by Terraform), and
+  services with no inventory vmid, are skipped silently.
 - All tasks are skipped under Docker (`ansible_virtualization_type == 'docker'`)
   for molecule testing.
 

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -8,12 +8,16 @@
 # LXCs as plain shells; this role applies the root-only bits over native root
 # SSH, idempotently.
 #
-# The map is keyed by container ID (string). Each entry is a fixed, non-secret
-# vmid -> feature declaration replicating the live terraform-proxmox
-# deployment.json media stack (download-vpn, sonarr, radarr, plex, jellyseerr).
-# No IPs, no secrets — safe to commit.
+# The feature map is keyed by SERVICE NAME (plex, jellyseerr, sonarr, radarr,
+# download-vpn) — NOT by raw VMID. Each service's current VMID is resolved at
+# run time from the terraform inventory (containers keyed by hostname, each with
+# a `vmid`), injected onto proxmox hosts by playbooks/load_terraform.yml as
+# `media_lxc_features_service_vmids_from_terraform`. A future VMID renumber needs
+# ZERO changes here: the new vmid flows in through terraform_inventory.json and
+# each service keeps its features automatically. No IPs, no secrets — safe to
+# commit.
 #
-# Per-vmid shape:
+# Per-service shape:
 #   mounts:     list of { src: <host path>, dst: <in-container path>, ro: <bool, default false> }
 #   keyctl:     bool — ensure features contains keyctl=1, MERGED into existing
 #               features (terraform-set nesting=1 is preserved, never dropped)
@@ -23,33 +27,43 @@
 # are skipped (terraform may not have created them yet). All tasks are skipped
 # under Docker virtualization (molecule).
 media_lxc_features_map:
-  "210":  # download-vpn — qBittorrent + Prowlarr behind Proton WireGuard
+  plex:  # media streaming
+    mounts:
+      - { src: /rpool/data/media, dst: /mnt/media }
+    keyctl: false
+    tun: false
+  jellyseerr:  # request UI (Docker-in-LXC); no bind-mounts
+    mounts: []
+    keyctl: true
+    tun: false
+  sonarr:  # TV PVR
+    mounts:
+      - { src: /rpool/data/downloads, dst: /mnt/downloads }
+      - { src: /rpool/data/media, dst: /mnt/media }
+    keyctl: false
+    tun: false
+  radarr:  # movie PVR
+    mounts:
+      - { src: /rpool/data/downloads, dst: /mnt/downloads }
+      - { src: /rpool/data/media, dst: /mnt/media }
+    keyctl: false
+    tun: false
+  download-vpn:  # qBittorrent + Prowlarr behind Proton WireGuard
     mounts:
       - { src: /rpool/data/downloads, dst: /mnt/downloads }
       - { src: /rpool/data/media, dst: /mnt/media }
     keyctl: true
     tun: true
-  "211":  # sonarr — TV PVR
-    mounts:
-      - { src: /rpool/data/downloads, dst: /mnt/downloads }
-      - { src: /rpool/data/media, dst: /mnt/media }
-    keyctl: false
-    tun: false
-  "212":  # radarr — movie PVR
-    mounts:
-      - { src: /rpool/data/downloads, dst: /mnt/downloads }
-      - { src: /rpool/data/media, dst: /mnt/media }
-    keyctl: false
-    tun: false
-  "213":  # plex — media streaming
-    mounts:
-      - { src: /rpool/data/media, dst: /mnt/media }
-    keyctl: false
-    tun: false
-  "214":  # jellyseerr — request UI (Docker-in-LXC); no bind-mounts
-    mounts: []
-    keyctl: true
-    tun: false
+
+# Service -> VMID resolution, sourced from the terraform inventory and injected
+# onto proxmox hosts by playbooks/load_terraform.yml. Defaults to {} when unset
+# (e.g. a bare role run without load_terraform), in which case the role resolves
+# no containers and acts on nothing — the safe no-op.
+media_lxc_features_service_vmids: >-
+  {{
+    media_lxc_features_service_vmids_from_terraform
+    | default(hostvars[inventory_hostname].media_lxc_features_service_vmids_from_terraform | default({}), true)
+  }}
 
 # /dev/net/tun device numbers (char major:minor). Stable Linux allocation for
 # the TUN/TAP driver. Verified on pve1: `stat -c %t:%T /dev/net/tun` -> a:c8

--- a/roles/media_lxc_features/tasks/main.yml
+++ b/roles/media_lxc_features/tasks/main.yml
@@ -9,6 +9,47 @@
 # Ordering: terraform-proxmox creates the media LXCs as plain shells ->
 # THIS role applies root-only features -> ansible-proxmox-apps converges the
 # services. See README.md.
+#
+# The feature map is keyed by SERVICE NAME. The effective vmid -> features map
+# is built here by resolving each service's CURRENT vmid from the terraform
+# inventory (media_lxc_features_service_vmids), so a vmid renumber needs no role
+# change — only terraform_inventory.json updates. Services without a resolved
+# vmid (not in the inventory) contribute nothing.
+
+- name: Select the services that have a vmid in the terraform inventory
+  ansible.builtin.set_fact:
+    # Drop any service the inventory does not currently place (not yet created /
+    # not deployed). Keeps the join below total over what remains.
+    media_lxc_features_selected: >-
+      {{
+        media_lxc_features_map | dict2items
+        | selectattr('key', 'in', media_lxc_features_service_vmids)
+        | list
+      }}
+  tags:
+    - media_lxc_features
+
+- name: Resolve the service feature map to the current vmids
+  ansible.builtin.set_fact:
+    # Join the service-keyed features onto each service's CURRENT vmid (resolved
+    # from the terraform inventory), producing the vmid-keyed dict the loop below
+    # consumes: { "<vmid>": <features> }. VMIDs are stringified to match the
+    # `pct list` present-set. A vmid renumber flows in through the inventory and
+    # needs NO change here — each service simply lands on its new vmid.
+    media_lxc_features_resolved: >-
+      {{
+        dict(
+          (
+            media_lxc_features_selected
+            | map(attribute='key')
+            | map('extract', media_lxc_features_service_vmids)
+            | map('string') | list
+          )
+          | zip(media_lxc_features_selected | map(attribute='value') | list)
+        )
+      }}
+  tags:
+    - media_lxc_features
 
 - name: Enumerate LXC containers present on this host
   ansible.builtin.command:
@@ -42,7 +83,7 @@
 
 - name: Apply root-only features to each present media container
   ansible.builtin.include_tasks: configure_container.yml
-  loop: "{{ media_lxc_features_map | dict2items }}"
+  loop: "{{ media_lxc_features_resolved | default({}) | dict2items }}"
   loop_control:
     loop_var: media_ct
     label: "container {{ media_ct.key }}"


### PR DESCRIPTION
## What

`media_lxc_features` applied root-only LXC features (bind-mounts, `keyctl`, `/dev/net/tun`) keyed by **hardcoded VMID** (210-214). The media VMIDs are being renumbered, which under the old design forced a role edit and risked features landing on the wrong container.

This refactors the feature map to be keyed by **service name** and resolves each service's *current* VMID from the terraform inventory at run time, so a renumber needs **zero** role changes.

## How

- **`playbooks/load_terraform.yml`** projects `terraform_data.containers` (keyed by service hostname, each carrying its `vmid`) into `media_lxc_features_service_vmids_from_terraform` — `{ service: vmid }` — and injects it onto proxmox hosts. Mirrors the existing `nas_storage_from_terraform` / `zfs_pools_from_terraform` injection pattern.
- **`roles/media_lxc_features/defaults/main.yml`** rekeys `media_lxc_features_map` by service (`plex`, `jellyseerr`, `sonarr`, `radarr`, `download-vpn`) and adds `media_lxc_features_service_vmids` resolution (defaults to `{}` → safe no-op when unwired).
- **`roles/media_lxc_features/tasks/main.yml`** joins the service-keyed feature map against the service→vmid resolution to build the effective `{ vmid: features }` it loops. A VMID renumber flows in through `terraform_inventory.json`; each service keeps its features and follows its new VMID. Services absent from the inventory resolve to nothing and are skipped.

The new mapping (210 plex, 211 jellyseerr, 212 sonarr, 213 radarr, 214 download-vpn) is realized purely by the inventory — the role never names a raw VMID.

## Per-service feature map (unchanged semantics, now keyed by service)

| service | bind-mounts | keyctl | /dev/net/tun |
| --- | --- | --- | --- |
| plex | `/rpool/data/media`→`/mnt/media` | no | no |
| jellyseerr | (none) | yes | no |
| sonarr | downloads + media | no | no |
| radarr | downloads + media | no | no |
| download-vpn | downloads + media | yes | yes |

## Preserved

Idempotency (config-diff guards, restart-on-change), the present-vmid skip guard, and the Docker short-circuit are unchanged.

## Verification

- `ansible-lint` (profile **production**): 0 failures / 0 warnings on all 12 files.
- Service→vmid join proven against real inventory data for **both** the live (old) and new mappings — each service lands on its correct vmid.
- Molecule `verify.yml`: 17/17 assertions pass (service-keyed map, the new-vmid join, absent-skip, keyctl-merge, tun 10:200, pct-absent guard).
- Molecule converge logic under simulated Docker: resolves the new vmids and skips all `pct` work via the Docker guard (0 failed).
- CI `inventory_load` verify step passes with the new injection task (media-less fixture → empty media resolution → safe no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)