### PR TITLE
feat(databases): generic ZFS database namespace + SQLite warm standby

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,12 @@ Configure the Proxmox VE host itself (not applications).
 - Proxmox monitoring (healthchecks)
 - Crash diagnostics
 - Common system packages
+- ZFS dataset realization, quotas, and NFS exports (`zfs_pools`), including the
+  generic engine-/tier-agnostic `<pool>/databases` namespace (datasets declared
+  in `terraform-proxmox` `node_storage`; convention in `roles/zfs_pools/README.md`)
+- Local snapshots + cross-node replication (`sanoid` / `syncoid`)
+- SQLite warm-standby archival (`sqlite_standby`) — one consumer of the
+  databases namespace
 
 ## Pipeline Role
 

--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -25,3 +25,27 @@ syncoid_jobs:
   - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk2"
     source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
     target: "bulk/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
+
+# Layer-1 protection (local ZFS snapshots via sanoid) for the warm-standby
+# database namespace. Recursive so any bulk/databases/<instance> child inherits
+# the daily-cadence, long-history `database` retention template. These snapshots
+# are what preserve pre-prune history (even though the live source is pruned)
+# and what syncoid ships to pve3. The bulk/databases parent is created by
+# zfs_pools from the terraform-proxmox node_storage declaration — apply that
+# first (see the zfs_pools README "Database storage namespace").
+sanoid_datasets:
+  "bulk/databases":
+    use_template: database
+    recursive: "yes"
+
+# Insert-only SQLite warm-standby jobs (sqlite_standby role). The storage is
+# engine-agnostic and generic; the per-database specifics (source host/path,
+# tables) are environment-specific, so they are populated per deployment rather
+# than committed. Uncomment and fill in to activate:
+# sqlite_standby_jobs:
+#   - name: "events-archive"
+#     source_host: "root@10.0.x.y"
+#     source_path: "/var/lib/app/live.db"
+#     archive_path: "/bulk/databases/events/archive.db"
+#     tables:
+#       - { name: "events", key: "id" }

--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -30,3 +30,11 @@ syncoid_jobs:
   - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk2"
     source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
     target: "bulk/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
+  # Database warm-standby DR: pull the whole bulk/databases namespace from the
+  # always-on pve2 into this offline-DR leg (recursive via default options, so
+  # every bulk/databases/<instance> child comes along). Source is pve2 by design
+  # (the warm-standby home), unlike the splunk jobs whose source node is derived
+  # from tofu. Refreshes only during pve3 power-on windows.
+  - name: "databases"
+    source: "root@pve2:bulk/databases"
+    target: "bulk/replica/pve2/databases"

--- a/molecule/sqlite_standby/converge.yml
+++ b/molecule/sqlite_standby/converge.yml
@@ -1,0 +1,22 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    # Package install, dir creation, and timer enable are Docker-skipped; this
+    # proves the sync script + timer render the expected insert-only contract
+    # from the job definition.
+    sqlite_standby_healthcheck_url: "https://hc-ping.example/standby"
+    sqlite_standby_jobs:
+      - name: "events-archive"
+        source_host: "root@10.0.0.10"
+        source_path: "/var/lib/app/live.db"
+        archive_path: "/bulk/databases/events/archive.db"
+        tables:
+          - { name: "events", key: "id" }
+          - { name: "samples", key: "ts" }
+
+  roles:
+    - role: sqlite_standby

--- a/molecule/sqlite_standby/molecule.yml
+++ b/molecule/sqlite_standby/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-sqlite-standby-test
+    image: "${MOLECULE_IMAGE:-debian:stable-slim}"
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/sqlite_standby/verify.yml
+++ b/molecule/sqlite_standby/verify.yml
@@ -1,0 +1,43 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Read the rendered sync script
+      ansible.builtin.slurp:
+        src: /usr/local/bin/sqlite-standby-sync.sh
+      register: sqlite_standby_script
+
+    - name: Read the rendered timer unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/sqlite-standby.timer
+      register: sqlite_standby_timer
+
+    - name: Decode rendered files
+      ansible.builtin.set_fact:
+        sqlite_standby_script_text: "{{ sqlite_standby_script.content | b64decode }}"
+        sqlite_standby_timer_text: "{{ sqlite_standby_timer.content | b64decode }}"
+
+    - name: Assert the sync script renders the insert-only contract
+      ansible.builtin.assert:
+        that:
+          # Job invocation with its source, archive, and table:key pairs.
+          - >-
+            'sync_job "events-archive" "root@10.0.0.10" "/var/lib/app/live.db"
+            "/bulk/databases/events/archive.db" "events:id" "samples:ts"'
+            in sqlite_standby_script_text
+          # Insert-only, never-delete semantics.
+          - "'INSERT OR IGNORE INTO main.[' in sqlite_standby_script_text"
+          - "'DELETE FROM' not in sqlite_standby_script_text"
+          # Per-job failure isolation present.
+          - "'one or more jobs FAILED' in sqlite_standby_script_text"
+        fail_msg: "sqlite-standby sync script did not render the expected contract"
+
+    - name: Assert the timer is daily and persistent
+      ansible.builtin.assert:
+        that:
+          - "'OnCalendar=*-*-* 03:30:00' in sqlite_standby_timer_text"
+          - "'Persistent=true' in sqlite_standby_timer_text"
+        fail_msg: "sqlite-standby timer did not render the expected schedule"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -121,6 +121,17 @@
       tags:
         - syncoid
 
+    # Insert-only SQLite warm standby — one consumer of the generic
+    # <pool>/databases storage namespace. Daily appends new rows from a source
+    # DB into a queryable archive (never deletes). Inert until
+    # sqlite_standby_jobs is set (per host). Runs after zfs_pools (dataset) and
+    # syncoid; the namespace is snapshotted (sanoid) and replicated (syncoid).
+    - role: sqlite_standby
+      tags:
+        - sqlite_standby
+      vars:
+        sqlite_standby_healthcheck_url: "https://hc-ping.com/{{ lookup('env', 'HEALTHCHECK_PING_KEY') }}/sqlite-standby"
+
     - role: idrac_kiosk
       tags:
         - idrac_kiosk

--- a/roles/sanoid/defaults/main.yml
+++ b/roles/sanoid/defaults/main.yml
@@ -31,6 +31,17 @@ sanoid_templates:
     yearly: 0
     autosnap: "yes"
     autoprune: "yes"
+  # Warm/standby/backup databases (daily-cadence, long history). hot/primary
+  # databases that need point-in-time recovery use the `critical` template.
+  database:
+    frequently: 0
+    hourly: 0
+    daily: 30
+    weekly: 8
+    monthly: 12
+    yearly: 3
+    autosnap: "yes"
+    autoprune: "yes"
   scratch:
     autosnap: "no"
     autoprune: "no"

--- a/roles/sqlite_standby/README.md
+++ b/roles/sqlite_standby/README.md
@@ -1,0 +1,98 @@
+# sqlite_standby
+
+Daily, **insert-only** SQLite **warm standby**. For each configured job this role
+pulls a consistent online backup of a source SQLite database and appends only
+**new** rows into a local archive database — it **never deletes**, so the live
+source can enforce a short retention (prune old rows) while the archive keeps
+the full history and stays directly queryable.
+
+It is one **consumer** of the engine-agnostic `<pool>/databases` storage
+namespace (see the [`zfs_pools`](../zfs_pools/README.md) role). The storage layer
+owns tiering, snapshots, read-only NFS export, and cross-node replication; this
+role only fills an archive that lives there.
+
+## Installation
+
+Ships in `ansible-proxmox`, applied via `playbooks/site.yml`. No separate install.
+
+## How it works
+
+Per job, daily (`systemd` timer):
+
+1. **Consistent copy** — `sqlite3 '<src>' ".backup '<tmp>'"` on the source over
+   SSH (safe for a live WAL database), pulled back with binary `rsync`.
+2. **Seed (first run)** — the consistent copy *becomes* the archive verbatim, so
+   the full schema and **primary keys** are preserved (required for dedupe).
+3. **Insert-only append (subsequent runs)** — per configured table:
+
+   ```sql
+   INSERT OR IGNORE INTO main.[t]
+   SELECT * FROM src.[t] WHERE [key] > (SELECT MAX([key]) FROM main.[t]);
+   ```
+
+   Only rows past the archive's current high-water mark are added; `OR IGNORE`
+   keeps the first-seen row on a primary-key collision. Nothing is ever deleted.
+
+The archive is kept in `journal_mode=DELETE` so a **read-only NFS consumer** sees
+a self-consistent file. For a guaranteed point-in-time view while a sync may be
+running, query the latest ZFS snapshot under `<dataset>/.zfs/snapshot/`.
+
+A failed job is logged to `/var/log/sqlite-standby/` and does **not** abort the
+others; a failure pings `<healthcheck>/fail`.
+
+## Prerequisites (apply-time, out of band)
+
+- SSH trust from this host's `root` to each `source_host`. `cluster_ssh_trust`
+  covers PVE node↔node; a database guest is **not** a PVE node, so add that
+  trust separately.
+- `sqlite3` present on each source host, with transient free space (~the DB
+  size) for the online backup.
+- The target dataset (e.g. `bulk/databases`) created by `zfs_pools` from the
+  `terraform-proxmox` declaration.
+
+## Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `sqlite_standby_enabled` | `true` | Master enable |
+| `sqlite_standby_jobs` | `[]` | Jobs (see below) — inert until set |
+| `sqlite_standby_on_calendar` | `*-*-* 03:30:00` | `systemd` `OnCalendar` (daily) |
+| `sqlite_standby_persistent` | `true` | Run a missed schedule on next boot |
+| `sqlite_standby_healthcheck_url` | `""` | healthchecks.io URL (`/fail` on error) |
+| `sqlite_standby_run_now` | `false` | Opt-in: run immediately during the play |
+| `sqlite_standby_staging_dir` | `/var/lib/sqlite-standby` | Pulled-copy staging |
+
+### Job shape
+
+```yaml
+sqlite_standby_jobs:
+  - name: "events-archive"
+    source_host: "root@10.0.x.y"
+    source_path: "/var/lib/app/live.db"
+    archive_path: "/bulk/databases/events/archive.db"
+    tables:
+      - { name: "events", key: "id" }      # key MUST be monotonic per table
+      - { name: "samples", key: "ts" }
+```
+
+## Best-effort caveats
+
+- **Each table needs a monotonic key** (`INTEGER PRIMARY KEY`, autoincrement id,
+  or a never-decreasing timestamp). Tables without one cannot be appended safely
+  and should be omitted (or reseeded).
+- **Insert-only**: an UPDATE to an existing row keeps the first-seen version;
+  intermediate edits are not retained. (To retain full change history, model it
+  as append-only rows on the source.)
+- **Daily lag** by design — a queryable daily archive, not a near-real-time
+  replica.
+- **Full copy each run** — the current implementation transfers a full
+  consistent copy per run and needs transient free space on the source; a
+  delta-only optimization is a tracked follow-up.
+
+## Usage
+
+```bash
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags sqlite_standby
+# Seed/refresh now (e.g. first run) without waiting for the timer:
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags sqlite_standby -e sqlite_standby_run_now=true
+```

--- a/roles/sqlite_standby/defaults/main.yml
+++ b/roles/sqlite_standby/defaults/main.yml
@@ -1,0 +1,45 @@
+---
+# sqlite_standby role defaults — daily, insert-only SQLite warm standby.
+#
+# One CONSUMER of the generic <pool>/databases storage namespace (see the
+# zfs_pools role). For each configured job it pulls a consistent online backup
+# of a source SQLite database over SSH and appends only NEW rows (by a per-table
+# monotonic key) into a local archive DB — it never deletes, so the live source
+# can be pruned while history accrues here. The archive stays directly queryable
+# (and is read-only-exported + snapshotted + replicated by the storage layer).
+#
+# Inert until sqlite_standby_jobs is set. Prerequisites (out of band): SSH trust
+# from this host's root to each source host, and sqlite3 on the source.
+# cluster_ssh_trust covers PVE node<->node trust, NOT host->guest.
+
+sqlite_standby_enabled: true
+
+# sqlite3 (append engine) + rsync (binary pull) installed on THIS (standby) host.
+sqlite_standby_packages:
+  - sqlite3
+  - rsync
+sqlite_standby_sqlite_bin: sqlite3
+sqlite_standby_staging_dir: /var/lib/sqlite-standby
+sqlite_standby_log_dir: /var/log/sqlite-standby
+
+# Daily by design (a warm standby / queryable daily archive, not a hot replica).
+sqlite_standby_on_calendar: "*-*-* 03:30:00"
+# Run a missed schedule on next boot (sensible for a backup job).
+sqlite_standby_persistent: true
+
+# Optional healthchecks.io URL; "<url>" pinged on success, "<url>/fail" on
+# failure. Wire from the play (env-sourced), like proxmox_monitoring.
+sqlite_standby_healthcheck_url: ""
+
+# Opt-in: run the sync immediately during the play (seed/refresh on demand) in
+# addition to installing the timer. Mirrors syncoid_run_now.
+sqlite_standby_run_now: false
+
+# Insert-only warm-standby jobs (empty -> inert). Each job:
+#   - name: "<instance>"                          # log label + remote temp name
+#     source_host: "root@10.0.x.y"                # ssh target holding the live DB
+#     source_path: "/path/to/live.db"             # live SQLite DB on the source
+#     archive_path: "/bulk/databases/<instance>/archive.db"
+#     tables:                                      # per-table monotonic key
+#       - { name: "events", key: "id" }
+sqlite_standby_jobs: []

--- a/roles/sqlite_standby/handlers/main.yml
+++ b/roles/sqlite_standby/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Reload systemd so it picks up the freshly written unit files. Skipped under
+# Docker (molecule), where systemd is not PID 1.
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/sqlite_standby/tasks/main.yml
+++ b/roles/sqlite_standby/tasks/main.yml
@@ -1,0 +1,113 @@
+---
+# sqlite_standby tasks — install the engine and render the daily insert-only
+# sync script + systemd timer. Package install, directory creation, and the
+# timer enable are Docker-skipped (molecule); the script and unit files always
+# render so the contract is verifiable in-container.
+
+- name: Install sqlite_standby packages (sqlite3 + rsync)
+  ansible.builtin.apt:
+    name: "{{ sqlite_standby_packages }}"
+    state: present
+    update_cache: true
+  when:
+    - sqlite_standby_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - sqlite_standby
+
+- name: Ensure staging and log directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  loop:
+    - "{{ sqlite_standby_staging_dir }}"
+    - "{{ sqlite_standby_log_dir }}"
+  when:
+    - sqlite_standby_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - sqlite_standby
+
+- name: Ensure archive parent directories exist
+  ansible.builtin.file:
+    path: "{{ item.archive_path | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  loop: "{{ sqlite_standby_jobs }}"
+  loop_control:
+    label: "{{ item.archive_path | dirname }}"
+  when:
+    - sqlite_standby_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - sqlite_standby
+
+- name: Deploy the warm-standby sync script
+  ansible.builtin.template:
+    src: sqlite-standby-sync.sh.j2
+    dest: /usr/local/bin/sqlite-standby-sync.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when: sqlite_standby_enabled
+  tags:
+    - sqlite_standby
+
+- name: Render the warm-standby service unit
+  ansible.builtin.template:
+    src: sqlite-standby.service.j2
+    dest: /etc/systemd/system/sqlite-standby.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: sqlite_standby_enabled
+  notify: Reload systemd daemon
+  tags:
+    - sqlite_standby
+
+- name: Render the warm-standby timer unit
+  ansible.builtin.template:
+    src: sqlite-standby.timer.j2
+    dest: /etc/systemd/system/sqlite-standby.timer
+    owner: root
+    group: root
+    mode: "0644"
+  when: sqlite_standby_enabled
+  notify: Reload systemd daemon
+  tags:
+    - sqlite_standby
+
+# Apply any pending daemon-reload now so the timer below enables against the
+# freshly written unit (handlers otherwise run only at end of play).
+- name: Reload systemd before enabling the timer
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start the warm-standby timer
+  ansible.builtin.systemd:
+    name: sqlite-standby.timer
+    enabled: true
+    state: started
+  when:
+    - sqlite_standby_enabled
+    - sqlite_standby_jobs | length > 0
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - sqlite_standby
+
+# Opt-in immediate run (seed/refresh on demand) — mirrors syncoid_run_now.
+# Useful to seed a new archive without waiting for the timer.
+- name: Run the warm-standby sync now (opt-in seed/refresh)
+  ansible.builtin.command: /usr/local/bin/sqlite-standby-sync.sh
+  when:
+    - sqlite_standby_enabled
+    - sqlite_standby_jobs | length > 0
+    - sqlite_standby_run_now | bool
+    - ansible_virtualization_type != 'docker'
+  changed_when: true
+  tags:
+    - sqlite_standby

--- a/roles/sqlite_standby/templates/sqlite-standby-sync.sh.j2
+++ b/roles/sqlite_standby/templates/sqlite-standby-sync.sh.j2
@@ -1,0 +1,86 @@
+#!/bin/bash
+# sqlite-standby-sync — daily, insert-only SQLite warm-standby sync.
+# Managed by Ansible — do not edit manually.
+#
+# Per job: take a consistent online backup of the source DB (sqlite3 .backup
+# over SSH), pull it (binary rsync), then INSERT OR IGNORE only rows newer than
+# the archive's current per-table high-water mark. Never deletes; an UPDATE
+# keeps the first-seen row. The archive uses journal_mode=DELETE so a read-only
+# NFS consumer sees a self-consistent file (for a guaranteed point-in-time view,
+# read the latest ZFS snapshot under <dataset>/.zfs/snapshot/). A failed job is
+# logged and does NOT abort the others.
+set -uo pipefail
+
+SQLITE="{{ sqlite_standby_sqlite_bin }}"
+STAGING="{{ sqlite_standby_staging_dir }}"
+LOG_DIR="{{ sqlite_standby_log_dir }}"
+HC="{{ sqlite_standby_healthcheck_url }}"
+mkdir -p "$STAGING" "$LOG_DIR"
+log="$LOG_DIR/$(date +%Y-%m-%d).log"
+
+say()     { echo "=== $(date +%H:%M:%S) $* ===" >>"$log"; }
+ping_hc() { [ -n "$HC" ] && curl -fsS -m 10 --retry 3 -o /dev/null "$1" >/dev/null 2>&1 || true; }
+
+sync_job() {
+  local name="$1" src_host="$2" src_path="$3" archive="$4"; shift 4
+  say "job $name: ${src_host}:${src_path} -> ${archive}"
+  mkdir -p "$(dirname "$archive")"
+
+  local rtmp="/tmp/sqlite-standby-${name}.db"
+  local snap="${STAGING}/${name}.snap.db"
+  rm -f "$snap"
+
+  # 1. Consistent online backup on the source (handles a live WAL DB), pull it.
+  if ! ssh -o BatchMode=yes "$src_host" "${SQLITE} '${src_path}' \".backup '${rtmp}'\"" >>"$log" 2>&1; then
+    say "  FAILED: online backup on source"
+    return 1
+  fi
+  if ! rsync -a --remove-source-files "${src_host}:${rtmp}" "$snap" >>"$log" 2>&1; then
+    say "  FAILED: rsync pull"
+    ssh -o BatchMode=yes "$src_host" "rm -f '${rtmp}'" >>"$log" 2>&1 || true
+    return 1
+  fi
+
+  # 2. First run: the consistent copy *is* the archive (full schema + primary
+  #    keys preserved, so INSERT OR IGNORE can dedupe). journal_mode=DELETE
+  #    leaves no -wal so NFS read-only consumers see a self-consistent file.
+  if [ ! -f "$archive" ]; then
+    mv "$snap" "$archive"
+    "$SQLITE" "$archive" "PRAGMA journal_mode=DELETE;" >>"$log" 2>&1 || true
+    say "  seeded archive from first consistent copy"
+    return 0
+  fi
+
+  # 3. Insert-only append: rows past the archive's current high-water mark per
+  #    table; OR IGNORE keeps the first-seen row on a primary-key collision.
+  "$SQLITE" "$archive" "PRAGMA journal_mode=DELETE;" >>"$log" 2>&1 || true
+  local sql="ATTACH '${snap}' AS src;"
+  local pair t key
+  for pair in "$@"; do
+    t="${pair%%:*}"
+    key="${pair##*:}"
+    sql+="INSERT OR IGNORE INTO main.[${t}] SELECT * FROM src.[${t}]"
+    sql+=" WHERE [${key}] > (SELECT MAX([${key}]) FROM main.[${t}]);"
+  done
+  sql+="DETACH src;"
+  if ! "$SQLITE" "$archive" "$sql" >>"$log" 2>&1; then
+    say "  FAILED: insert-only append"
+    rm -f "$snap"
+    return 1
+  fi
+  rm -f "$snap"
+  say "  job $name OK"
+}
+
+rc=0
+{% for job in sqlite_standby_jobs %}
+sync_job "{{ job.name }}" "{{ job.source_host }}" "{{ job.source_path }}" "{{ job.archive_path }}"{% for t in job.tables %} "{{ t.name }}:{{ t.key }}"{% endfor %} || rc=1
+{% endfor %}
+
+if [ "$rc" -ne 0 ]; then
+  say "one or more jobs FAILED"
+  ping_hc "${HC}/fail"
+  exit 1
+fi
+say "all jobs OK"
+ping_hc "${HC}"

--- a/roles/sqlite_standby/templates/sqlite-standby.service.j2
+++ b/roles/sqlite_standby/templates/sqlite-standby.service.j2
@@ -1,0 +1,8 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Insert-only SQLite warm-standby sync
+Documentation=ansible role sqlite_standby
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sqlite-standby-sync.sh

--- a/roles/sqlite_standby/templates/sqlite-standby.timer.j2
+++ b/roles/sqlite_standby/templates/sqlite-standby.timer.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Daily insert-only SQLite warm-standby sync
+Documentation=ansible role sqlite_standby
+
+[Timer]
+OnCalendar={{ sqlite_standby_on_calendar }}
+Persistent={{ sqlite_standby_persistent | ternary('true', 'false') }}
+
+[Install]
+WantedBy=timers.target

--- a/roles/zfs_pools/README.md
+++ b/roles/zfs_pools/README.md
@@ -77,6 +77,65 @@ form** (`recordsize: "1M"`, `compression: "zstd"`, `readonly: "on"`) and
 `quota` keeps its own dedicated (byte-compared) handling — do not also put it
 under `properties`.
 
+### Per-dataset NFS export
+
+`datasets.<name>.nfs_export` (optional) is the exact ZFS `sharenfs` value, set
+verbatim and compared with `zfs get -H -o value sharenfs`. Use it to expose a
+dataset over NFS — typically **read-only and LAN-scoped** for query access:
+
+```yaml
+datasets:
+  databases:
+    nfs_export: "ro=@10.0.0.0/8 ro=@192.168.0.0/16"  # space-separated clients
+```
+
+Children **inherit** a parent's `sharenfs`, so exporting a namespace parent
+(e.g. `bulk/databases`) makes every dataset beneath it queryable read-only
+without per-child config; a child can opt out with `sharenfs: "off"` under
+`properties`. When any dataset declares `nfs_export`, the role ensures
+`nfs-kernel-server` is installed and running. Leave it `null` (the default) for
+no export.
+
+## Database storage namespace (engine- and tier-agnostic)
+
+A reserved `<pool>/databases/<instance>` namespace standardizes where database
+data lives, independent of engine (SQLite, PostgreSQL, MySQL, …) or role
+(hot/primary, warm/standby, backup/archive). The parent `databases` dataset on
+a pool is a lightweight container; each database is its **own child dataset** so
+it carries engine-appropriate tuning, its own quota, snapshot policy, and
+(optionally) replication.
+
+**Tier → pool.** Pick the pool by latency need, not engine:
+
+| Role | Pool | Why |
+| --- | --- | --- |
+| hot / primary | `fast` (NVMe) | low-latency random I/O |
+| warm / standby / backup / archive | `bulk` (non-fast) | capacity over latency |
+
+**Engine → `recordsize`.** Match ZFS `recordsize` to the engine's page/IO unit:
+
+| Engine | `recordsize` | Notes |
+| --- | --- | --- |
+| PostgreSQL | `8K`–`16K` | 8K page; consider a separate WAL dataset, `logbias=throughput` |
+| MySQL / MariaDB (InnoDB) | `16K` | 16K page |
+| SQLite | `32K`–`64K` | balances query reads vs. append writes |
+
+Always pair with `compression: "zstd"` and `atime: "off"`. The namespace parent
+defaults to a neutral `recordsize: "16K"`; per-instance children override.
+
+**Role → snapshots / replication / export.**
+
+- **primary/hot** → `critical` sanoid template (hourly + long retention); export
+  off.
+- **warm/standby/backup** → `database` sanoid template (daily, long retention),
+  `syncoid` DR replication, and `nfs_export` read-only so the standby is
+  queryable from another machine.
+
+The parent is snapshotted/replicated **recursively**, so adding a child instance
+inherits snapshots, the DR copy, and (on `bulk`) the read-only export with no
+extra wiring. Engine-specific *sync* mechanisms (e.g. the `sqlite_standby` role,
+`pg_basebackup`, `mysqldump`) are separate consumers of this namespace.
+
 ## Usage
 
 ```bash

--- a/roles/zfs_pools/defaults/main.yml
+++ b/roles/zfs_pools/defaults/main.yml
@@ -12,7 +12,10 @@ zfs_pools_config: >-
   }}
 
 # Map of pools for this node, keyed by pool name. Shape per pool:
-#   { type, raid, protected, register, content, datasets: { <name>: { quota, mountpoint } } }
+#   { type, raid, protected, register, content,
+#     datasets: { <name>: { quota, mountpoint, nfs_export, properties } } }
+# nfs_export (optional) is the exact zfs `sharenfs` value, e.g.
+# "ro=@10.0.0.0/8 ro=@192.168.0.0/16"; children inherit a parent's sharenfs.
 zfs_pools_map: "{{ zfs_pools_config.pools | default({}) }}"
 
 # SAFETY: creating a zpool from raw devices is a destructive commissioning step

--- a/roles/zfs_pools/tasks/datasets.yml
+++ b/roles/zfs_pools/tasks/datasets.yml
@@ -66,3 +66,18 @@
   when: zfs_dataset.value.properties | default({}) | length > 0
   tags:
     - zfs_pools
+
+# Optional read-only/scoped NFS export (zfs sharenfs). Children inherit a
+# parent's sharenfs, so exporting a namespace parent (e.g. bulk/databases) makes
+# every dataset under it queryable read-only without per-child config.
+- name: "Apply NFS exports in pool {{ zfs_pool.key }}"
+  ansible.builtin.include_tasks: nfs_export.yml
+  loop: "{{ zfs_pool.value.datasets | default({}) | dict2items }}"
+  loop_control:
+    loop_var: zfs_dataset
+    label: "{{ zfs_pool.key }}/{{ zfs_dataset.key }}"
+  when:
+    - zfs_dataset.value.nfs_export | default(None) is not none
+    - zfs_dataset.value.nfs_export | default('') | length > 0
+  tags:
+    - zfs_pools

--- a/roles/zfs_pools/tasks/nfs_export.yml
+++ b/roles/zfs_pools/tasks/nfs_export.yml
@@ -1,0 +1,40 @@
+---
+# Idempotently export a single dataset over NFS via the ZFS `sharenfs` property.
+# Included per-dataset from datasets.yml when `nfs_export` is set; `zfs_pool` and
+# `zfs_dataset` (dict2items entries) are in scope. `nfs_export` is the exact ZFS
+# `sharenfs` value — e.g. "ro=@10.0.0.0/8 ro=@192.168.0.0/16" for a LAN-scoped
+# read-only export. Space-separated client specs, comma-separated options per
+# client, mirroring exports(5). This whole path is already Docker-skipped via the
+# datasets.yml include gate in main.yml, so no per-task docker guard is needed.
+
+- name: "Ensure nfs-kernel-server is installed for {{ zfs_pool.key ~ '/' ~ zfs_dataset.key }}"
+  ansible.builtin.apt:
+    name: nfs-kernel-server
+    state: present
+    update_cache: true
+  tags:
+    - zfs_pools
+
+- name: "Ensure nfs-server is enabled and started for {{ zfs_pool.key ~ '/' ~ zfs_dataset.key }}"
+  ansible.builtin.systemd:
+    name: nfs-server
+    enabled: true
+    state: started
+  tags:
+    - zfs_pools
+
+- name: "Read current sharenfs for {{ zfs_pool.key ~ '/' ~ zfs_dataset.key }}"
+  ansible.builtin.command:
+    cmd: "zfs get -H -o value sharenfs {{ zfs_pool.key }}/{{ zfs_dataset.key }}"
+  register: zfs_pools_sharenfs_cur
+  changed_when: false
+  tags:
+    - zfs_pools
+
+- name: "Set sharenfs for {{ zfs_pool.key ~ '/' ~ zfs_dataset.key }}"
+  ansible.builtin.command:
+    cmd: "zfs set sharenfs={{ zfs_dataset.value.nfs_export | quote }} {{ zfs_pool.key }}/{{ zfs_dataset.key }}"
+  when: zfs_pools_sharenfs_cur.stdout != (zfs_dataset.value.nfs_export | string)
+  changed_when: true
+  tags:
+    - zfs_pools


### PR DESCRIPTION
## Summary

Adds a generic, engine- and tier-agnostic ZFS database storage namespace and one consumer for SQLite warm standbys. The storage layer supports any engine (SQLite, PostgreSQL, MySQL) and any role (hot/primary, warm/standby, backup), not a single use case.

## Storage layer (generic)

- zfs_pools: realizes the node_storage nfs_export field as zfs sharenfs (read-only, LAN-scoped). Children inherit a parent export, so exporting a <pool>/databases parent makes every instance under it queryable read-only with no per-child config.
- Convention documented in roles/zfs_pools/README.md: tier to pool (fast = hot/primary, bulk = warm/standby/backup), per-engine recordsize (Postgres 8-16K, MySQL 16K, SQLite 32-64K), per-role snapshot/replication/export policy.
- sanoid: new database retention template (daily cadence, long history).

## Consumer (SQLite)

- sqlite_standby role: daily, insert-only warm standby. Pulls a consistent online backup over SSH and appends only new rows (INSERT OR IGNORE by a per-table monotonic key). Never deletes; the live source can be pruned while history accrues and remains queryable. journal_mode=DELETE for read-only NFS consumers. Config-driven; molecule scenario included.

## Wiring

- pve2: sanoid snapshots of the namespace + commented job example.
- pve3: syncoid DR replication of the namespace.
- site.yml: sqlite_standby role (inert until jobs are set).

## Follow-up (not in this PR)

- Declare the databases dataset(s) in terraform-proxmox node_storage (the variable already supports nfs_export + properties; tofu_inventory.json is gitignored/generated) and regenerate. Apply this first; the pve2/pve3 wiring references bulk/databases.
- Populate real sqlite_standby_jobs (environment-specific) and SSH trust pve2 to the source host.

## Verification

- ansible-lint (production profile): pass.
- Rendered sync script: bash -n clean; converge play syntax-check clean.
- Molecule could not run locally (env molecule-docker driver crashes in sanity_checks before any task; missing Python docker SDK). CI runs it.
- Live verification (real hosts, not CI): zfs get on bulk/databases, read-only mount + SELECT, sanoid snapshots, syncoid DR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)