### PR TITLE
fix(zfs_pools): handle datasets with no quota (null)

### DIFF
--- a/roles/zfs_pools/tasks/datasets.yml
+++ b/roles/zfs_pools/tasks/datasets.yml
@@ -48,7 +48,10 @@
     label: "{{ zfs_pool.key }}/{{ item.key }}={{ item.value.quota | default('none') }}"
     index_var: zfs_pools_ds_idx
   when:
-    - item.value.quota | default('') | length > 0
+    # default('', true) coerces a null/absent quota (e.g. replica or scratch
+    # datasets) to '' so `length` doesn't choke on None; the second filter is
+    # only reached for datasets that actually declare a quota.
+    - item.value.quota | default('', true) | length > 0
     - zfs_pools_ds_quota.results[zfs_pools_ds_idx].stdout | int != item.value.quota | human_to_bytes
   changed_when: true
   tags:


### PR DESCRIPTION
## Problem

Running `zfs_pools` on pve2 to register `hdd2` + create `hdd2/replica/pve1` failed:

```
The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()
  datasets.yml:51  - item.value.quota | default('') | length > 0
```

`replica/pve1` declares no quota, so `item.value.quota` is `null` (None). The `default('')` filter only substitutes for **undefined**, not `None`, so `None | length` crashes.

## Impact

Any quota-less dataset hits this — including pve3's `scratch: {}` once commissioned. The dataset was *created* (`zfs create -p` runs first), but the play aborted before the `pvesm` registration step.

## Fix

`default('', true)` — the `true` second arg makes the filter also replace falsy/None. The downstream `human_to_bytes` comparison is only reached for datasets that actually declare a quota (short-circuit `and`).

ansible-lint (production) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)