### PR TITLE
feat(sanoid): ZFS snapshot retention role (layer-1 protection)

### DIFF
--- a/molecule/sanoid/converge.yml
+++ b/molecule/sanoid/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    # A representative per-criticality assignment. Package install + timer are
+    # skipped under Docker; this proves the role converges and sanoid.conf
+    # renders the templates and dataset sections from the contract.
+    sanoid_datasets:
+      "rpool/data/nas":
+        use_template: critical
+        recursive: "yes"
+      "nvme1/siem/cribl-pq":
+        use_template: scratch
+
+  roles:
+    - role: sanoid

--- a/molecule/sanoid/molecule.yml
+++ b/molecule/sanoid/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-sanoid-test
+    image: debian:12-slim
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/sanoid/verify.yml
+++ b/molecule/sanoid/verify.yml
@@ -1,0 +1,26 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Read the rendered sanoid.conf
+      ansible.builtin.slurp:
+        src: /etc/sanoid/sanoid.conf
+      register: sanoid_conf
+
+    - name: Decode sanoid.conf
+      ansible.builtin.set_fact:
+        sanoid_conf_text: "{{ sanoid_conf.content | b64decode }}"
+
+    - name: Assert templates and dataset assignments rendered
+      ansible.builtin.assert:
+        that:
+          - "'[template_critical]' in sanoid_conf_text"
+          - "'[template_scratch]' in sanoid_conf_text"
+          - "'[rpool/data/nas]' in sanoid_conf_text"
+          - "'use_template = critical' in sanoid_conf_text"
+          # scratch dataset opts out of snapshots
+          - "'[nvme1/siem/cribl-pq]' in sanoid_conf_text"
+        fail_msg: "sanoid.conf did not render the expected templates/datasets"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -50,6 +50,12 @@
       tags:
         - zfs_pools
 
+    # Local ZFS snapshot retention (sanoid) for the datasets zfs_pools manages.
+    # Layer 1 protection (rollback); cross-node replication is a separate role.
+    - role: sanoid
+      tags:
+        - sanoid
+
     # Root-only media LXC features (bind-mounts, keyctl, /dev/net/tun) that the
     # BPG provider's API token cannot set. Runs AFTER OpenTofu creates the
     # media LXC shells and zfs_pools manages the /rpool/data datasets, and

--- a/roles/sanoid/README.md
+++ b/roles/sanoid/README.md
@@ -1,0 +1,52 @@
+# sanoid
+
+Schedules and prunes ZFS snapshots with [sanoid](https://github.com/jimsalterjrs/sanoid)
+— local point-in-time protection (accidental delete / corruption rollback). It
+is **layer 1** of the storage-resiliency model; cross-node replication
+(syncoid) and guest backups (PBS) are separate roles.
+
+## Installation
+
+This role ships in the `ansible-proxmox` repository and is applied via
+`playbooks/site.yml`. No separate installation is required beyond cloning the
+repo and installing collection dependencies:
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
+## Scope
+
+- Installs the `sanoid` package, renders `/etc/sanoid/sanoid.conf`, and enables
+  `sanoid.timer`.
+- Snapshots only the datasets you assign in `sanoid_datasets`; templates alone
+  take nothing. The role is inert until datasets are assigned.
+- Package install + timer are skipped under Docker so molecule can converge.
+
+## Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `sanoid_enabled` | `true` | Master enable for the role |
+| `sanoid_timer_enabled` | `true` | Enable/start `sanoid.timer` |
+| `sanoid_templates` | critical / media / scratch | Retention templates by criticality tier |
+| `sanoid_datasets` | `{}` | Map of `dataset => { use_template, recursive, … }` |
+
+Quote `yes`/`no` values — sanoid wants literal `yes`/`no`, and unquoted YAML
+coerces them to booleans.
+
+## Usage
+
+```yaml
+sanoid_datasets:
+  "rpool/data/nas": { use_template: critical, recursive: "yes" }
+  "nvme1/siem/splunk-hot": { use_template: critical }
+  "nvme1/siem/cribl-pq": { use_template: scratch }   # transient, no snapshots
+```
+
+```bash
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags sanoid
+sanoid --monitor-snapshots   # health check after a few cycles
+```

--- a/roles/sanoid/defaults/main.yml
+++ b/roles/sanoid/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+# sanoid role defaults — ZFS snapshot scheduling + retention.
+#
+# Datasets are assigned per host (group_vars/host_vars) by criticality tier.
+# The role is inert until sanoid_datasets is populated (templates alone take no
+# snapshots).
+
+sanoid_enabled: true
+sanoid_package: sanoid
+sanoid_timer_enabled: true
+sanoid_config_dir: /etc/sanoid
+
+# Retention templates by criticality tier. Quote yes/no so YAML keeps them
+# strings — sanoid wants literal yes/no, not Python booleans (True/False).
+sanoid_templates:
+  critical:
+    frequently: 0
+    hourly: 36
+    daily: 30
+    weekly: 8
+    monthly: 6
+    yearly: 0
+    autosnap: "yes"
+    autoprune: "yes"
+  media:
+    frequently: 0
+    hourly: 0
+    daily: 14
+    weekly: 4
+    monthly: 3
+    yearly: 0
+    autosnap: "yes"
+    autoprune: "yes"
+  scratch:
+    autosnap: "no"
+    autoprune: "no"
+
+# Per-dataset assignment (empty by default). Set in inventory, e.g.:
+#   sanoid_datasets:
+#     "rpool/data/nas": { use_template: critical, recursive: "yes" }
+#     "nvme1/siem/cribl-pq": { use_template: scratch }
+sanoid_datasets: {}

--- a/roles/sanoid/tasks/main.yml
+++ b/roles/sanoid/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+# sanoid role tasks — install sanoid, render its config, enable the timer.
+# Package install and the systemd timer are skipped under Docker (molecule);
+# config rendering still runs so the contract can be verified in-container.
+
+- name: Install sanoid
+  ansible.builtin.apt:
+    name: "{{ sanoid_package }}"
+    state: present
+    update_cache: true
+  when:
+    - sanoid_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - sanoid
+
+- name: Ensure sanoid config directory exists
+  ansible.builtin.file:
+    path: "{{ sanoid_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: sanoid_enabled
+  tags:
+    - sanoid
+
+- name: Render sanoid.conf
+  ansible.builtin.template:
+    src: sanoid.conf.j2
+    dest: "{{ sanoid_config_dir }}/sanoid.conf"
+    owner: root
+    group: root
+    mode: "0644"
+  when: sanoid_enabled
+  tags:
+    - sanoid
+
+- name: Enable and start the sanoid timer
+  ansible.builtin.systemd:
+    name: sanoid.timer
+    enabled: true
+    state: started
+  when:
+    - sanoid_enabled
+    - sanoid_timer_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - sanoid

--- a/roles/sanoid/templates/sanoid.conf.j2
+++ b/roles/sanoid/templates/sanoid.conf.j2
@@ -1,0 +1,16 @@
+# Managed by Ansible — do not edit manually.
+# ZFS snapshot retention (sanoid). https://github.com/jimsalterjrs/sanoid
+{% for tname, opts in sanoid_templates | dictsort %}
+
+[template_{{ tname }}]
+{% for k, v in opts | dictsort %}
+        {{ k }} = {{ v }}
+{% endfor %}
+{% endfor %}
+{% for ds, opts in sanoid_datasets | dictsort %}
+
+[{{ ds }}]
+{% for k, v in opts | dictsort %}
+        {{ k }} = {{ v }}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
## Summary

New `sanoid` role: scheduled ZFS snapshots + retention — **layer 1** of the
storage-resiliency model (instant rollback from accidental delete / corruption).

## What

- Installs `sanoid`, renders `/etc/sanoid/sanoid.conf` from criticality
  templates (`critical` / `media` / `scratch`), enables `sanoid.timer`.
- Snapshots only datasets assigned in `sanoid_datasets` — **inert until set**, so
  no surprise snapshots. Per-tier templates keep retention sensible (e.g. critical
  = 36h/30d/8w/6m; scratch = no snapshots).
- Wired into `site.yml` right after `zfs_pools`, so it protects the datasets that
  role provisions. Package + timer are Docker-skipped for molecule.

## Verification

- `ansible-lint` ✓ production profile (54 files).
- Rendered `sanoid.conf` confirmed valid: `yes`/`no` stay strings (not booleans),
  templates + dataset sections correct, `scratch` tier opts out of snapshots.
- molecule `sanoid` scenario runs in CI (Docker unavailable locally).

## Scope

Local snapshots only. Cross-node replication (syncoid) and guest backups (PBS)
are separate roles. Per-host `sanoid_datasets` assignments are inventory config
applied with credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)