### PR TITLE
fix(cluster_ssh_trust): correct non-idempotent changed_when

### DIFF
--- a/roles/cluster_ssh_trust/tasks/main.yml
+++ b/roles/cluster_ssh_trust/tasks/main.yml
@@ -27,7 +27,10 @@
       after=$(sha1sum /root/.ssh/known_hosts);
       [[ "${before%% *}" == "${after%% *}" ]] && echo UNCHANGED || echo CHANGED
   register: cluster_ssh_trust_seed
-  changed_when: "'CHANGED' in cluster_ssh_trust_seed.stdout"
+  # Exact match, NOT `'CHANGED' in stdout`: "CHANGED" is a substring of
+  # "UNCHANGED", so the `in` test reported changed on every run (the seed step
+  # is otherwise idempotent). stdout is exactly one token, so == is safe.
+  changed_when: cluster_ssh_trust_seed.stdout == "CHANGED"
   when:
     - cluster_ssh_trust_enabled | bool
     - cluster_ssh_trust_peers | length > 0


### PR DESCRIPTION
## Problem

`cluster_ssh_trust` reported `changed` on **every** run, even when `/root/.ssh/known_hosts` was untouched — the exact non-idempotency this role exists to prevent.

## Root cause

The seed task echoes `CHANGED` or `UNCHANGED`, but the test was:

```yaml
changed_when: "'CHANGED' in cluster_ssh_trust_seed.stdout"
```

`"CHANGED"` is a substring of `"UNCHANGED"`, so the `in` test matched both outcomes.

## Verification (live, pve1/pve2)

- The seed logic itself is idempotent: a fresh `ssh-keyscan` of all peers produced **0 new lines** vs. the stored set (`NEW=0`), and replaying the exact `>> append + sort -u` sequence on a copy yielded an **identical sha1** (`B == A`, empty diff). So the script correctly emits `UNCHANGED`.
- Despite that, three consecutive role runs all reported `changed=1` — consistent with the substring bug.

## Fix

Exact equality (`stdout` is exactly one token):

```yaml
changed_when: cluster_ssh_trust_seed.stdout == "CHANGED"
```

ansible-lint (production profile) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)