### PR TITLE
fix(inventory): S3 resolver works under --check (tempfile has no path in check mode)

### DIFF
--- a/playbooks/load_tofu.yml
+++ b/playbooks/load_tofu.yml
@@ -59,6 +59,10 @@
                 else ''
               }}
 
+        # Inventory resolution is read-only and must work under --check too
+        # (tempfile creates no path in check mode, which would blow up the
+        # download's dest templating before failed_when applies) — so the
+        # fetch pair always really runs (check_mode: false).
         - name: Fetch the published inventory from S3
           when: tofu_inventory_s3_effective | length > 0
           block:
@@ -67,6 +71,7 @@
                 state: file
                 suffix: tofu_inventory.json
               register: tofu_inv_tmp
+              check_mode: false
 
             - name: Download the inventory from S3
               amazon.aws.s3_object:
@@ -78,6 +83,7 @@
               register: tofu_inv_s3
               changed_when: false
               failed_when: false
+              check_mode: false
 
             # failed_when:false masks the module's failed flag, so success is
             # judged by the artifact itself: the GET overwrote the empty temp


### PR DESCRIPTION
## Bug

Live `--check` run of `site.yml` failed in the resolver (#266):

```text
fatal: [localhost]: Task failed: Finalization of task args for 'amazon.aws.s3_object' failed: Error while resolving value for 'dest': object of type 'dict' has no attribute 'path'
```

In check mode `tempfile` creates nothing and registers no `path`, so the download task dies at arg templating — before `failed_when` applies. (The pre-#266 CLI version masked this: `command` tasks skip in check mode, so S3 was silently never tried and check runs leaned on the local cache — which CI doesn't have.)

## Fix

Inventory resolution is read-only and must work under `--check`: the temp-file + download pair now always really runs (`check_mode: false`).

## Verification

- `ansible-lint` production profile clean; syntax-check clean
- Live `--check` from a cache-less worktree with real creds: account derived → S3 object downloaded → inventory resolved from S3 → loaded and validated (`failed=0`)

Refs: #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)