### PR TITLE
feat(lxc_gpu_features): pass AMD RX 6800 into hermes-infer LXC

### DIFF
--- a/playbooks/load_terraform.yml
+++ b/playbooks/load_terraform.yml
@@ -96,3 +96,24 @@
             )
           }}
       loop: "{{ groups['proxmox'] | default([]) }}"
+
+    # Service -> VMID resolution for lxc_gpu_features (GPU passthrough). Same
+    # projection as the media map above, exposed under its own var so the GPU
+    # role has no coupling to media naming. Extra (non-GPU) entries are harmless.
+    - name: Inject Terraform service -> vmid map for GPU passthrough onto proxmox hosts
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        lxc_gpu_features_service_vmids_from_terraform: >-
+          {{
+            dict(
+              (terraform_data.containers | default({})) | dict2items
+              | selectattr('value.vmid', 'defined')
+              | map(attribute='key') | list
+              | zip(
+                  (terraform_data.containers | default({})) | dict2items
+                  | selectattr('value.vmid', 'defined')
+                  | map(attribute='value.vmid') | list
+                )
+            )
+          }}
+      loop: "{{ groups['proxmox'] | default([]) }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -58,6 +58,13 @@
       tags:
         - media_lxc_features
 
+    # Root-only AMD GPU passthrough (/dev/dri + /dev/kfd) for the inference LXC
+    # (hermes-infer, vmid 167) — same root@pam-only contract as media_lxc_features.
+    # Runs after terraform creates the shell, before ansible-proxmox-apps installs Ollama.
+    - role: lxc_gpu_features
+      tags:
+        - lxc_gpu_features
+
     - role: ntp
       tags:
         - ntp

--- a/roles/lxc_gpu_features/README.md
+++ b/roles/lxc_gpu_features/README.md
@@ -1,0 +1,78 @@
+# lxc_gpu_features
+
+Binds AMD GPU device nodes (`/dev/dri`, `/dev/kfd`) into GPU LXC containers over
+native `root@pam` SSH, idempotently. Companion to `media_lxc_features`.
+
+## Installation
+
+This role ships with the `ansible-proxmox` repository — no external install. It
+is wired into `playbooks/site.yml` (after `media_lxc_features`) and runs against
+the `proxmox` host group. Service → VMID resolution is injected by
+`playbooks/load_terraform.yml` from `terraform_inventory.json`, so the role must
+run after that play (already imported first by `site.yml`). Tools come from the
+repo's Nix dev shell (`direnv allow`); no `pip`/`galaxy` step is required.
+
+## Why this role exists (the contract split)
+
+The BPG Proxmox provider's API token **cannot** set arbitrary device
+passthrough — Proxmox restricts `lxc.cgroup2.devices.allow` / `lxc.mount.entry`
+to `root@pam` *ticket* auth, so the token gets HTTP 403. So `terraform-proxmox`
+creates the GPU LXC as a plain **shell**, and this role applies the device
+lines. Identical split to `media_lxc_features` (which passes `/dev/net/tun` to
+the download-vpn LXC).
+
+## Ordering
+
+1. `terraform-proxmox` — creates `hermes-infer` (vmid 167) as a privileged shell.
+2. **this role** — binds `/dev/dri` (226) + `/dev/kfd` (235), reboots on change.
+3. `ansible-proxmox-apps` (role `ollama`) — installs Ollama + ROCm, adds the
+   service user to `render`/`video`, pulls Hermes 4.
+
+## What it writes
+
+A marker-guarded block in `/etc/pve/lxc/<vmid>.conf`:
+
+```text
+lxc.cgroup2.devices.allow: c 226:* rwm
+lxc.mount.entry: /dev/dri dev/dri none bind,optional,create=dir
+lxc.cgroup2.devices.allow: c 235:* rwm
+lxc.mount.entry: /dev/kfd dev/kfd none bind,optional,create=file
+```
+
+## Feature map (keyed by service, not VMID)
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `lxc_gpu_features_map` | `{ hermes-infer: { dri: true, kfd: true } }` | Service → which device groups to bind |
+| `lxc_gpu_features_dri_major` | `226` | `/dev/dri` char major |
+| `lxc_gpu_features_kfd_major` | `235` | `/dev/kfd` char major |
+| `lxc_gpu_features_service_vmids` | from terraform inventory | Service → current vmid (auto) |
+
+The current vmid is resolved at run time from `terraform_inventory.json`, so a
+vmid renumber needs no change here.
+
+## Idempotency & guards
+
+`blockinfile` is marker-guarded — reports `changed` only on edit, and the
+handler reboots **only** changed containers, so a converged host does nothing.
+Acts only on vmids actually present (`pct list`); skipped entirely under Docker
+virtualization (molecule), and a no-op when the inventory resolves no GPU
+services.
+
+## Usage
+
+```bash
+# Dry run
+env -u DOPPLER_PROJECT -u DOPPLER_CONFIG -u DOPPLER_ENVIRONMENT doppler run -- \
+  ./scripts/run-ansible.sh playbooks/site.yml --limit pve1 --tags lxc_gpu_features --check --diff
+
+# Apply (after terraform creates the LXC shell, before apps converge)
+env -u DOPPLER_PROJECT -u DOPPLER_CONFIG -u DOPPLER_ENVIRONMENT doppler run -- \
+  ./scripts/run-ansible.sh playbooks/site.yml --limit pve1 --tags lxc_gpu_features
+```
+
+Verify the devices landed inside the container:
+
+```bash
+pct exec 167 -- ls -l /dev/dri /dev/kfd
+```

--- a/roles/lxc_gpu_features/defaults/main.yml
+++ b/roles/lxc_gpu_features/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+# lxc_gpu_features role defaults
+#
+# Root-only LXC GPU passthrough that the BPG Proxmox provider's API token CANNOT
+# set: Proxmox restricts arbitrary device passthrough to root@pam *ticket* auth,
+# so the API token gets HTTP 403. terraform-proxmox creates the GPU LXC as a
+# plain shell; this role binds the AMD GPU device nodes into it over native root
+# SSH, idempotently. Mirrors the media_lxc_features pattern exactly.
+#
+# Ordering: terraform-proxmox (shell) -> THIS role (devices) ->
+# ansible-proxmox-apps role: ollama (inference stack). See README.md.
+#
+# Per-service shape:
+#   dri: bool — bind /dev/dri (card0 + renderD128, char major 226) for compute
+#   kfd: bool — bind /dev/kfd (char major 235) for ROCm/HIP compute
+#
+# Keyed by SERVICE NAME; each service's current vmid is resolved at run time from
+# the terraform inventory (see lxc_gpu_features_service_vmids). A vmid renumber
+# needs no change here. Only vmids present on the host are acted on; every task
+# is skipped under Docker virtualization (molecule). No IPs, no secrets.
+lxc_gpu_features_map:
+  hermes-infer:  # Ollama + ROCm on the RX 6800 (privileged LXC)
+    dri: true
+    kfd: true
+
+# AMD GPU character-device majors on pve1, verified live:
+#   /dev/dri/card0 = 226:0, /dev/dri/renderD128 = 226:128, /dev/kfd = 235:0.
+# A `*` minor covers card + render + any future render nodes.
+lxc_gpu_features_dri_major: 226
+lxc_gpu_features_kfd_major: 235
+
+# Service -> VMID resolution, injected by playbooks/load_terraform.yml. Defaults
+# to {} (a safe no-op that resolves no containers) when unset — e.g. a bare role
+# run without load_terraform having populated the inventory.
+lxc_gpu_features_service_vmids: >-
+  {{
+    lxc_gpu_features_service_vmids_from_terraform
+    | default(hostvars[inventory_hostname].lxc_gpu_features_service_vmids_from_terraform | default({}), true)
+  }}

--- a/roles/lxc_gpu_features/handlers/main.yml
+++ b/roles/lxc_gpu_features/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+# lxc_gpu_features handlers
+#
+# Device-passthrough changes take effect only after the container restarts.
+# Mutating tasks append the vmid to lxc_gpu_features_changed and notify this
+# handler, which reboots ONLY those containers — a converged host does nothing.
+
+- name: Restart changed gpu containers
+  ansible.builtin.command:
+    cmd: "pct reboot {{ item }}"
+  loop: "{{ lxc_gpu_features_changed | default([]) | unique }}"
+  loop_control:
+    label: "container {{ item }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - lxc_gpu_features_changed | default([]) | length > 0
+  changed_when: true

--- a/roles/lxc_gpu_features/tasks/configure_container.yml
+++ b/roles/lxc_gpu_features/tasks/configure_container.yml
@@ -1,0 +1,51 @@
+---
+# Bind AMD GPU device nodes into a single GPU LXC.
+# gpu_ct.key   = container ID (string)
+# gpu_ct.value = { dri: bool, kfd: bool }
+#
+# `pct set` has no flag for arbitrary device passthrough, so the standard method
+# is raw lines appended to /etc/pve/lxc/<vmid>.conf:
+#   lxc.cgroup2.devices.allow: c 226:* rwm           # /dev/dri (card + render)
+#   lxc.mount.entry: /dev/dri dev/dri none bind,optional,create=dir
+#   lxc.cgroup2.devices.allow: c 235:* rwm           # /dev/kfd (ROCm)
+#   lxc.mount.entry: /dev/kfd dev/kfd none bind,optional,create=file
+# blockinfile is marker-guarded -> idempotent, reports changed only on edit.
+# This is a PRIVILEGED LXC, so host GIDs map 1:1; the ollama service user is
+# added to render/video inside the container by the ansible-proxmox-apps role.
+
+- name: "Build GPU passthrough lines for container {{ gpu_ct.key }}"
+  ansible.builtin.set_fact:
+    lxc_gpu_features_lines: >-
+      {{
+        (
+          ([
+            'lxc.cgroup2.devices.allow: c ' ~ lxc_gpu_features_dri_major ~ ':* rwm',
+            'lxc.mount.entry: /dev/dri dev/dri none bind,optional,create=dir'
+          ] if (gpu_ct.value.dri | default(true)) else [])
+          +
+          ([
+            'lxc.cgroup2.devices.allow: c ' ~ lxc_gpu_features_kfd_major ~ ':* rwm',
+            'lxc.mount.entry: /dev/kfd dev/kfd none bind,optional,create=file'
+          ] if (gpu_ct.value.kfd | default(true)) else [])
+        )
+      }}
+  tags:
+    - lxc_gpu_features
+
+- name: "Passthrough AMD GPU devices into container {{ gpu_ct.key }}"
+  ansible.builtin.blockinfile:
+    path: "/etc/pve/lxc/{{ gpu_ct.key }}.conf"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK lxc_gpu_features"
+    block: '{{ lxc_gpu_features_lines | join("\n") }}'
+    insertafter: EOF
+  notify: Restart changed gpu containers
+  register: lxc_gpu_features_set
+  tags:
+    - lxc_gpu_features
+
+- name: "Record GPU-passthrough change for container {{ gpu_ct.key }}"
+  ansible.builtin.set_fact:
+    lxc_gpu_features_changed: "{{ lxc_gpu_features_changed | default([]) + [gpu_ct.key] }}"
+  when: lxc_gpu_features_set is defined and lxc_gpu_features_set.changed
+  tags:
+    - lxc_gpu_features

--- a/roles/lxc_gpu_features/tasks/main.yml
+++ b/roles/lxc_gpu_features/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+# lxc_gpu_features role tasks
+#
+# Applies root-only AMD GPU device passthrough to GPU LXCs that the BPG Proxmox
+# API token cannot set (403; root@pam only). Runs over native root SSH,
+# idempotently, only on vmids that actually exist on the host.
+#
+# The feature map is keyed by SERVICE NAME. The effective vmid -> features map is
+# built here by resolving each service's CURRENT vmid from the terraform
+# inventory (lxc_gpu_features_service_vmids), so a vmid renumber needs no role
+# change — only terraform_inventory.json updates. Services without a resolved
+# vmid (not in the inventory) contribute nothing.
+
+- name: Select GPU services that have a vmid in the terraform inventory
+  ansible.builtin.set_fact:
+    lxc_gpu_features_selected: >-
+      {{
+        lxc_gpu_features_map | dict2items
+        | selectattr('key', 'in', lxc_gpu_features_service_vmids)
+        | list
+      }}
+  tags:
+    - lxc_gpu_features
+
+- name: Resolve the GPU service feature map to current vmids
+  ansible.builtin.set_fact:
+    lxc_gpu_features_resolved: >-
+      {{
+        dict(
+          (
+            lxc_gpu_features_selected
+            | map(attribute='key')
+            | map('extract', lxc_gpu_features_service_vmids)
+            | map('string') | list
+          )
+          | zip(lxc_gpu_features_selected | map(attribute='value') | list)
+        )
+      }}
+  tags:
+    - lxc_gpu_features
+
+- name: Enumerate LXC containers present on this host
+  ansible.builtin.command:
+    cmd: pct list
+  register: lxc_gpu_features_pct_list
+  changed_when: false
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - lxc_gpu_features
+
+- name: Build the set of vmids present on this host
+  ansible.builtin.set_fact:
+    lxc_gpu_features_present: >-
+      {{
+        lxc_gpu_features_pct_list.stdout_lines | default([])
+        | map('regex_search', '^\d+')
+        | select('truthy')
+        | list
+      }}
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - lxc_gpu_features
+
+- name: Reset the changed-container accumulator
+  ansible.builtin.set_fact:
+    lxc_gpu_features_changed: []
+  tags:
+    - lxc_gpu_features
+
+- name: Apply GPU passthrough to each present GPU container
+  ansible.builtin.include_tasks: configure_container.yml
+  loop: "{{ lxc_gpu_features_resolved | default({}) | dict2items }}"
+  loop_control:
+    loop_var: gpu_ct
+    label: "container {{ gpu_ct.key }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - gpu_ct.key in lxc_gpu_features_present | default([])
+  tags:
+    - lxc_gpu_features


### PR DESCRIPTION
## Summary
Adds the `lxc_gpu_features` ansible-proxmox host role to pass the AMD RX 6800 (`/dev/dri` 226 + `/dev/kfd` 235) into the privileged `hermes-infer` LXC (vmid 167) for local Ollama/ROCm inference.

Mirrors `media_lxc_features`: the BPG Proxmox API token cannot set device passthrough (HTTP 403 — Proxmox restricts it to `root@pam` ticket auth), so Terraform creates the LXC as a shell and this role applies the device lines over native root SSH via a marker-guarded `blockinfile` on `/etc/pve/lxc/<vmid>.conf`, rebooting only changed containers. Service→vmid is resolved from the terraform inventory, so a vmid renumber needs no role change.

## Changes
- `roles/lxc_gpu_features/` — new role (defaults, tasks, configure_container, handlers, README)
- `playbooks/site.yml` — wire role after `media_lxc_features`
- `playbooks/load_terraform.yml` — inject `lxc_gpu_features_service_vmids_from_terraform`

## Test plan
- [x] `ansible-lint` passes (production profile, 0 failures / 0 warnings)
- [ ] After Terraform creates CT 167: run `--limit pve1 --tags lxc_gpu_features`, then verify `pct exec 167 -- ls /dev/dri /dev/kfd` and `rocminfo` inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)