### PR TITLE
feat(replication): codify Splunk VM 200 sanoid+syncoid protection

### DIFF
--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -1,14 +1,18 @@
 ---
-# Host vars for pve1 (primary, always-on).
+# Host vars for pve1 (primary, always-on — currently the Splunk node).
 #
 # Layer-1 protection (local ZFS snapshots via sanoid) for the Splunk all-in-one
-# VM (vmid 200), whose disks live on rpool/data. These snapshots are also the
-# source syncoid pulls to pve2 (see host_vars/pve2.yml). Scoped to Splunk for
-# now; broadening sanoid to the rest of rpool/data (nas, media) is a follow-up.
+# VM disks, so the snapshots exist for syncoid to pull (and as a rollback
+# point). vm-<id>-disk-<n> is Proxmox's default zvol naming, kept as-is. The
+# empty leftover disk-1 was removed; we snapshot the OS disk (0) and
+# /opt/splunk config+indexes (2). Whole-disk for now; the critical/volatile
+# SSD split is a tracked follow-up.
+#
+# NOTE (generalization, follow-up): this assumes Splunk runs on pve1. When the
+# layout is generalized (data-driven from splunk_vm_from_tofu across nodes),
+# this moves out of a per-host file. See docs design + follow-up issue.
 sanoid_datasets:
   "rpool/data/vm-200-disk-0":
-    use_template: critical
-  "rpool/data/vm-200-disk-1":
     use_template: critical
   "rpool/data/vm-200-disk-2":
     use_template: critical

--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -1,0 +1,14 @@
+---
+# Host vars for pve1 (primary, always-on).
+#
+# Layer-1 protection (local ZFS snapshots via sanoid) for the Splunk all-in-one
+# VM (vmid 200), whose disks live on rpool/data. These snapshots are also the
+# source syncoid pulls to pve2 (see host_vars/pve2.yml). Scoped to Splunk for
+# now; broadening sanoid to the rest of rpool/data (nas, media) is a follow-up.
+sanoid_datasets:
+  "rpool/data/vm-200-disk-0":
+    use_template: critical
+  "rpool/data/vm-200-disk-1":
+    use_template: critical
+  "rpool/data/vm-200-disk-2":
+    use_template: critical

--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -2,19 +2,26 @@
 # Host vars for pve2 (secondary, always-on — the backup/replica target).
 #
 # Layer-2 protection (cross-node ZFS replication via syncoid, PULL model): pve2
-# pulls the Splunk VM (vmid 200) disk snapshots from pve1 into hdd2/replica/pve1.
-# The hdd2/replica/pve1 parent dataset is created by zfs_pools from the
-# terraform-proxmox node_storage declaration; syncoid creates the per-disk leaf
-# datasets under it. Prereqs (both verified): root SSH pve2->pve1 works (PVE
-# cluster keys + cluster_ssh_trust known_hosts), and each source disk has at
-# least one snapshot for --no-sync-snap to replicate.
+# pulls the Splunk VM disk snapshots from its source node into
+# hdd2/replica/<node>. The source NODE NAME is derived from tofu
+# (splunk_vm_from_tofu, injected by load_tofu) — never hard-coded — so this
+# follows the VM if it is ever defined on a different node. The vmid and the
+# vm-<id>-disk-<n> leaves use Proxmox's default naming (kept as-is); hdd2 is
+# pve2's own local pool. The hdd2/replica/<node> parent is created by zfs_pools
+# from the terraform-proxmox node_storage declaration; syncoid creates the
+# per-disk leaves.
+#
+# Prereqs (verified live): root SSH pve2->source works (PVE cluster keys +
+# cluster_ssh_trust known_hosts); each source disk has a snapshot for
+# --no-sync-snap (sanoid on the source provides ongoing ones).
+#
+# disk-1 was an empty leftover (removed); replicate the OS disk (0) and
+# /opt/splunk config+indexes (2). Whole-disk for now; excluding the volatile
+# index tier is the tracked critical/volatile follow-up.
 syncoid_jobs:
-  - name: pve1-splunk-disk0
-    source: "root@pve1:rpool/data/vm-200-disk-0"
-    target: "hdd2/replica/pve1/vm-200-disk-0"
-  - name: pve1-splunk-disk1
-    source: "root@pve1:rpool/data/vm-200-disk-1"
-    target: "hdd2/replica/pve1/vm-200-disk-1"
-  - name: pve1-splunk-disk2
-    source: "root@pve1:rpool/data/vm-200-disk-2"
-    target: "hdd2/replica/pve1/vm-200-disk-2"
+  - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk0"
+    source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
+    target: "hdd2/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
+  - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk2"
+    source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
+    target: "hdd2/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"

--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -1,0 +1,20 @@
+---
+# Host vars for pve2 (secondary, always-on — the backup/replica target).
+#
+# Layer-2 protection (cross-node ZFS replication via syncoid, PULL model): pve2
+# pulls the Splunk VM (vmid 200) disk snapshots from pve1 into hdd2/replica/pve1.
+# The hdd2/replica/pve1 parent dataset is created by zfs_pools from the
+# terraform-proxmox node_storage declaration; syncoid creates the per-disk leaf
+# datasets under it. Prereqs (both verified): root SSH pve2->pve1 works (PVE
+# cluster keys + cluster_ssh_trust known_hosts), and each source disk has at
+# least one snapshot for --no-sync-snap to replicate.
+syncoid_jobs:
+  - name: pve1-splunk-disk0
+    source: "root@pve1:rpool/data/vm-200-disk-0"
+    target: "hdd2/replica/pve1/vm-200-disk-0"
+  - name: pve1-splunk-disk1
+    source: "root@pve1:rpool/data/vm-200-disk-1"
+    target: "hdd2/replica/pve1/vm-200-disk-1"
+  - name: pve1-splunk-disk2
+    source: "root@pve1:rpool/data/vm-200-disk-2"
+    target: "hdd2/replica/pve1/vm-200-disk-2"

--- a/playbooks/load_tofu.yml
+++ b/playbooks/load_tofu.yml
@@ -117,3 +117,12 @@
             )
           }}
       loop: "{{ groups['proxmox'] | default([]) }}"
+
+    # Splunk VM identity (node + vmid) for the sanoid/syncoid replication config.
+    # Lets host_vars derive the source node + vmid from tofu instead of
+    # hard-coding node names (keyed by splunk instance, currently "splunk").
+    - name: Inject OpenTofu Splunk VM identity onto proxmox hosts
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        splunk_vm_from_tofu: "{{ tofu_data.splunk_vm | default({}) }}"
+      loop: "{{ groups['proxmox'] | default([]) }}"


### PR DESCRIPTION
## What

Codifies off-node protection for the live, previously-unprotected Splunk all-in-one VM (vmid 200) as committed config — closing the loop the earlier manual `/tmp` one-off failed to (sanoid/syncoid were never installed on pve2).

- `playbooks/load_tofu.yml` — inject `splunk_vm_from_tofu` (node + vmid) so config derives the node, never hard-codes it.
- `host_vars/pve1.yml` — **sanoid** (layer 1): local snapshots of `vm-200-disk-0` (OS) + `vm-200-disk-2` (/opt/splunk config+indexes), `critical` tier.
- `host_vars/pve2.yml` — **syncoid** (layer 2): pull-replicate those disks → `hdd2/replica/<node>/*`, source node derived from `splunk_vm_from_tofu`.

## Design decisions (with @maintainer)

- **Whole-disk replication now, critical/volatile split later.** Config + indexes are co-mingled on one /opt/splunk disk (verified inside the VM), so a clean split needs Splunk-level `indexes.conf` work — tracked as a follow-up (SSD index tier + config-only backup).
- **Keep Proxmox default `vm-<id>-disk-<n>` zvol names** (per Proxmox docs); semantic tiering comes from the dataset, not custom names.
- **No hard-coded node names** — derived from tofu `splunk_vm`.
- **disk-1 (empty leftover) removed** from the VM.

## Prereqs satisfied

`tank`→`hdd2` applied; `hdd2/replica/<node>` created by zfs_pools (needs #245); root SSH pve2→pve1 verified; source disks have snapshots.

ansible-lint (production) + yamllint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)