### PR TITLE
feat(nas_storage): macOS / Time Machine / Infuse SMB support

### DIFF
--- a/molecule/nas_storage/converge.yml
+++ b/molecule/nas_storage/converge.yml
@@ -51,6 +51,14 @@
           create_mask: "0664"
           directory_mask: "0775"
           comment: "Home Assistant media storage"
+        - name: "timemachine"
+          path: "/mnt/nas/timemachine"
+          valid_users: "@nas"
+          browsable: true
+          read_only: false
+          force_group: "nas"
+          time_machine: true
+          comment: "Mac Time Machine target"
 
   tasks:
     - name: Update apt cache

--- a/molecule/nas_storage/verify.yml
+++ b/molecule/nas_storage/verify.yml
@@ -42,6 +42,7 @@
         - /etc/samba/smb.conf.d/nas.conf
         - /etc/samba/smb.conf.d/ha-backups.conf
         - /etc/samba/smb.conf.d/ha-media.conf
+        - /etc/samba/smb.conf.d/timemachine.conf
       register: samba_config_files
 
     - name: Assert Samba config files exist
@@ -79,3 +80,27 @@
         that:
           - "'[ha-backups]' in (ha_backup_share.content | b64decode)"
           - "'valid users = homeassistant' in (ha_backup_share.content | b64decode)"
+
+    - name: Read global smb.conf
+      ansible.builtin.slurp:
+        src: /etc/samba/smb.conf
+      register: nas_smb_conf
+
+    - name: Assert macOS (vfs_fruit) tuning is present globally
+      ansible.builtin.assert:
+        that:
+          - "'vfs objects = catia fruit streams_xattr' in (nas_smb_conf.content | b64decode)"
+          - "'fruit:metadata = stream' in (nas_smb_conf.content | b64decode)"
+        fail_msg: "Global vfs_fruit macOS tuning missing from smb.conf"
+
+    - name: Read Time Machine share config
+      ansible.builtin.slurp:
+        src: /etc/samba/smb.conf.d/timemachine.conf
+      register: nas_tm_share
+
+    - name: Assert Time Machine share enables fruit time machine
+      ansible.builtin.assert:
+        that:
+          - "'[timemachine]' in (nas_tm_share.content | b64decode)"
+          - "'fruit:time machine = yes' in (nas_tm_share.content | b64decode)"
+        fail_msg: "timemachine share did not render fruit:time machine = yes"

--- a/roles/nas_storage/README.md
+++ b/roles/nas_storage/README.md
@@ -44,7 +44,28 @@ sops exec-env secrets.sops.yml 'doppler run -- ./scripts/run-ansible.sh playbook
 | `nas_storage_group_name` | `nas` | Unix/Samba group for shared access |
 | `nas_storage_managed_users` | `[]` | Declarative Samba-backed service accounts |
 | `nas_storage_shares` | single `nas` share fallback | Declarative Samba shares |
+| `nas_storage_macos_optimized` | `true` | Global vfs_fruit tuning for macOS Finder/Time Machine |
 | `nas_storage_password_fingerprint_dir` | `/etc/samba/password-fingerprints` | Root-only password hash cache for idempotence |
+
+## Apple clients (macOS, Time Machine, Infuse)
+
+When `nas_storage_macos_optimized` is true (default), the global Samba config
+enables `vfs_fruit` (`catia fruit streams_xattr` + `fruit:*` options) so macOS
+Finder behaves correctly and shares can serve Time Machine. It is harmless for
+non-Apple clients.
+
+Per-share Apple options (set on a share in the `host_services.nas.shares`
+contract):
+
+| Share field | Effect |
+| --- | --- |
+| `time_machine: true` | Adds `fruit:time machine = yes` — the share becomes a Time Machine target |
+| `time_machine_max_size: "1T"` | Optional per-share Time Machine quota |
+| `read_only: true` | A read-only media share — e.g. for **Infuse** on Apple TV / iPhone to play directly over SMB alongside Plex |
+
+Spotlight *search* over SMB additionally requires a server-side indexer
+(Tracker/Elasticsearch) and is out of scope; Finder browsing and metadata work
+with `vfs_fruit` alone.
 
 ## Notes
 

--- a/roles/nas_storage/defaults/main.yml
+++ b/roles/nas_storage/defaults/main.yml
@@ -17,6 +17,9 @@ nas_storage_group_name: "{{ nas_storage_config.group_name | default('nas') }}"
 # Samba configuration
 nas_storage_smb_share_name: "{{ nas_storage_config.smb_share_name | default('nas') }}"
 nas_storage_smb_workgroup: "WORKGROUP"
+# macOS Finder/Time Machine integration via vfs_fruit (global). Enables
+# fruit:* options and per-share `time_machine: true`. Harmless for non-Mac.
+nas_storage_macos_optimized: "{{ nas_storage_config.macos_optimized | default(true) }}"
 nas_storage_smb_valid_users: "{{ nas_storage_config.smb_valid_users | default('@' ~ nas_storage_group_name) }}"
 nas_storage_packages:
   - samba

--- a/roles/nas_storage/templates/share.conf.j2
+++ b/roles/nas_storage/templates/share.conf.j2
@@ -9,3 +9,9 @@
    create mask = {{ item.create_mask | default('0664') }}
    directory mask = {{ item.directory_mask | default('0775') }}
    force group = {{ item.force_group | default(nas_storage_group_name) }}
+{% if item.time_machine | default(false) | bool %}
+   fruit:time machine = yes
+{% if item.time_machine_max_size is defined %}
+   fruit:time machine max size = {{ item.time_machine_max_size }}
+{% endif %}
+{% endif %}

--- a/roles/nas_storage/templates/smb.conf.j2
+++ b/roles/nas_storage/templates/smb.conf.j2
@@ -10,4 +10,16 @@
    max log size = 1000
    logging = file
    panic action = /usr/share/samba/panic-action %d
+{% if nas_storage_macos_optimized | default(true) | bool %}
+   # macOS Finder + Time Machine integration (vfs_fruit). Harmless for non-Mac
+   # clients; required for `fruit:time machine` shares and clean Finder behaviour.
+   vfs objects = catia fruit streams_xattr
+   fruit:metadata = stream
+   fruit:model = TimeCapsule
+   fruit:posix_rename = yes
+   fruit:veto_appledouble = no
+   fruit:nfs_aces = no
+   fruit:wipe_intentionally_left_blank_rfork = yes
+   fruit:delete_empty_adfiles = yes
+{% endif %}
    include = /etc/samba/smb.conf.d/*.conf


### PR DESCRIPTION
## Summary

Adds Apple-ecosystem SMB support to `nas_storage`: macOS Finder integration,
Time Machine targets, and Infuse-friendly read-only media shares.

## What

- **macOS-tuned SMB**: global `vfs_fruit` (`catia fruit streams_xattr` + `fruit:*`
  options, incl. `fruit:model = TimeCapsule`), gated by `nas_storage_macos_optimized`
  (default true). Harmless for non-Apple clients.
- **Time Machine**: per-share `time_machine: true` → `fruit:time machine = yes`
  (+ optional `time_machine_max_size`).
- **Infuse**: a `read_only: true` media share plays directly on Apple TV / iPhone
  over SMB alongside Plex (no transcode).
- molecule converge/verify exercise the global fruit block + a Time Machine share.

## Verification

- `ansible-lint` ✓ production profile (13 files).
- Rendered `share.conf` (TM share → `fruit:time machine = yes` + max size) and
  `smb.conf` (global fruit block, each directive on its own line) confirmed.
- molecule `nas_storage` runs `testparm` in CI (Docker unavailable locally).

## Scope / follow-up

Consumes an optional `time_machine` field on `host_services.nas.shares` — added in
a companion terraform-proxmox PR. Spotlight *search* over SMB needs a server-side
indexer (Tracker) and is intentionally out of scope; Finder browsing/metadata work
with vfs_fruit alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)