### PR TITLE
feat(zfs_pools): idempotent per-dataset ZFS properties

### DIFF
--- a/molecule/zfs_pools/converge.yml
+++ b/molecule/zfs_pools/converge.yml
@@ -22,6 +22,9 @@
           datasets:
             backups:
               quota: "1T"
+              properties:
+                recordsize: "1M"
+                compression: "zstd"
 
   roles:
     - role: zfs_pools

--- a/molecule/zfs_pools/verify.yml
+++ b/molecule/zfs_pools/verify.yml
@@ -11,6 +11,9 @@
           datasets:
             backups:
               quota: "1T"
+              properties:
+                recordsize: "1M"
+                compression: "zstd"
 
   tasks:
     - name: Re-derive pools from the injected node_storage contract
@@ -24,6 +27,9 @@
           - zfs_pools_check.tank.datasets.backups.quota == '1T'
           # Confirms the byte-comparison used for idempotent quota drift.
           - (zfs_pools_check.tank.datasets.backups.quota | human_to_bytes) == 1099511627776
+          # Confirms the per-dataset properties map resolves through the contract.
+          - zfs_pools_check.tank.datasets.backups.properties.recordsize == '1M'
+          - zfs_pools_check.tank.datasets.backups.properties.compression == 'zstd'
         fail_msg: "node_storage contract did not resolve as expected"
 
     - name: Probe for ZFS pools (should be absent in the molecule container)

--- a/roles/zfs_pools/README.md
+++ b/roles/zfs_pools/README.md
@@ -58,8 +58,24 @@ zfs_pools_map:
     register: true        # run `pvesm add zfspool` if not already registered
     content: [images, rootdir]
     datasets:
-      backups: { quota: "1T" }
+      backups:
+        quota: "1T"
+        properties:                 # optional; any zfs property=value
+          recordsize: "1M"
+          compression: "zstd"
+          "com.sun:auto-snapshot": "false"
 ```
+
+### Per-dataset properties
+
+`datasets.<name>.properties` is an optional map of arbitrary ZFS properties
+(`recordsize`, `compression`, `readonly`, `atime`, `com.sun:auto-snapshot`,
+user properties, …). Each is read with `zfs get -H -o value` and only set when
+it differs, so re-runs report no change. Declare values in **ZFS canonical
+form** (`recordsize: "1M"`, `compression: "zstd"`, `readonly: "on"`) and
+**quote** them so YAML does not coerce `on`/`off`/`true`/`false` to booleans.
+`quota` keeps its own dedicated (byte-compared) handling — do not also put it
+under `properties`.
 
 ## Usage
 
@@ -76,6 +92,8 @@ doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags zfs_pools
 - Datasets: checked with `zfs list`; created with `zfs create -p` when absent.
 - Quotas: compared in **bytes** (`zfs get -Hp` vs `human_to_bytes(desired)`), so
   `1T` and `1024G` do not cause spurious changes.
+- Properties: each `properties` entry compared as a string (`zfs get -H -o
+  value`) and only `zfs set` when it differs.
 - Registration: `pvesm status --storage <pool>` gates `pvesm add`.
 
 All ZFS / `pvesm` tasks are skipped under Docker (`ansible_virtualization_type

--- a/roles/zfs_pools/tasks/dataset_properties.yml
+++ b/roles/zfs_pools/tasks/dataset_properties.yml
@@ -1,0 +1,31 @@
+---
+# Idempotently apply arbitrary ZFS properties for a single dataset.
+# Included per-dataset from datasets.yml; `zfs_pool` (pool dict2items entry) and
+# `zfs_dataset` (dataset dict2items entry) are in scope. Each value is compared
+# against what ZFS reports (`zfs get -H -o value`), so declare properties in ZFS
+# canonical form (e.g. recordsize: "1M", compression: "zstd", readonly: "on",
+# "com.sun:auto-snapshot": "false") and quote them so YAML does not coerce
+# on/off/true/false into booleans.
+
+- name: "Read current properties for {{ zfs_pool.key ~ '/' ~ zfs_dataset.key }}"
+  ansible.builtin.command:
+    cmd: "zfs get -H -o value {{ item.key }} {{ zfs_pool.key }}/{{ zfs_dataset.key }}"
+  register: zfs_pools_ds_prop
+  changed_when: false
+  loop: "{{ zfs_dataset.value.properties | dict2items }}"
+  loop_control:
+    label: "{{ zfs_pool.key }}/{{ zfs_dataset.key }} {{ item.key }}"
+  tags:
+    - zfs_pools
+
+- name: "Set drifted properties for {{ zfs_pool.key ~ '/' ~ zfs_dataset.key }}"
+  ansible.builtin.command:
+    cmd: "zfs set {{ item.key }}={{ item.value | string }} {{ zfs_pool.key }}/{{ zfs_dataset.key }}"
+  loop: "{{ zfs_dataset.value.properties | dict2items }}"
+  loop_control:
+    label: "{{ zfs_pool.key }}/{{ zfs_dataset.key }} {{ item.key }}={{ item.value }}"
+    index_var: zfs_pools_ds_prop_idx
+  when: zfs_pools_ds_prop.results[zfs_pools_ds_prop_idx].stdout != (item.value | string)
+  changed_when: true
+  tags:
+    - zfs_pools

--- a/roles/zfs_pools/tasks/datasets.yml
+++ b/roles/zfs_pools/tasks/datasets.yml
@@ -53,3 +53,13 @@
   changed_when: true
   tags:
     - zfs_pools
+
+- name: "Apply per-dataset properties in pool {{ zfs_pool.key }}"
+  ansible.builtin.include_tasks: dataset_properties.yml
+  loop: "{{ zfs_pool.value.datasets | default({}) | dict2items }}"
+  loop_control:
+    loop_var: zfs_dataset
+    label: "{{ zfs_pool.key }}/{{ zfs_dataset.key }}"
+  when: zfs_dataset.value.properties | default({}) | length > 0
+  tags:
+    - zfs_pools


### PR DESCRIPTION
## Summary

Adds an optional `datasets.<name>.properties` map to the `zfs_pools` role so the
`node_storage` contract can tune **recordsize, compression, readonly,
com.sun:auto-snapshot**, and any other ZFS property per dataset — not just quota.

## Why

Foundation (WS1) for a broader ZFS storage-architecture effort (SIEM tiering,
media datasets, snapshot/replication targets). Each "chunk" needs workload-tuned
properties (e.g. `recordsize=1M` + `compression=zstd` for media; `recordsize=128K`
for Splunk; `com.sun:auto-snapshot=false` for scratch/transient datasets).

## What

- New `roles/zfs_pools/tasks/dataset_properties.yml`: read each property with
  `zfs get -H -o value`, `zfs set` only when it differs — idempotent, mirroring
  the existing byte-compared quota idiom.
- Included per-dataset from `datasets.yml`, guarded so datasets without
  `properties` are skipped; runs only on real hosts (existing Docker skip-guard).
- README documents the field + the ZFS-canonical-form / quote-your-values caveat.
- molecule `zfs_pools` converge/verify exercise the new field through the contract.

## Verification

- `ansible-lint` passes on the **production** profile (0 failures, 11 files).
- molecule `zfs_pools` runs in CI (Docker + the docker python module are
  unavailable in the local Nix dev shell).
- Declarative role capability only — no infrastructure applied.

## Scope / follow-ups

Consumed once `terraform-proxmox`'s `node_storage` dataset schema gains a
`properties` field (separate PR). Part of a multi-repo storage architecture;
backward-compatible (datasets without `properties` are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)