### PR TITLE
feat(syncoid): cross-node ZFS replication role (layer 2)

### DIFF
--- a/molecule/syncoid/converge.yml
+++ b/molecule/syncoid/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    # Pull model: this node is the target (pve2), pulling pve1 datasets.
+    # Package + cron are Docker-skipped; this proves the wrapper renders the
+    # expected syncoid invocations from the job contract.
+    syncoid_jobs:
+      - name: pve1-nas
+        source: "root@pve1:rpool/data/nas"
+        target: "tank/replica/pve1/nas"
+      - name: pve1-splunk-hot
+        source: "root@pve1:nvme1/siem/splunk-hot"
+        target: "tank/replica/pve1/splunk-hot"
+
+  roles:
+    - role: syncoid

--- a/molecule/syncoid/molecule.yml
+++ b/molecule/syncoid/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-syncoid-test
+    image: debian:12-slim
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/syncoid/verify.yml
+++ b/molecule/syncoid/verify.yml
@@ -1,0 +1,24 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Read the rendered syncoid wrapper
+      ansible.builtin.slurp:
+        src: /usr/local/bin/syncoid-replicate.sh
+      register: syncoid_wrapper
+
+    - name: Decode wrapper
+      ansible.builtin.set_fact:
+        syncoid_wrapper_text: "{{ syncoid_wrapper.content | b64decode }}"
+
+    - name: Assert wrapper renders the pull invocations from the job contract
+      ansible.builtin.assert:
+        that:
+          - "'replicate --recursive --no-sync-snap --quiet root@pve1:rpool/data/nas tank/replica/pve1/nas' in syncoid_wrapper_text"
+          - "'root@pve1:nvme1/siem/splunk-hot tank/replica/pve1/splunk-hot' in syncoid_wrapper_text"
+          # failure isolation present so an offline source does not abort the run
+          - "'FAILED (rc=' in syncoid_wrapper_text"
+        fail_msg: "syncoid wrapper did not render the expected jobs"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -74,6 +74,12 @@
           - "192.168.0.0/16"
           - "10.0.0.0/8"
 
+    # Cross-node ZFS replication (syncoid, layer 2). Pull model — runs on the
+    # backup node; inert until syncoid_jobs is set.
+    - role: syncoid
+      tags:
+        - syncoid
+
     - role: idrac_kiosk
       tags:
         - idrac_kiosk

--- a/roles/syncoid/README.md
+++ b/roles/syncoid/README.md
@@ -1,0 +1,55 @@
+# syncoid
+
+Cross-node ZFS replication with [syncoid](https://github.com/jimsalterjrs/sanoid)
+— **layer 2** of the storage-resiliency model (survives losing a whole node or
+pool). Pairs with the `sanoid` role: syncoid ships the snapshots sanoid takes.
+
+## Installation
+
+This role ships in the `ansible-proxmox` repository and is applied via
+`playbooks/site.yml`. No separate installation is required beyond cloning the
+repo and installing collection dependencies:
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
+## Model
+
+**Pull, from the target.** Run this role on the **backup** node (e.g. pve2); it
+SSHes to each source (e.g. pve1) and pulls. Pull-from-backup is safer than push
+— a compromised source cannot reach the backup. `--no-sync-snap` replicates the
+snapshots `sanoid` already took rather than creating new ones.
+
+A failed job (source offline — expected for the intermittent pve3) is logged to
+`/var/log/syncoid/` and does **not** abort the remaining jobs.
+
+## Prerequisite (apply-time)
+
+SSH trust from this node's `syncoid_user` (default `root`) to each source host,
+set up out of band. The role schedules replication; it does not distribute keys.
+
+## Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `syncoid_enabled` | `true` | Master enable |
+| `syncoid_jobs` | `[]` | List of `{ name, source, target, options? }` — inert until set |
+| `syncoid_default_options` | `--recursive --no-sync-snap --quiet` | Applied when a job omits `options` |
+| `syncoid_cron_hour` / `syncoid_cron_minute` | `2` / `17` | Replication schedule |
+| `syncoid_user` | `root` | User that runs syncoid (needs SSH to sources) |
+
+## Usage
+
+```yaml
+syncoid_jobs:
+  - name: pve1-nas
+    source: "root@pve1:rpool/data/nas"
+    target: "tank/replica/pve1/nas"
+```
+
+```bash
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags syncoid
+```

--- a/roles/syncoid/defaults/main.yml
+++ b/roles/syncoid/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# syncoid role defaults — cross-node ZFS replication (layer 2 of resiliency).
+#
+# PULL model: run this on the TARGET (backup) node; it SSHes to each source to
+# pull snapshots. Pull-from-backup is safer than push — a compromised source
+# cannot reach the backup. Inert until syncoid_jobs is set. SSH trust from this
+# node's syncoid_user to each source host is a prerequisite, set up out of band.
+
+syncoid_enabled: true
+syncoid_package: sanoid # provides both sanoid and syncoid
+syncoid_user: root
+syncoid_log_dir: /var/log/syncoid
+syncoid_cron_hour: 2
+syncoid_cron_minute: 17
+# Integrate with sanoid: replicate existing sanoid snapshots instead of making
+# syncoid's own (--no-sync-snap), recurse the tree, stay quiet for cron.
+syncoid_default_options: "--recursive --no-sync-snap --quiet"
+
+# Replication jobs (empty by default). Each pulls source -> local target:
+#   syncoid_jobs:
+#     - name: pve1-nas
+#       source: "root@pve1:rpool/data/nas"
+#       target: "tank/replica/pve1/nas"
+#     - name: pve1-splunk-hot
+#       source: "root@pve1:nvme1/siem/splunk-hot"
+#       target: "tank/replica/pve1/splunk-hot"
+syncoid_jobs: []

--- a/roles/syncoid/tasks/main.yml
+++ b/roles/syncoid/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+# syncoid role tasks — install, render the replication wrapper, schedule it.
+# Package install + cron are Docker-skipped; the wrapper still renders so
+# molecule can verify the generated commands.
+
+- name: Install sanoid (provides syncoid)
+  ansible.builtin.apt:
+    name: "{{ syncoid_package }}"
+    state: present
+    update_cache: true
+  when:
+    - syncoid_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - syncoid
+
+- name: Ensure syncoid log directory exists
+  ansible.builtin.file:
+    path: "{{ syncoid_log_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: syncoid_enabled
+  tags:
+    - syncoid
+
+- name: Deploy syncoid replication wrapper
+  ansible.builtin.template:
+    src: syncoid-replicate.sh.j2
+    dest: /usr/local/bin/syncoid-replicate.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when: syncoid_enabled
+  tags:
+    - syncoid
+
+- name: Schedule syncoid replication
+  ansible.builtin.cron:
+    name: "syncoid-replicate"
+    job: "/usr/local/bin/syncoid-replicate.sh"
+    hour: "{{ syncoid_cron_hour }}"
+    minute: "{{ syncoid_cron_minute }}"
+    user: "{{ syncoid_user }}"
+  when:
+    - syncoid_enabled
+    - syncoid_jobs | length > 0
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - syncoid

--- a/roles/syncoid/templates/syncoid-replicate.sh.j2
+++ b/roles/syncoid/templates/syncoid-replicate.sh.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+# syncoid replication — pull ZFS datasets to this (target) node.
+# Managed by Ansible — do not edit manually. One run per configured job; a
+# failed job (e.g. source offline) is logged and does NOT abort the rest.
+set -uo pipefail
+
+LOG_DIR="{{ syncoid_log_dir }}"
+mkdir -p "$LOG_DIR"
+log="$LOG_DIR/$(date +%Y-%m-%d).log"
+
+replicate() {
+  echo "=== $(date +%H:%M:%S) syncoid $* ===" >>"$log"
+  local rc=0
+  syncoid "$@" >>"$log" 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "  FAILED (rc=$rc)" >>"$log"
+  fi
+}
+
+{% for job in syncoid_jobs %}
+replicate {{ job.options | default(syncoid_default_options) }} {{ job.source }} {{ job.target }}
+{% endfor %}


### PR DESCRIPTION
## Summary

New `syncoid` role: cross-node ZFS replication — **layer 2** of the resiliency
model (survives losing a whole node/pool). Pairs with `sanoid` (it ships sanoid's
snapshots via `--no-sync-snap`).

## What

- **Pull model**: runs on the backup node (pve2), SSHes to each source (pve1) and
  pulls. Pull-from-backup is safer than push.
- **Failure isolation**: an offline source (e.g. the intermittent pve3) is logged
  to `/var/log/syncoid/` and does not abort the remaining jobs.
- Inert until `syncoid_jobs` is set; cron-scheduled. Wired into `site.yml`.

## Verification

- `ansible-lint` ✓ production profile (54 files).
- Rendered wrapper `shellcheck`-clean — notably captures syncoid's real exit code
  (`|| rc=$?`) instead of the `if`-condition's `$?` (SC2319).
- molecule `syncoid` asserts the wrapper renders the pull invocations + failure
  isolation (Docker unavailable locally; runs in CI).

## Scope / apply-time prerequisite

SSH trust from the backup node's `syncoid_user` to each source host (set up out of
band) — the role schedules replication, it does not distribute keys. pve3 targets
stay off until that node is commissioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)