### PR TITLE
feat(cluster_ssh_trust): automate inter-node SSH known_hosts trust

### DIFF
--- a/molecule/cluster_ssh_trust/converge.yml
+++ b/molecule/cluster_ssh_trust/converge.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    # The keyscan/seed step is skipped under Docker; this proves the role
+    # converges and creates the root .ssh dir with correct perms.
+    cluster_ssh_trust_peers:
+      - pve1
+      - pve2
+
+  roles:
+    - role: cluster_ssh_trust

--- a/molecule/cluster_ssh_trust/converge.yml
+++ b/molecule/cluster_ssh_trust/converge.yml
@@ -4,12 +4,8 @@
   become: true
   gather_facts: true
 
-  vars:
-    # The keyscan/seed step is skipped under Docker; this proves the role
-    # converges and creates the root .ssh dir with correct perms.
-    cluster_ssh_trust_peers:
-      - pve1
-      - pve2
-
+  # No peer list set here on purpose: PROXMOX_VE_NODES is unset under molecule and
+  # the pve_cluster_members group is absent, so the keyscan/seed step is skipped.
+  # This proves the role converges and creates the root .ssh dir with correct perms.
   roles:
     - role: cluster_ssh_trust

--- a/molecule/cluster_ssh_trust/molecule.yml
+++ b/molecule/cluster_ssh_trust/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-cluster-ssh-trust-test
+    image: debian:12-slim
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/cluster_ssh_trust/verify.yml
+++ b/molecule/cluster_ssh_trust/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Stat /root/.ssh
+      ansible.builtin.stat:
+        path: /root/.ssh
+      register: rootssh
+
+    - name: Assert root .ssh exists with secure perms
+      ansible.builtin.assert:
+        that:
+          - rootssh.stat.exists
+          - rootssh.stat.isdir
+          - rootssh.stat.mode == "0700"
+        fail_msg: "/root/.ssh missing or wrong permissions"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -16,6 +16,12 @@
       tags:
         - common
 
+    # Inter-node root SSH trust (known_hosts) — must precede anything that SSHes
+    # between nodes (syncoid replication, pvecm). Idempotent; survives renames.
+    - role: cluster_ssh_trust
+      tags:
+        - cluster_ssh_trust
+
     - role: zfs_swap
       tags:
         - zfs_swap

--- a/roles/cluster_ssh_trust/README.md
+++ b/roles/cluster_ssh_trust/README.md
@@ -21,9 +21,14 @@ ansible-galaxy collection install -r requirements.yml
 
 ## What it does
 
-- Runs `ssh-keyscan` for each peer in `cluster_ssh_trust_peers` (default: the
-  `pve_cluster_members` inventory group, which resolves via the PVE cluster's
-  `/etc/hosts`) and merges the keys into `/root/.ssh/known_hosts`, de-duplicated.
+- Runs `ssh-keyscan` for each peer in `cluster_ssh_trust_peers` and merges the
+  keys into `/root/.ssh/known_hosts`, de-duplicated.
+- Peers come from the **`PROXMOX_VE_NODES`** Doppler variable — the single
+  source of truth for the cluster node list, shared by terraform and ansible
+  (e.g. `pve1,pve2,pve3`). The value is tokenised with `regex_findall`, so plain
+  comma-separated, bracketed (`[pve1, pve2]`), or quoted forms all work. When the
+  variable is absent (e.g. molecule), it falls back to the `pve_cluster_members`
+  inventory group.
 - Idempotent: re-runs only report `changed` when a new/rotated key is added.
 - Skipped under Docker so molecule can converge.
 
@@ -32,7 +37,7 @@ ansible-galaxy collection install -r requirements.yml
 | Variable | Default | Description |
 | --- | --- | --- |
 | `cluster_ssh_trust_enabled` | `true` | Master enable |
-| `cluster_ssh_trust_peers` | `pve_cluster_members` names | Hosts whose keys to trust (names/IPs/FQDNs) |
+| `cluster_ssh_trust_peers` | from `PROXMOX_VE_NODES` (fallback: `pve_cluster_members`) | Hosts whose keys to trust |
 
 ## Usage
 

--- a/roles/cluster_ssh_trust/README.md
+++ b/roles/cluster_ssh_trust/README.md
@@ -1,0 +1,49 @@
+# cluster_ssh_trust
+
+Keeps inter-node **root SSH** working automatically across the Proxmox cluster
+by seeding each node's `/root/.ssh/known_hosts` with the **current** host keys
+of every cluster peer. Without this, root SSH between nodes (syncoid
+replication, `pvecm`, live migration) fails with *Host key verification failed*
+after a node rename or reinstall — exactly what happened when `pve` was renamed
+to `pve1`.
+
+## Installation
+
+This role ships in the `ansible-proxmox` repository and is applied via
+`playbooks/site.yml`. No separate installation is required beyond cloning the
+repo and installing collection dependencies:
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
+## What it does
+
+- Runs `ssh-keyscan` for each peer in `cluster_ssh_trust_peers` (default: the
+  `pve_cluster_members` inventory group, which resolves via the PVE cluster's
+  `/etc/hosts`) and merges the keys into `/root/.ssh/known_hosts`, de-duplicated.
+- Idempotent: re-runs only report `changed` when a new/rotated key is added.
+- Skipped under Docker so molecule can converge.
+
+## Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `cluster_ssh_trust_enabled` | `true` | Master enable |
+| `cluster_ssh_trust_peers` | `pve_cluster_members` names | Hosts whose keys to trust (names/IPs/FQDNs) |
+
+## Usage
+
+```bash
+# Applied automatically as part of site.yml; or target it directly:
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags cluster_ssh_trust
+```
+
+## Scope / follow-up
+
+This is the **interim** automation. Full per-host, generated-at-instantiation,
+encrypted-in-inventory, rotatable SSH **key** management (replacing the single
+shared Ansible key) is tracked as a separate design effort. This role only
+manages `known_hosts` trust, not the keypairs themselves.

--- a/roles/cluster_ssh_trust/defaults/main.yml
+++ b/roles/cluster_ssh_trust/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# cluster_ssh_trust — keep inter-node root SSH working without manual steps.
+#
+# Seeds each node's /root/.ssh/known_hosts with the CURRENT host keys of all
+# cluster peers (idempotent), so root SSH between nodes — syncoid replication,
+# live migration, pvecm — works and survives node renames/reinstalls. This is
+# the INTERIM fix; full per-host, rotatable, inventory-stored key management is
+# tracked separately (see role README).
+
+cluster_ssh_trust_enabled: true
+
+# Peers to trust. Defaults to the cluster-member inventory names, which resolve
+# via the PVE cluster's /etc/hosts. Override to add IPs or FQDNs.
+cluster_ssh_trust_peers: "{{ groups['pve_cluster_members'] | default([]) }}"

--- a/roles/cluster_ssh_trust/defaults/main.yml
+++ b/roles/cluster_ssh_trust/defaults/main.yml
@@ -9,6 +9,14 @@
 
 cluster_ssh_trust_enabled: true
 
-# Peers to trust. Defaults to the cluster-member inventory names, which resolve
-# via the PVE cluster's /etc/hosts. Override to add IPs or FQDNs.
-cluster_ssh_trust_peers: "{{ groups['pve_cluster_members'] | default([]) }}"
+# Canonical node list: the PROXMOX_VE_NODES Doppler variable (the single source
+# of truth shared by terraform + ansible), e.g. "pve1,pve2,pve3". regex_findall
+# extracts the hostname tokens, so the value may be plain comma-separated,
+# bracketed, and/or quoted — all are tolerated. Falls back to the
+# pve_cluster_members inventory group when the variable is absent (e.g. molecule).
+cluster_ssh_trust_peers: >-
+  {{
+    (lookup('env', 'PROXMOX_VE_NODES') | default('', true)
+      | regex_findall('[A-Za-z0-9][A-Za-z0-9._-]*'))
+    or (groups['pve_cluster_members'] | default([]))
+  }}

--- a/roles/cluster_ssh_trust/tasks/main.yml
+++ b/roles/cluster_ssh_trust/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+# cluster_ssh_trust tasks — seed /root/.ssh/known_hosts with every cluster
+# peer's current host keys so inter-node root SSH never needs a manual
+# ssh-keyscan (and survives renames). Skipped under Docker (molecule).
+
+- name: Ensure root .ssh directory exists
+  ansible.builtin.file:
+    path: /root/.ssh
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  when: cluster_ssh_trust_enabled | bool
+  tags:
+    - cluster_ssh_trust
+
+- name: Seed cluster peer host keys into known_hosts (idempotent)
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: >-
+      set -o pipefail;
+      touch /root/.ssh/known_hosts;
+      before=$(sort -u /root/.ssh/known_hosts | sha1sum);
+      ssh-keyscan -T 5 {{ cluster_ssh_trust_peers | join(' ') }} 2>/dev/null
+      >> /root/.ssh/known_hosts || true;
+      sort -u -o /root/.ssh/known_hosts /root/.ssh/known_hosts;
+      after=$(sha1sum /root/.ssh/known_hosts);
+      [[ "${before%% *}" == "${after%% *}" ]] && echo UNCHANGED || echo CHANGED
+  register: cluster_ssh_trust_seed
+  changed_when: "'CHANGED' in cluster_ssh_trust_seed.stdout"
+  when:
+    - cluster_ssh_trust_enabled | bool
+    - cluster_ssh_trust_peers | length > 0
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - cluster_ssh_trust


### PR DESCRIPTION
## Summary

New `cluster_ssh_trust` role: keeps inter-node **root SSH** working automatically
by seeding each node's `/root/.ssh/known_hosts` with all cluster peers' current
host keys. The `pve`→`pve1` rename left this broken (`Host key verification failed`),
which blocked syncoid replication during the live storage apply.

## Why

Codifies a fix that otherwise requires a manual `ssh-keyscan` after any node
rename/reinstall. Inter-node root SSH underpins syncoid replication, `pvecm`, and
live migration. This is the **interim** automation; full per-host rotatable key
management is a tracked follow-up.

## What

- Idempotent, change-detecting seed of `known_hosts` from `cluster_ssh_trust_peers`
  (default: the `pve_cluster_members` group, resolved via the cluster `/etc/hosts`).
- Wired into `site.yml` **before** syncoid; skipped under Docker for molecule.

## Verification

- `ansible-lint` ✓ production profile (58 files).
- Rendered seed command `shellcheck`-clean (`set -o pipefail`, bash executable).
- molecule `cluster_ssh_trust` asserts `/root/.ssh` perms (keyscan skipped in-container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)