### PR TITLE
feat(proxmox_monitoring): ZFS pool capacity alerts via ntfy

### DIFF
--- a/roles/proxmox_monitoring/README.md
+++ b/roles/proxmox_monitoring/README.md
@@ -3,6 +3,18 @@
 Configures system monitoring tools for Proxmox VE crash investigation and
 health monitoring.
 
+## Installation
+
+This role ships in the `ansible-proxmox` repository and is applied via
+`playbooks/site.yml`. No separate installation is required beyond cloning the
+repo and installing collection dependencies:
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
 ## Components
 
 ### sysstat (sar)
@@ -33,6 +45,15 @@ minute.
 
 External uptime monitoring ping (optional).
 
+### zfs-capacity
+
+Pushes an [ntfy](https://ntfy.sh) alert when a ZFS pool crosses a usage band
+(default 50/75/90%). State is tracked per pool under
+`/var/lib/zfs-capacity-monitor/`, so a notification fires only on a band
+**change** (rising or recovering) — not every run. Priority scales with the
+band (50 → default, 75 → high, 90 → urgent). Disabled until
+`proxmox_monitoring_ntfy_url` is set.
+
 ## Variables
 
 | Variable | Default | Description |
@@ -45,6 +66,10 @@ External uptime monitoring ping (optional).
 | `proxmox_monitoring_crash_monitor_interval` | `1` | Crash monitor cron interval (minutes) |
 | `proxmox_monitoring_healthchecks_interval` | `1` | Healthchecks.io ping interval (minutes) |
 | `proxmox_monitoring_log_retention_days` | `90` | Days to retain |
+| `proxmox_monitoring_enable_zfs_capacity` | `true` | Enable ZFS capacity alerts |
+| `proxmox_monitoring_ntfy_url` | `""` | ntfy topic URL (secret); empty disables |
+| `proxmox_monitoring_zfs_capacity_interval` | `15` | Capacity check cron interval (minutes) |
+| `proxmox_monitoring_zfs_capacity_thresholds` | `[50, 75, 90]` | Usage bands (%) that trigger alerts |
 
 ## Usage
 

--- a/roles/proxmox_monitoring/defaults/main.yml
+++ b/roles/proxmox_monitoring/defaults/main.yml
@@ -19,3 +19,11 @@ proxmox_monitoring_enable_sysstat: true
 proxmox_monitoring_enable_atop: true
 proxmox_monitoring_enable_crash_monitor: true
 proxmox_monitoring_enable_healthchecks: true
+proxmox_monitoring_enable_zfs_capacity: true
+
+# ZFS pool capacity alerts: push via ntfy when a pool crosses a usage band.
+proxmox_monitoring_zfs_capacity_interval: 15
+proxmox_monitoring_zfs_capacity_thresholds: [50, 75, 90]
+# ntfy topic URL, e.g. https://ntfy.example.com/proxmox-storage
+# Set via vault/external variable — DO NOT commit a real URL. Empty disables it.
+proxmox_monitoring_ntfy_url: ""

--- a/roles/proxmox_monitoring/tasks/main.yml
+++ b/roles/proxmox_monitoring/tasks/main.yml
@@ -113,3 +113,31 @@
           {{ proxmox_monitoring_healthchecks_ping_url }}
         minute: "*/{{ proxmox_monitoring_healthchecks_interval }}"
         user: root
+
+- name: Configure ZFS capacity monitor
+  when:
+    - proxmox_monitoring_enable_zfs_capacity
+    - proxmox_monitoring_ntfy_url | length > 0
+  block:
+    - name: Create ZFS capacity monitor state directory
+      ansible.builtin.file:
+        path: /var/lib/zfs-capacity-monitor
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Deploy ZFS capacity monitor script
+      ansible.builtin.template:
+        src: zfs-capacity-monitor.sh.j2
+        dest: /usr/local/bin/zfs-capacity-monitor.sh
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Configure ZFS capacity monitor cron job
+      ansible.builtin.cron:
+        name: "zfs-capacity-monitor"
+        job: "/usr/local/bin/zfs-capacity-monitor.sh"
+        minute: "*/{{ proxmox_monitoring_zfs_capacity_interval }}"
+        user: root

--- a/roles/proxmox_monitoring/templates/zfs-capacity-monitor.sh.j2
+++ b/roles/proxmox_monitoring/templates/zfs-capacity-monitor.sh.j2
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+# ZFS pool capacity monitor — pushes an ntfy alert when a pool crosses a usage
+# band (e.g. 50/75/90%). State is tracked per pool so a notification fires only
+# on a band CHANGE, not every run. Managed by Ansible — do not edit manually.
+
+NTFY_URL="{{ proxmox_monitoring_ntfy_url }}"
+STATE_DIR="/var/lib/zfs-capacity-monitor"
+THRESHOLDS=({{ proxmox_monitoring_zfs_capacity_thresholds | join(' ') }})
+
+mkdir -p "$STATE_DIR"
+
+notify() {
+  # $1=title  $2=priority  $3=tags  $4=message
+  curl -fsS -m 10 --retry 3 -o /dev/null \
+    -H "Title: $1" -H "Priority: $2" -H "Tags: $3" \
+    -d "$4" "$NTFY_URL" || true
+}
+
+zpool list -H -o name,capacity | while IFS=$'\t' read -r pool cap_raw; do
+  cap="${cap_raw%\%}"
+
+  # Current band = highest threshold the pool has reached (0 if below all).
+  band=0
+  for t in "${THRESHOLDS[@]}"; do
+    if [ "$cap" -ge "$t" ]; then band="$t"; fi
+  done
+
+  state_file="$STATE_DIR/${pool//\//_}.band"
+  last=0
+  if [ -f "$state_file" ]; then last="$(cat "$state_file")"; fi
+  if [ "$band" = "$last" ]; then continue; fi
+
+  if [ "$band" -gt "$last" ]; then
+    case "$band" in
+      90) prio="urgent"; tags="rotating_light" ;;
+      75) prio="high"; tags="warning" ;;
+      *) prio="default"; tags="floppy_disk" ;;
+    esac
+    notify "ZFS ${pool} at ${cap}%" "$prio" "$tags" \
+      "Pool '${pool}' crossed ${band}% capacity (now ${cap}%) on $(hostname)."
+  else
+    notify "ZFS ${pool} recovered" "default" "white_check_mark" \
+      "Pool '${pool}' dropped to ${cap}% (below ${last}%) on $(hostname)."
+  fi
+  echo "$band" >"$state_file"
+done


### PR DESCRIPTION
## Summary

Adds a ZFS pool capacity monitor to the `proxmox_monitoring` role that pushes an
**ntfy** notification (your phone/Mac) when a pool crosses a usage band — default
**50 / 75 / 90%**.

## Why

There was no capacity alerting at all — pools could silently fill (ZFS performance
also degrades past ~80%). ntfy was chosen because the ntfy LXC already exists and
delivers to iOS/macOS; healthchecks.io stays the uptime dead-man's-switch.

## What

- `templates/zfs-capacity-monitor.sh.j2`: per-pool band check; priority scales
  (75 → high, 90 → urgent); a recovery alert fires when usage drops to a lower band.
- Per-pool state under `/var/lib/zfs-capacity-monitor/` → **one alert per band
  change**, not one every run.
- cron job + state dir, mirroring the existing crash-monitor pattern.
- Gated: disabled until `proxmox_monitoring_ntfy_url` is set (no token committed).

## Verification

- `ansible-lint` ✓ production profile (7 files).
- `shellcheck` ✓ on the rendered script (fixed the `set -euo pipefail` shebang;
  used `if/then/fi` to stay `set -e`-safe).
- **Functional test** with fake `zpool`/`curl` stubs across 4 runs: confirmed
  threshold crossings alert with correct priority, repeat runs stay silent, and
  recoveries notify — state files end at the expected bands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)