### PR TITLE
feat(ci): converge media features on download-vpn rebuild dispatch

### DIFF
--- a/.github/workflows/converge-media-features.yml
+++ b/.github/workflows/converge-media-features.yml
@@ -1,0 +1,68 @@
+# Converge media LXC features — hop 2 of the download-vpn rebuild chain (#368).
+#
+# After terraform-proxmox recreates the bare download-vpn shell it fires a
+# repository_dispatch (event_type: rebuild-download-vpn) at this repo. The
+# media_lxc_features role re-applies the host bind-mounts, /dev/net/tun, and
+# keyctl over root@pam (the BPG API token cannot) — REQUIRED before the app
+# converge, since WireGuard cannot start without /dev/net/tun. On success this
+# dispatches the final hop at ansible-proxmox-apps.
+#
+# Requires a self-hosted runner ([self-hosted, Linux]) with Nix and the Doppler
+# token (project iac-conf-mgmt, config prd — provides the root@pam SSH key) in
+# its environment, plus the synced tofu_inventory.json (load_tofu.yml). See
+# dryvist/terraform-proxmox docs/REBUILD.md for the full prerequisites.
+name: Converge media LXC features
+
+"on":
+  repository_dispatch:
+    types: [rebuild-download-vpn]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: converge-media-features
+  cancel-in-progress: false
+
+jobs:
+  converge:
+    name: Apply media_lxc_features (root@pam)
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # run-ansible.sh loads the Doppler-provided SSH key into ssh-agent (never to
+      # disk) and runs the play; the media_lxc_features tag scopes it to the
+      # root@pam-only container features (mounts, /dev/net/tun, keyctl).
+      - name: Apply media LXC features
+        run: >-
+          nix develop --command
+          doppler run -p iac-conf-mgmt -c prd --
+          ./scripts/run-ansible.sh playbooks/site.yml --tags media_lxc_features
+
+  dispatch:
+    name: Dispatch the download_vpn converge
+    needs: converge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: dryvist
+          repositories: ansible-proxmox-apps
+          permission-contents: write
+
+      - name: repository_dispatch -> ansible-proxmox-apps (download_vpn)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: >-
+          gh api repos/dryvist/ansible-proxmox-apps/dispatches
+          -f event_type=rebuild-download-vpn

--- a/.github/workflows/converge-media-features.yml
+++ b/.github/workflows/converge-media-features.yml
@@ -3,14 +3,16 @@
 # After terraform-proxmox recreates the bare download-vpn shell it fires a
 # repository_dispatch (event_type: rebuild-download-vpn) at this repo. The
 # media_lxc_features role re-applies the host bind-mounts, /dev/net/tun, and
-# keyctl over root@pam (the BPG API token cannot) — REQUIRED before the app
-# converge, since WireGuard cannot start without /dev/net/tun. On success this
-# dispatches the final hop at ansible-proxmox-apps.
+# keyctl over the privileged Proxmox SSH user (the BPG API token cannot) —
+# REQUIRED before the app converge, since WireGuard cannot start without
+# /dev/net/tun. On success this dispatches the final hop at ansible-proxmox-apps.
 #
-# Requires a self-hosted runner ([self-hosted, Linux]) with Nix and the Doppler
-# token (project iac-conf-mgmt, config prd — provides the root@pam SSH key) in
-# its environment, plus the synced tofu_inventory.json (load_tofu.yml). See
-# dryvist/terraform-proxmox docs/REBUILD.md for the full prerequisites.
+# Requires a self-hosted runner ([self-hosted, Linux]) with Nix and a Doppler
+# service token (repo/org secret DOPPLER_TOKEN). The token is config-scoped, so
+# it alone resolves the Proxmox SSH key + API credentials — the project/config
+# names are derived from it and never appear in this file. Also requires the
+# synced tofu_inventory.json (load_tofu.yml). See dryvist/terraform-proxmox
+# docs/REBUILD.md for the full prerequisites.
 name: Converge media LXC features
 
 "on":
@@ -27,20 +29,28 @@ concurrency:
 
 jobs:
   converge:
-    name: Apply media_lxc_features (root@pam)
+    name: Apply media LXC features
     runs-on: [self-hosted, Linux]
     timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # run-ansible.sh loads the Doppler-provided SSH key into ssh-agent (never to
-      # disk) and runs the play; the media_lxc_features tag scopes it to the
-      # root@pam-only container features (mounts, /dev/net/tun, keyctl).
+      # Service token is config-scoped, so project/config are derived from it and
+      # never appear here. inject-env-vars exposes the Proxmox SSH key + API
+      # credentials to the following step's environment.
+      - name: Fetch Doppler secrets
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
+        with:
+          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          inject-env-vars: true
+
+      # run-ansible.sh loads the SSH key into ssh-agent (never to disk) and runs
+      # the play; the media_lxc_features tag scopes it to the privileged-user-only
+      # container features (mounts, /dev/net/tun, keyctl).
       - name: Apply media LXC features
         run: >-
           nix develop --command
-          doppler run -p iac-conf-mgmt -c prd --
           ./scripts/run-ansible.sh playbooks/site.yml --tags media_lxc_features
 
   dispatch:


### PR DESCRIPTION
## What

Hop 2 of the `download-vpn` rebuild dispatch chain (`dryvist/ansible-proxmox-apps#368`). Adds `.github/workflows/converge-media-features.yml`.

## Why

When terraform-proxmox recreates the `download-vpn` LXC shell, the host-only container features (bind-mounts of `/rpool/data/{downloads,media}`, `/dev/net/tun`, keyctl) are gone — the BPG API token can't set them, so the `media_lxc_features` role applies them over root@pam. **WireGuard cannot start without `/dev/net/tun`**, so this must run before the app converge.

## How

- `on: repository_dispatch [rebuild-download-vpn]` (fired by terraform-proxmox) + `workflow_dispatch` (standalone), `runs-on: [self-hosted, Linux]`.
- `converge` job: `doppler run -p iac-conf-mgmt -c prd -- ./scripts/run-ansible.sh playbooks/site.yml --tags media_lxc_features` inside the repo's Nix devshell (the wrapper loads the Doppler SSH key into ssh-agent only).
- `dispatch` job: mints a scoped token with `actions/create-github-app-token` and fires `repository_dispatch` at `ansible-proxmox-apps` — same idiom as `dryvist/.github`'s `_dispatch-flake-consumers.yml`.

## Verification

- `actionlint` clean (one false positive on `create-github-app-token` `client-id`, matching the org's existing `_dispatch-flake-consumers.yml`).
- `zizmor` (shared `dryvist/.github/zizmor.yml`): 0 high/medium; one low `artipacked` matching existing org `checkout@v6` usage.
- **Dormant until the operator provisions the self-hosted runner + Doppler env.** Live converge is destructive/homelab-only — not verifiable in CI.