### PR TITLE
feat(zfs): rename node pools to tier-named bulk/fast (node-agnostic)

### DIFF
--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -3,11 +3,11 @@
 #
 # Layer-2 protection (cross-node ZFS replication via syncoid, PULL model): pve2
 # pulls the Splunk VM disk snapshots from its source node into
-# hdd2/replica/<node>. The source NODE NAME is derived from tofu
+# bulk/replica/<node>. The source NODE NAME is derived from tofu
 # (splunk_vm_from_tofu, injected by load_tofu) — never hard-coded — so this
 # follows the VM if it is ever defined on a different node. The vmid and the
-# vm-<id>-disk-<n> leaves use Proxmox's default naming (kept as-is); hdd2 is
-# pve2's own local pool. The hdd2/replica/<node> parent is created by zfs_pools
+# vm-<id>-disk-<n> leaves use Proxmox's default naming (kept as-is); bulk is
+# pve2's own local pool. The bulk/replica/<node> parent is created by zfs_pools
 # from the terraform-proxmox node_storage declaration; syncoid creates the
 # per-disk leaves.
 #
@@ -21,7 +21,7 @@
 syncoid_jobs:
   - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk0"
     source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
-    target: "hdd2/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
+    target: "bulk/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
   - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk2"
     source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
-    target: "hdd2/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
+    target: "bulk/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"

--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -9,12 +9,12 @@ node_auto_poweroff_enabled: true
 
 # Layer-2 protection (cross-node ZFS replication via syncoid, PULL model): pve3
 # is the second (offline-DR) replica target. It pulls the Splunk VM disk
-# snapshots from its source node into hdd3/replica/<node> — the same jobs pve2
-# runs into hdd2/replica/<node>, so both always-on (pve2) and offline-DR (pve3)
+# snapshots from its source node into bulk/replica/<node> — the same jobs pve2
+# runs into bulk/replica/<node>, so both always-on (pve2) and offline-DR (pve3)
 # legs hold an independent copy. The source NODE NAME is derived from tofu
 # (splunk_vm_from_tofu, injected by load_tofu) — never hard-coded — so this
-# follows the VM if it is ever defined on a different node. hdd3 is pve3's own
-# local raidz2 pool; the hdd3/replica/<node> parent is created by zfs_pools from
+# follows the VM if it is ever defined on a different node. bulk is pve3's own
+# local raidz2 pool; the bulk/replica/<node> parent is created by zfs_pools from
 # the terraform-proxmox node_storage declaration, and syncoid creates the
 # per-disk leaves.
 #
@@ -26,7 +26,7 @@ node_auto_poweroff_enabled: true
 syncoid_jobs:
   - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk0"
     source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
-    target: "hdd3/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
+    target: "bulk/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-0"
   - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk2"
     source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
-    target: "hdd3/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
+    target: "bulk/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -20,19 +20,17 @@ all:
           ansible_user: "{{ lookup('env', 'PROXMOX_VM_SSH_USERNAME') }}"
           ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') | default(omit, true) }}"
           proxmox_node_name: pve3
-          # tofu `nodes.pve3.commissioned = false` (bad drive) — excluded
-          # from STORAGE registration (zfs_pools keys off this flag + tofu
-          # node_storage, so bulk-pool is never created here) until commissioned.
-          # Corosync membership is decoupled from storage: pve3 IS a cluster
-          # member below while its storage stays uncommissioned (joined the
-          # 3-node homelab-cluster 2026-05-31).
-          pve_node_commissioned: false
+          # pve3 commissioned 2026-06-07: `bulk` (raidz2) created + registered,
+          # Splunk DR replicas seeded. zfs_pools manages its datasets from tofu
+          # node_storage. Corosync membership is decoupled from storage: pve3
+          # joined the 3-node homelab-cluster 2026-05-31.
+          pve_node_commissioned: true
       children:
         # Nodes eligible to form/join the cluster. Corosync membership is
-        # decoupled from storage commissioning: pve3 is a member (joined the
-        # 3-node homelab-cluster 2026-05-31) even though its `bulk-pool` is
-        # still uncommissioned — zfs_pools gates pool creation on
-        # pve_node_commissioned + tofu node_storage, not on this group.
+        # decoupled from storage commissioning: pve3 joined the 3-node
+        # homelab-cluster 2026-05-31 with its `bulk` pool commissioned —
+        # zfs_pools gates pool creation on pve_node_commissioned + tofu
+        # node_storage, not on this group.
         pve_cluster_members:
           hosts:
             pve1: {}

--- a/playbooks/cluster.yml
+++ b/playbooks/cluster.yml
@@ -4,7 +4,7 @@
 # Two ordered plays guarantee the primary creates the cluster BEFORE any
 # secondary tries to join. Both target the `pve_cluster_members` group only.
 # Cluster membership is decoupled from storage commissioning: pve3 is a member
-# while its `bulk-pool` stays uncommissioned (storage is gated separately by
+# with its `bulk` pool commissioned (storage is gated separately by
 # `pve_node_commissioned` in the zfs_pools role).
 #
 # The role is inert unless enabled, so formation is an explicit, deliberate run:

--- a/roles/pve_cluster/README.md
+++ b/roles/pve_cluster/README.md
@@ -65,11 +65,11 @@ or a SOPS-encrypted var.
 ## Usage
 
 The cluster is formed by `playbooks/cluster.yml`, which targets the primary
-first (creates) then secondaries (join). `pve3` is a cluster member even though
-its tofu `commissioned` flag is `false` (bad drive): corosync membership is
-decoupled from storage commissioning, so `pve3` joins the cluster while its
-`bulk-pool` stays uncommissioned (`zfs_pools` gates pool creation on
-`pve_node_commissioned`, not on cluster-group membership).
+first (creates) then secondaries (join). `pve3` is a cluster member with its
+tofu `commissioned` flag `true`: corosync membership is decoupled from storage
+commissioning, so `pve3` joined the cluster and its `bulk` pool is commissioned
+(`zfs_pools` gates pool creation on `pve_node_commissioned`, not on
+cluster-group membership).
 
 ```bash
 # Form the cluster (enable + allow-list supplied at run time, fingerprint via -e)


### PR DESCRIPTION
## Summary

Standardize ZFS pool naming across the cluster so any node can act as a stand-in for another (Phase 1 of the media/storage program).

| Node | Before | After |
| --- | --- | --- |
| pve1 | `ssd-pool` | `fast` |
| pve2 | `hdd2` (raidz1) | `bulk` |
| pve3 | `hdd3` (raidz2) | `bulk` |

`rpool` (boot) is untouched everywhere.

## What ran live (verified)

- `zpool export <old> && zpool import <old> <new>` per node — all data rode across intact (Splunk DR replicas preserved).
- `/etc/pve/storage.cfg` reconciled to a unified `bulk` (`-nodes pve2,pve3`) + `fast` (`-nodes pve1`); old `ssd-pool`/`hdd2`/`hdd3` IDs removed.
- syncoid wrappers redeployed with `bulk` targets; a **live pve2 replication run completed exit 0** into `bulk/replica/pve1/vm-200-disk-{0,2}`.
- `zfs_pools` reconcile idempotent, 0 failures.

## This diff (tracked)

- `host_vars/pve2.yml` + `pve3.yml`: syncoid replication targets `hdd2`/`hdd3` → `bulk`.
- `hosts.yml`: mark pve3 commissioned (`bulk` raidz2 created + DR replicas seeded).
- Comment refreshes in `cluster.yml` + `pve_cluster/README.md` (`bulk-pool` → `bulk`).

Resolves the pve2 tank/hdd2 naming drift. The `node_storage` source of truth (terraform-proxmox `deployment.json`, gitignored) was updated in lockstep; a reviewed `terragrunt apply` regenerates the canonical `tofu_inventory.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)