### PR TITLE
feat(syncoid): replicate Splunk VM disks to pve3 hdd3 (DR leg)

### DIFF
--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -6,3 +6,27 @@
 # node_auto_poweroff role installs a local systemd timer that gracefully powers
 # pve3 off on a schedule; the time (default 22:00) lives in the role defaults.
 node_auto_poweroff_enabled: true
+
+# Layer-2 protection (cross-node ZFS replication via syncoid, PULL model): pve3
+# is the second (offline-DR) replica target. It pulls the Splunk VM disk
+# snapshots from its source node into hdd3/replica/<node> — the same jobs pve2
+# runs into hdd2/replica/<node>, so both always-on (pve2) and offline-DR (pve3)
+# legs hold an independent copy. The source NODE NAME is derived from tofu
+# (splunk_vm_from_tofu, injected by load_tofu) — never hard-coded — so this
+# follows the VM if it is ever defined on a different node. hdd3 is pve3's own
+# local raidz2 pool; the hdd3/replica/<node> parent is created by zfs_pools from
+# the terraform-proxmox node_storage declaration, and syncoid creates the
+# per-disk leaves.
+#
+# Prereqs (verified live): root SSH pve3->source works (PVE cluster keys +
+# cluster_ssh_trust known_hosts); each source disk has a sanoid snapshot for
+# --no-sync-snap. Replicate the OS disk (0) and /opt/splunk config+indexes (2);
+# disk-1 was an empty leftover. Whole-disk for now; excluding the volatile index
+# tier is the tracked critical/volatile follow-up.
+syncoid_jobs:
+  - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk0"
+    source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
+    target: "hdd3/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
+  - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk2"
+    source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
+    target: "hdd3/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"


### PR DESCRIPTION
# Replicate Splunk VM disks to pve3 hdd3 (DR leg)

## What

Add `syncoid_jobs` to `inventory/host_vars/pve3.yml` so pve3 (the normally-off
R710 DR leg) pulls the Splunk VM disks from pve1 into its `hdd3/replica/pve1`
dataset — the same PULL replication pve2 runs into `hdd2/replica/pve1`.

```yaml
syncoid_jobs:
  - splunk-200-disk0: root@pve1:rpool/data/vm-200-disk-0 -> hdd3/replica/pve1/vm-200-disk-0
  - splunk-200-disk2: root@pve1:rpool/data/vm-200-disk-2 -> hdd3/replica/pve1/vm-200-disk-2
```

## Why

Completes commissioning pve3 as the second (offline) replica of the SIEM data —
**layer 2** of the 4-layer ZFS resiliency model (RAID -> sanoid snapshots ->
syncoid replication -> pve3 offline). Splunk data now has two independent
cross-node copies: the always-on pve2 (`hdd2`) and the offline-DR pve3 (`hdd3`).
Source node/vmid are derived from tofu (`splunk_vm_from_tofu`), never hard-coded,
so the jobs follow the VM if it ever moves.

## Context

The `hdd3` raidz2 pool (5x 1TB, ~2.6 TB usable) was commissioned on pve3 out of
band (zpool create + datasets + `pvesm` registration via the `zfs_pools` role;
device list is host-specific and not committed). This PR is the small, committable
slice: the replication job declaration.

## Verification

- `syncoid_jobs` resolve via tofu to `pve1` / vmid `200` / `hdd3/replica/pve1`.
- Root SSH pve3 -> pve1 confirmed; `cluster_ssh_trust` + `syncoid` roles applied.
- Initial ~65 GB seed (disk-0 13.7G + disk-2 51.8G) replicated into
  `hdd3/replica/pve1`; cron (`17 2 * * *`) + `node_auto_poweroff` timer in place.

`inventory/tofu_inventory.json` is gitignored (per-worktree runtime file) and is
not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
