### PR TITLE
feat(media): single /bulk/data bind-mount + inventory-derived media guests for the pve2 rebuild

### DIFF
--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -33,6 +33,12 @@ syncoid_jobs:
 # and what syncoid ships to pve3. The bulk/databases parent is created by
 # zfs_pools from the terraform-proxmox node_storage declaration — apply that
 # first (see the zfs_pools README "Database storage namespace").
+# bulk/data (the unified media dataset the pve2 media LXCs bind-mount) is
+# DELIBERATELY absent here: terraform-proxmox declares it with
+# com.sun:auto-snapshot=false because torrent churn would bloat snapshots, and
+# the media payload is re-acquirable. If the library half ever deserves
+# snapshots, that means either splitting it back out or accepting short-lived
+# sanoid retention on the whole dataset — a maintainer decision, not a default.
 sanoid_datasets:
   "bulk/databases":
     use_template: database

--- a/molecule/media_lxc_features/converge.yml
+++ b/molecule/media_lxc_features/converge.yml
@@ -7,7 +7,7 @@
   vars:
     # Stand in for the tofu inventory's service -> vmid resolution that
     # playbooks/load_tofu.yml injects on a real host. Uses the NEW 6-digit
-    # pve2 media VMID mapping (703040 plex, 736030 seerr, 715240 sonarr,
+    # Media-node VMID mapping (703040 plex, 736030 seerr, 715240 sonarr,
     # 715340 radarr, 725140 download-vpn) so converge proves the role follows
     # a renumber with no change to the service-keyed feature map.
     media_lxc_features_service_vmids_from_tofu:

--- a/molecule/media_lxc_features/converge.yml
+++ b/molecule/media_lxc_features/converge.yml
@@ -6,20 +6,20 @@
 
   vars:
     # Stand in for the tofu inventory's service -> vmid resolution that
-    # playbooks/load_tofu.yml injects on a real host. Uses the NEW media
-    # VMID mapping (210 plex, 211 jellyseerr, 212 sonarr, 213 radarr,
-    # 214 download-vpn) so converge proves the role follows a renumber with no
-    # change to the service-keyed feature map.
+    # playbooks/load_tofu.yml injects on a real host. Uses the NEW 6-digit
+    # pve2 media VMID mapping (703040 plex, 736030 seerr, 715240 sonarr,
+    # 715340 radarr, 725140 download-vpn) so converge proves the role follows
+    # a renumber with no change to the service-keyed feature map.
     media_lxc_features_service_vmids_from_tofu:
-      plex: 210
-      jellyseerr: 211
-      sonarr: 212
-      radarr: 213
-      download-vpn: 214
+      plex: 703040
+      seerr: 736030
+      sonarr: 715240
+      radarr: 715340
+      download-vpn: 725140
 
   roles:
-    # Under Docker the role short-circuits every `pct`/blockinfile task
-    # (ansible_virtualization_type == 'docker'). This proves the role converges
-    # cleanly, the service-keyed feature map loads, the service -> vmid join
-    # resolves, and the skip guards hold.
+    # Under Docker the role short-circuits every `pct`/blockinfile task AND
+    # the /bulk/data data-root prep (ansible_virtualization_type == 'docker').
+    # This proves the role converges cleanly, the service-keyed feature map
+    # loads, the service -> vmid join resolves, and the skip guards hold.
     - role: media_lxc_features

--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -5,14 +5,14 @@
   gather_facts: true
 
   vars:
-    # The NEW media VMID mapping (same as converge). Used to prove the
-    # service-keyed feature map resolves onto the renumbered vmids.
+    # The NEW 6-digit pve2 media VMID mapping (same as converge). Used to prove
+    # the service-keyed feature map resolves onto the renumbered vmids.
     media_lxc_features_verify_service_vmids:
-      plex: 210
-      jellyseerr: 211
-      sonarr: 212
-      radarr: 213
-      download-vpn: 214
+      plex: 703040
+      seerr: 736030
+      sonarr: 715240
+      radarr: 715340
+      download-vpn: 725140
 
   tasks:
     - name: Load the role defaults (service-keyed feature map)
@@ -23,60 +23,70 @@
       ansible.builtin.assert:
         that:
           - "'plex' in media_lxc_features_map"
-          - "'jellyseerr' in media_lxc_features_map"
+          - "'seerr' in media_lxc_features_map"
           - "'sonarr' in media_lxc_features_map"
           - "'radarr' in media_lxc_features_map"
           - "'download-vpn' in media_lxc_features_map"
           # No raw vmids leaked back in as keys.
-          - "'210' not in media_lxc_features_map"
-          - "'214' not in media_lxc_features_map"
+          - "'703040' not in media_lxc_features_map"
+          - "'725140' not in media_lxc_features_map"
         fail_msg: "media_lxc_features_map must be keyed by service name, not vmid"
 
-    - name: Assert plex gets the media mount only, read-write
+    - name: Assert plex gets the single unified data mount, read-write
       ansible.builtin.assert:
         that:
           - media_lxc_features_map['plex'].mounts | length == 1
-          - media_lxc_features_map['plex'].mounts[0].src == '/rpool/data/media'
-          - media_lxc_features_map['plex'].mounts[0].dst == '/mnt/media'
+          - media_lxc_features_map['plex'].mounts[0].src == '/bulk/data'
+          - media_lxc_features_map['plex'].mounts[0].dst == '/data'
           - not (media_lxc_features_map['plex'].mounts[0].ro | default(false))
           - not (media_lxc_features_map['plex'].keyctl | bool)
           - not (media_lxc_features_map['plex'].tun | bool)
         fail_msg: "plex feature contract did not resolve as expected"
 
-    - name: Assert jellyseerr gets keyctl only, no bind-mounts, no tun
+    - name: Assert seerr gets keyctl only, no bind-mounts, no tun
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['jellyseerr'].mounts | default([]) | length == 0
-          - media_lxc_features_map['jellyseerr'].keyctl | bool
-          - not (media_lxc_features_map['jellyseerr'].tun | bool)
-        fail_msg: "jellyseerr feature contract did not resolve as expected"
+          - media_lxc_features_map['seerr'].mounts | default([]) | length == 0
+          - media_lxc_features_map['seerr'].keyctl | bool
+          - not (media_lxc_features_map['seerr'].tun | bool)
+        fail_msg: "seerr feature contract did not resolve as expected"
 
-    - name: Assert sonarr/radarr get both mounts, no keyctl, no tun
+    - name: Assert sonarr/radarr get the single unified data mount, no keyctl, no tun
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['sonarr'].mounts | length == 2
-          - media_lxc_features_map['radarr'].mounts | length == 2
+          - media_lxc_features_map['sonarr'].mounts | length == 1
+          - media_lxc_features_map['sonarr'].mounts[0].src == '/bulk/data'
+          - media_lxc_features_map['sonarr'].mounts[0].dst == '/data'
+          - media_lxc_features_map['radarr'].mounts | length == 1
+          - media_lxc_features_map['radarr'].mounts[0].src == '/bulk/data'
+          - media_lxc_features_map['radarr'].mounts[0].dst == '/data'
           - not (media_lxc_features_map['sonarr'].keyctl | bool)
           - not (media_lxc_features_map['radarr'].keyctl | bool)
           - not (media_lxc_features_map['sonarr'].tun | bool)
           - not (media_lxc_features_map['radarr'].tun | bool)
         fail_msg: "sonarr/radarr feature contract did not resolve as expected"
 
-    - name: Assert download-vpn gets both mounts, keyctl, and tun
+    - name: Assert download-vpn gets the single unified data mount, keyctl, and tun
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['download-vpn'].mounts | length == 2
-          - >-
-            (media_lxc_features_map['download-vpn'].mounts
-             | selectattr('src', 'equalto', '/rpool/data/downloads')
-             | map(attribute='dst') | first) == '/mnt/downloads'
-          - >-
-            (media_lxc_features_map['download-vpn'].mounts
-             | selectattr('src', 'equalto', '/rpool/data/media')
-             | map(attribute='dst') | first) == '/mnt/media'
+          - media_lxc_features_map['download-vpn'].mounts | length == 1
+          - media_lxc_features_map['download-vpn'].mounts[0].src == '/bulk/data'
+          - media_lxc_features_map['download-vpn'].mounts[0].dst == '/data'
           - media_lxc_features_map['download-vpn'].keyctl | bool
           - media_lxc_features_map['download-vpn'].tun | bool
         fail_msg: "download-vpn feature contract did not resolve as expected"
+
+    - name: Assert every mounted service shares the SAME dataset (hardlink contract)
+      ansible.builtin.assert:
+        that:
+          # qBittorrent + the *arrs can only hardlink within one dataset, so
+          # every declared mount across all services must share one source.
+          - >-
+            media_lxc_features_map | dict2items
+            | map(attribute='value.mounts') | map('default', [])
+            | flatten | map(attribute='src') | unique | list
+            == ['/bulk/data']
+        fail_msg: "all mounted media services must share the single /bulk/data dataset"
 
     - name: Assert the tun device numbers are the TUN/TAP allocation (10:200)
       ansible.builtin.assert:
@@ -84,6 +94,20 @@
           - media_lxc_features_tun_major == 10
           - media_lxc_features_tun_minor == 200
         fail_msg: "/dev/net/tun device numbers are not the expected 10:200"
+
+    - name: Assert the shared data-root contract (group GID + skeleton)
+      ansible.builtin.assert:
+        that:
+          - media_lxc_features_data_root == '/bulk/data'
+          - media_lxc_features_data_group == 'media'
+          - media_lxc_features_data_gid | int == 13000
+          # Group-writable + setgid so qbit/*arr-created content keeps the group.
+          - media_lxc_features_data_dir_mode == '2775'
+          - "'torrents/movies' in media_lxc_features_data_directories"
+          - "'torrents/tv' in media_lxc_features_data_directories"
+          - "'media/movies' in media_lxc_features_data_directories"
+          - "'media/tv' in media_lxc_features_data_directories"
+        fail_msg: "shared media data-root contract regressed"
 
     # ---------------------------------------------------------------------------
     # Service -> vmid JOIN: the load-bearing refactor. Re-derive the resolved
@@ -117,25 +141,25 @@
     - name: Assert the join puts each service's features on its NEW vmid
       ansible.builtin.assert:
         that:
-          # NEW: 210 plex (media mount only, no keyctl, no tun)
-          - "'210' in media_lxc_features_verify_resolved"
-          - media_lxc_features_verify_resolved['210'].mounts | length == 1
-          - media_lxc_features_verify_resolved['210'].mounts[0].dst == '/mnt/media'
-          - not (media_lxc_features_verify_resolved['210'].keyctl | bool)
-          - not (media_lxc_features_verify_resolved['210'].tun | bool)
-          # NEW: 211 jellyseerr (keyctl only, no mounts, no tun)
-          - media_lxc_features_verify_resolved['211'].mounts | length == 0
-          - media_lxc_features_verify_resolved['211'].keyctl | bool
-          - not (media_lxc_features_verify_resolved['211'].tun | bool)
-          # NEW: 212 sonarr / 213 radarr (both mounts, no keyctl, no tun)
-          - media_lxc_features_verify_resolved['212'].mounts | length == 2
-          - media_lxc_features_verify_resolved['213'].mounts | length == 2
-          - not (media_lxc_features_verify_resolved['212'].keyctl | bool)
-          - not (media_lxc_features_verify_resolved['213'].tun | bool)
-          # NEW: 214 download-vpn (both mounts + keyctl + tun)
-          - media_lxc_features_verify_resolved['214'].mounts | length == 2
-          - media_lxc_features_verify_resolved['214'].keyctl | bool
-          - media_lxc_features_verify_resolved['214'].tun | bool
+          # NEW: 703040 plex (single data mount, no keyctl, no tun)
+          - "'703040' in media_lxc_features_verify_resolved"
+          - media_lxc_features_verify_resolved['703040'].mounts | length == 1
+          - media_lxc_features_verify_resolved['703040'].mounts[0].dst == '/data'
+          - not (media_lxc_features_verify_resolved['703040'].keyctl | bool)
+          - not (media_lxc_features_verify_resolved['703040'].tun | bool)
+          # NEW: 736030 seerr (keyctl only, no mounts, no tun)
+          - media_lxc_features_verify_resolved['736030'].mounts | length == 0
+          - media_lxc_features_verify_resolved['736030'].keyctl | bool
+          - not (media_lxc_features_verify_resolved['736030'].tun | bool)
+          # NEW: 715240 sonarr / 715340 radarr (single data mount, no keyctl, no tun)
+          - media_lxc_features_verify_resolved['715240'].mounts | length == 1
+          - media_lxc_features_verify_resolved['715340'].mounts | length == 1
+          - not (media_lxc_features_verify_resolved['715240'].keyctl | bool)
+          - not (media_lxc_features_verify_resolved['715340'].tun | bool)
+          # NEW: 725140 download-vpn (single data mount + keyctl + tun)
+          - media_lxc_features_verify_resolved['725140'].mounts | length == 1
+          - media_lxc_features_verify_resolved['725140'].keyctl | bool
+          - media_lxc_features_verify_resolved['725140'].tun | bool
         fail_msg: "service -> vmid join did not place features on the new vmids"
 
     - name: Build a partial resolution (only plex placed) for the absent-skip case
@@ -143,7 +167,7 @@
         media_lxc_features_verify_partial_sel: >-
           {{
             media_lxc_features_map | dict2items
-            | selectattr('key', 'in', {'plex': 210})
+            | selectattr('key', 'in', {'plex': 703040})
             | list
           }}
     - name: Resolve the partial map (as the role does)
@@ -154,7 +178,7 @@
               (
                 media_lxc_features_verify_partial_sel
                 | map(attribute='key')
-                | map('extract', {'plex': 210})
+                | map('extract', {'plex': 703040})
                 | map('string') | list
               )
               | zip(media_lxc_features_verify_partial_sel | map(attribute='value') | list)
@@ -164,7 +188,7 @@
     - name: Assert only the resolvable service appears (absent-skip behaviour)
       ansible.builtin.assert:
         that:
-          - media_lxc_features_verify_partial.keys() | list == ['210']
+          - media_lxc_features_verify_partial.keys() | list == ['703040']
         fail_msg: "unresolved services must not appear in the effective map"
 
     # Guards the keyctl feature-merge logic (the load-bearing expression the role
@@ -202,3 +226,14 @@
         that:
           - media_lxc_features_pct_probe.rc != 0
         fail_msg: "Unexpected pct present — Docker skip guard may be broken"
+
+    - name: Probe for the data root (must be absent in the molecule container)
+      ansible.builtin.stat:
+        path: /bulk/data
+      register: media_lxc_features_data_root_probe
+
+    - name: Assert the data-root prep skipped under Docker (no /bulk/data created)
+      ansible.builtin.assert:
+        that:
+          - not media_lxc_features_data_root_probe.stat.exists
+        fail_msg: "Data-root prep must never invent /bulk/data on a host without the dataset"

--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -5,7 +5,7 @@
   gather_facts: true
 
   vars:
-    # The NEW 6-digit pve2 media VMID mapping (same as converge). Used to prove
+    # The NEW 6-digit media-node VMID mapping (same as converge). Used to prove
     # the service-keyed feature map resolves onto the renumbered vmids.
     media_lxc_features_verify_service_vmids:
       plex: 703040

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -93,7 +93,7 @@
 
     # Root-only media LXC features (bind-mounts, keyctl, /dev/net/tun) that the
     # BPG provider's API token cannot set. Runs AFTER OpenTofu creates the
-    # media LXC shells and zfs_pools manages the /rpool/data datasets, and
+    # media LXC shells and zfs_pools mounts the bulk/data dataset, and
     # BEFORE ansible-proxmox-apps converges the services. See the role README.
     - role: media_lxc_features
       tags:

--- a/roles/media_lxc_features/README.md
+++ b/roles/media_lxc_features/README.md
@@ -26,8 +26,8 @@ them. This role realizes them after creation.
 
 | Layer | Owns |
 | --- | --- |
-| terraform-proxmox | Create the media LXCs (CPU, RAM, disk, network, `nesting`) |
-| **this role** | Bind-mounts (`mp`), `keyctl` (merged), `/dev/net/tun` passthrough |
+| terraform-proxmox | Create the media LXCs (CPU, RAM, disk, network, `nesting`) + declare the `bulk/data` dataset (`node_storage`) |
+| **this role** | Bind-mounts (`mp`), `keyctl` (merged), `/dev/net/tun` passthrough, shared `media` group + `/bulk/data` directory skeleton |
 | ansible-proxmox-apps | Converge the services inside each LXC |
 
 `nesting=1` stays **OpenTofu-managed**. This role never drops it: `keyctl=1` is
@@ -42,7 +42,7 @@ terraform-proxmox (shells)  ->  media_lxc_features  ->  ansible-proxmox-apps
 
 Run this role **after** the LXCs exist and **before** the apps converge. In
 `playbooks/site.yml` it runs after `lxc_features` and after `zfs_pools` (the
-bind-mount sources are ZFS datasets under `/rpool/data`).
+bind-mount source is the `bulk/data` ZFS dataset, mounted at `/bulk/data`).
 
 ## Feature map (keyed by service, not VMID)
 
@@ -52,14 +52,37 @@ service, never a hardcoded VMID:
 
 | service | bind-mounts (host -> container) | keyctl | /dev/net/tun |
 | --- | --- | --- | --- |
-| plex | `/rpool/data/media`->`/mnt/media` | no | no |
-| jellyseerr | (none) | yes | no |
-| sonarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
-| radarr | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | no | no |
-| download-vpn | `/rpool/data/downloads`->`/mnt/downloads`, `/rpool/data/media`->`/mnt/media` | yes | yes |
+| plex | `/bulk/data`->`/data` | no | no |
+| seerr | (none) | yes | no |
+| sonarr | `/bulk/data`->`/data` | no | no |
+| radarr | `/bulk/data`->`/data` | no | no |
+| download-vpn | `/bulk/data`->`/data` | yes | yes |
 
-All bind-mounts are **read-write** (no `ro=1`), matching the live deployment.
+Every mounted service gets the **same single bind-mount**: the unified
+`bulk/data` dataset -> `/data`. One dataset (replacing the old separate
+`downloads` + `media` datasets/mounts) is what lets qBittorrent and the *arrs
+**hardlink** between `/data/torrents/*` and `/data/media/*` — hardlinks cannot
+cross dataset boundaries. All bind-mounts are **read-write** (no `ro=1`), the
+role's existing convention (plex is read-mostly by usage, not by mount flag).
 `/dev/net/tun` is char device **10:200** (verified on pve1).
+
+## Shared data root (host side)
+
+The `bulk/data` **dataset** (recordsize, auto-snapshot, quota) is declared in
+terraform-proxmox `node_storage` and realized by `zfs_pools`. This role owns
+the **POSIX layer** inside it, on hosts where `/bulk/data` exists:
+
+- the shared `media` group at a **fixed GID** (`13000` by default) — the path
+  is bind-mounted into several LXCs, so each guest's `media` group must map to
+  the same host GID;
+- the subdirectory skeleton `torrents/{movies,tv}` + `media/{movies,tv}`,
+  owner `root`, group `media`, mode `2775` (group-writable like the
+  `nas_storage` directory convention, plus setgid so app-created content keeps
+  the `media` group).
+
+Hosts without the data root (no bulk pool, or `zfs_pools` not yet applied)
+skip these tasks entirely; the role never invents a plain directory on the
+root filesystem.
 
 ### VMID resolution (renumber-proof)
 

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -26,7 +26,7 @@
 # Only vmids that actually exist on the target host are acted on; absent vmids
 # are skipped (tofu may not have created them yet). All tasks are skipped
 # under Docker virtualization (molecule).
-# Mount layout (pve2 rebuild): ONE bind-mount per service — the unified
+# Mount layout (bulk-node rebuild): ONE bind-mount per service — the unified
 # `bulk/data` dataset (host /bulk/data) -> /data in-container. The single
 # dataset is what lets qBittorrent and the *arrs HARDLINK between
 # /data/torrents/* and /data/media/* (hardlinks cannot cross the old

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -8,7 +8,7 @@
 # LXCs as plain shells; this role applies the root-only bits over native root
 # SSH, idempotently.
 #
-# The feature map is keyed by SERVICE NAME (plex, jellyseerr, sonarr, radarr,
+# The feature map is keyed by SERVICE NAME (plex, seerr, sonarr, radarr,
 # download-vpn) — NOT by raw VMID. Each service's current VMID is resolved at
 # run time from the tofu inventory (containers keyed by hostname, each with
 # a `vmid`), injected onto proxmox hosts by playbooks/load_tofu.yml as
@@ -26,32 +26,35 @@
 # Only vmids that actually exist on the target host are acted on; absent vmids
 # are skipped (tofu may not have created them yet). All tasks are skipped
 # under Docker virtualization (molecule).
+# Mount layout (pve2 rebuild): ONE bind-mount per service — the unified
+# `bulk/data` dataset (host /bulk/data) -> /data in-container. The single
+# dataset is what lets qBittorrent and the *arrs HARDLINK between
+# /data/torrents/* and /data/media/* (hardlinks cannot cross the old
+# downloads/media dataset boundary). All mounts stay read-write (the role's
+# existing convention; plex is read-mostly by usage, not by mount flag).
 media_lxc_features_map:
   plex:  # media streaming
     mounts:
-      - { src: /rpool/data/media, dst: /mnt/media }
+      - { src: /bulk/data, dst: /data }
     keyctl: false
     tun: false
-  jellyseerr:  # request UI (Docker-in-LXC); no bind-mounts
+  seerr:  # request UI (Docker-in-LXC); no bind-mounts
     mounts: []
     keyctl: true
     tun: false
   sonarr:  # TV PVR
     mounts:
-      - { src: /rpool/data/downloads, dst: /mnt/downloads }
-      - { src: /rpool/data/media, dst: /mnt/media }
+      - { src: /bulk/data, dst: /data }
     keyctl: false
     tun: false
   radarr:  # movie PVR
     mounts:
-      - { src: /rpool/data/downloads, dst: /mnt/downloads }
-      - { src: /rpool/data/media, dst: /mnt/media }
+      - { src: /bulk/data, dst: /data }
     keyctl: false
     tun: false
   download-vpn:  # qBittorrent + Prowlarr behind Proton WireGuard
     mounts:
-      - { src: /rpool/data/downloads, dst: /mnt/downloads }
-      - { src: /rpool/data/media, dst: /mnt/media }
+      - { src: /bulk/data, dst: /data }
     keyctl: true
     tun: true
 
@@ -70,3 +73,31 @@ media_lxc_features_service_vmids: >-
 # (hex) == 10:200 (decimal).
 media_lxc_features_tun_major: 10
 media_lxc_features_tun_minor: 200
+
+# ---------------------------------------------------------------------------
+# Shared media data root (host side of the bind-mount)
+# ---------------------------------------------------------------------------
+# The `bulk/data` DATASET itself (recordsize, auto-snapshot, quota) is declared
+# in terraform-proxmox node_storage and realized by the zfs_pools role. This
+# role owns the POSIX layer inside it: the shared `media` group and the
+# group-writable subdirectory skeleton qBittorrent + the *arrs hardlink across.
+# Same owner/group/mode convention as the nas_storage directory tasks
+# (owner root, shared group, group-writable), plus setgid (2775) so content the
+# apps create keeps the `media` group without per-app umask coupling.
+#
+# The GID is fixed (13000) because the path is bind-mounted into several LXCs:
+# in-container `media` groups must map to the same host GID on every guest.
+# Tasks run only when the data root already exists on the host (i.e. zfs_pools
+# mounted the dataset there) — nodes without the bulk pool are skipped, and a
+# plain directory is never invented on the root filesystem.
+media_lxc_features_data_root: /bulk/data
+media_lxc_features_data_group: media
+media_lxc_features_data_gid: 13000
+media_lxc_features_data_dir_mode: "2775"
+media_lxc_features_data_directories:
+  - torrents
+  - torrents/movies
+  - torrents/tv
+  - media
+  - media/movies
+  - media/tv

--- a/roles/media_lxc_features/tasks/main.yml
+++ b/roles/media_lxc_features/tasks/main.yml
@@ -16,6 +16,58 @@
 # change — only tofu_inventory.json updates. Services without a resolved
 # vmid (not in the inventory) contribute nothing.
 
+# ---------------------------------------------------------------------------
+# Shared media data root — POSIX layer inside the bulk/data dataset
+# ---------------------------------------------------------------------------
+# zfs_pools creates/mounts the dataset (from the tofu node_storage contract);
+# this prepares what the bind-mounts expose: the shared `media` group (fixed
+# GID — it must resolve identically inside every guest the path is mounted
+# into) and the group-writable subdirectory skeleton qBittorrent + the *arrs
+# hardlink across. Skipped wholesale on hosts where the data root does not
+# exist (no bulk pool on this node, or zfs_pools has not run yet).
+
+- name: Probe for the shared media data root
+  ansible.builtin.stat:
+    path: "{{ media_lxc_features_data_root }}"
+  register: media_lxc_features_data_root_stat
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - media_lxc_features
+
+- name: Ensure the shared media group exists
+  ansible.builtin.group:
+    name: "{{ media_lxc_features_data_group }}"
+    gid: "{{ media_lxc_features_data_gid }}"
+    state: present
+  when: media_lxc_features_data_root_stat.stat.exists | default(false)
+  tags:
+    - media_lxc_features
+
+- name: Ensure data root ownership and group-writable mode
+  ansible.builtin.file:
+    path: "{{ media_lxc_features_data_root }}"
+    state: directory
+    owner: root
+    group: "{{ media_lxc_features_data_group }}"
+    mode: "{{ media_lxc_features_data_dir_mode }}"
+  when: media_lxc_features_data_root_stat.stat.exists | default(false)
+  tags:
+    - media_lxc_features
+
+- name: Ensure media data subdirectories
+  ansible.builtin.file:
+    path: "{{ media_lxc_features_data_root }}/{{ item }}"
+    state: directory
+    owner: root
+    group: "{{ media_lxc_features_data_group }}"
+    mode: "{{ media_lxc_features_data_dir_mode }}"
+  loop: "{{ media_lxc_features_data_directories }}"
+  loop_control:
+    label: "{{ media_lxc_features_data_root }}/{{ item }}"
+  when: media_lxc_features_data_root_stat.stat.exists | default(false)
+  tags:
+    - media_lxc_features
+
 - name: Select the services that have a vmid in the tofu inventory
   ansible.builtin.set_fact:
     # Drop any service the inventory does not currently place (not yet created /

--- a/roles/proxmox_monitoring/README.md
+++ b/roles/proxmox_monitoring/README.md
@@ -47,11 +47,14 @@ External uptime monitoring ping (optional).
 
 ### zfs-capacity
 
-Pushes an [ntfy](https://ntfy.sh) alert when a ZFS pool crosses a usage band
-(default 50/75/90%). State is tracked per pool under
+Pushes an [ntfy](https://ntfy.sh) alert when a ZFS **pool** crosses a usage
+band (default 50/75/85/90%) or a **quota'd dataset** crosses a dataset band
+(default 85/90%, computed as `used/quota`). Quota-less datasets share their
+pool's free space, so the pool bands already cover them — per-dataset bands
+would only duplicate the pool alert. State is tracked per pool/dataset under
 `/var/lib/zfs-capacity-monitor/`, so a notification fires only on a band
 **change** (rising or recovering) — not every run. Priority scales with the
-band (50 → default, 75 → high, 90 → urgent). Disabled until
+band (50 → default, 75/85 → high, 90 → urgent). Disabled until
 `proxmox_monitoring_ntfy_url` is set.
 
 ## Variables
@@ -69,7 +72,8 @@ band (50 → default, 75 → high, 90 → urgent). Disabled until
 | `proxmox_monitoring_enable_zfs_capacity` | `true` | Enable ZFS capacity alerts |
 | `proxmox_monitoring_ntfy_url` | `""` | ntfy topic URL (secret); empty disables |
 | `proxmox_monitoring_zfs_capacity_interval` | `15` | Capacity check cron interval (minutes) |
-| `proxmox_monitoring_zfs_capacity_thresholds` | `[50, 75, 90]` | Usage bands (%) that trigger alerts |
+| `proxmox_monitoring_zfs_capacity_thresholds` | `[50, 75, 85, 90]` | Pool usage bands (%) that trigger alerts |
+| `proxmox_monitoring_zfs_dataset_capacity_thresholds` | `[85, 90]` | Quota'd-dataset usage bands (%; `used/quota`) |
 
 ## Usage
 

--- a/roles/proxmox_monitoring/defaults/main.yml
+++ b/roles/proxmox_monitoring/defaults/main.yml
@@ -31,7 +31,7 @@ proxmox_monitoring_zfs_capacity_thresholds: [50, 75, 85, 90]
 # filesystem dataset with a quota is checked as used/quota. Quota-less
 # datasets share their pool's free space, so their ">85%" moment IS the pool's
 # — the pool bands above cover them; per-dataset bands would only duplicate
-# that alert once per dataset (noise). bulk/data on pve2 is the motivating
+# that alert once per dataset (noise). bulk/data on the media node is the motivating
 # case: its quota caps torrent churn and this fires before writes start
 # failing at the quota wall.
 proxmox_monitoring_zfs_dataset_capacity_thresholds: [85, 90]

--- a/roles/proxmox_monitoring/defaults/main.yml
+++ b/roles/proxmox_monitoring/defaults/main.yml
@@ -22,8 +22,19 @@ proxmox_monitoring_enable_healthchecks: true
 proxmox_monitoring_enable_zfs_capacity: true
 
 # ZFS pool capacity alerts: push via ntfy when a pool crosses a usage band.
+# 85 sits between the old 75 warning and the 90 urgent band so every pool —
+# and with it every quota-less dataset it backs — alerts above 85% capacity.
 proxmox_monitoring_zfs_capacity_interval: 15
-proxmox_monitoring_zfs_capacity_thresholds: [50, 75, 90]
+proxmox_monitoring_zfs_capacity_thresholds: [50, 75, 85, 90]
+
+# ZFS DATASET capacity alerts (same script, same ntfy band mechanics): every
+# filesystem dataset with a quota is checked as used/quota. Quota-less
+# datasets share their pool's free space, so their ">85%" moment IS the pool's
+# — the pool bands above cover them; per-dataset bands would only duplicate
+# that alert once per dataset (noise). bulk/data on pve2 is the motivating
+# case: its quota caps torrent churn and this fires before writes start
+# failing at the quota wall.
+proxmox_monitoring_zfs_dataset_capacity_thresholds: [85, 90]
 # ntfy topic URL, e.g. https://ntfy.example.com/proxmox-storage
 # Set via vault/external variable — DO NOT commit a real URL. Empty disables it.
 proxmox_monitoring_ntfy_url: ""

--- a/roles/proxmox_monitoring/templates/zfs-capacity-monitor.sh.j2
+++ b/roles/proxmox_monitoring/templates/zfs-capacity-monitor.sh.j2
@@ -1,12 +1,16 @@
 #!/bin/bash
 set -euo pipefail
-# ZFS pool capacity monitor — pushes an ntfy alert when a pool crosses a usage
-# band (e.g. 50/75/90%). State is tracked per pool so a notification fires only
-# on a band CHANGE, not every run. Managed by Ansible — do not edit manually.
+# ZFS capacity monitor — pushes an ntfy alert when a POOL or a quota'd DATASET
+# crosses a usage band. State is tracked per pool/dataset so a notification
+# fires only on a band CHANGE, not every run. Quota-less datasets share their
+# pool's free space, so the pool bands already cover them (per-dataset bands
+# would just duplicate the pool alert). Managed by Ansible — do not edit
+# manually.
 
 NTFY_URL="{{ proxmox_monitoring_ntfy_url }}"
 STATE_DIR="/var/lib/zfs-capacity-monitor"
-THRESHOLDS=({{ proxmox_monitoring_zfs_capacity_thresholds | join(' ') }})
+POOL_THRESHOLDS=({{ proxmox_monitoring_zfs_capacity_thresholds | join(' ') }})
+DATASET_THRESHOLDS=({{ proxmox_monitoring_zfs_dataset_capacity_thresholds | join(' ') }})
 
 mkdir -p "$STATE_DIR"
 
@@ -17,31 +21,44 @@ notify() {
     -d "$4" "$NTFY_URL" || true
 }
 
-zpool list -H -o name,capacity | while IFS=$'\t' read -r pool cap_raw; do
-  cap="${cap_raw%\%}"
+# $1=kind (Pool|Dataset)  $2=name  $3=cap%  $4..=thresholds
+check_capacity() {
+  local kind="$1" name="$2" cap="$3"
+  shift 3
 
-  # Current band = highest threshold the pool has reached (0 if below all).
-  band=0
-  for t in "${THRESHOLDS[@]}"; do
+  # Current band = highest threshold reached (0 if below all).
+  local band=0 t
+  for t in "$@"; do
     if [ "$cap" -ge "$t" ]; then band="$t"; fi
   done
 
-  state_file="$STATE_DIR/${pool//\//_}.band"
-  last=0
+  local state_file="$STATE_DIR/${kind,,}_${name//\//_}.band"
+  local last=0
   if [ -f "$state_file" ]; then last="$(cat "$state_file")"; fi
-  if [ "$band" = "$last" ]; then continue; fi
+  if [ "$band" = "$last" ]; then return; fi
 
+  local prio tags
   if [ "$band" -gt "$last" ]; then
     case "$band" in
       90) prio="urgent"; tags="rotating_light" ;;
-      75) prio="high"; tags="warning" ;;
+      75 | 85) prio="high"; tags="warning" ;;
       *) prio="default"; tags="floppy_disk" ;;
     esac
-    notify "ZFS ${pool} at ${cap}%" "$prio" "$tags" \
-      "Pool '${pool}' crossed ${band}% capacity (now ${cap}%) on $(hostname)."
+    notify "ZFS ${name} at ${cap}%" "$prio" "$tags" \
+      "${kind} '${name}' crossed ${band}% capacity (now ${cap}%) on $(hostname)."
   else
-    notify "ZFS ${pool} recovered" "default" "white_check_mark" \
-      "Pool '${pool}' dropped to ${cap}% (below ${last}%) on $(hostname)."
+    notify "ZFS ${name} recovered" "default" "white_check_mark" \
+      "${kind} '${name}' dropped to ${cap}% (below ${last}%) on $(hostname)."
   fi
   echo "$band" >"$state_file"
+}
+
+zpool list -H -o name,capacity | while IFS=$'\t' read -r pool cap_raw; do
+  check_capacity "Pool" "$pool" "${cap_raw%\%}" "${POOL_THRESHOLDS[@]}"
+done
+
+# Quota'd datasets: capacity = used/quota (raw bytes via -p; quota 0 = none).
+zfs list -Hp -t filesystem -o name,used,quota | while IFS=$'\t' read -r ds used quota; do
+  [ "$quota" -gt 0 ] || continue
+  check_capacity "Dataset" "$ds" "$((used * 100 / quota))" "${DATASET_THRESHOLDS[@]}"
 done


### PR DESCRIPTION
## What

Host-side adaptation for the media stack's move to pve2's unified `bulk/data` dataset with new 6-digit VMIDs (the old five media LXCs retire after cutover).

### roles/media_lxc_features

- **Single bind-mount per service**: every mounted service now gets `/bulk/data -> /data` (replacing the old two-mount `downloads` + `media` pair). One dataset is what lets qBittorrent and the *arrs **hardlink** between `/data/torrents/*` and `/data/media/*` — hardlinks cannot cross dataset boundaries. plex gets the same mount, read-write per the role's existing convention (it never used `ro=1`; plex is read-mostly by usage, not mount flag). seerr keeps no mounts.
- **keyctl/tun unchanged**: download-vpn keeps keyctl + `/dev/net/tun`; seerr keeps keyctl only; plex/sonarr/radarr mounts only.
- **`jellyseerr` map key renamed to `seerr`** to match the inventory hostname (the tofu `containers` map is keyed by service hostname; the stale key would have resolved to nothing).
- **VMIDs stay fully inventory-derived** — no literals existed and none were added. `playbooks/load_tofu.yml` projects `tofu_data.containers` into `media_lxc_features_service_vmids_from_tofu` (`{service: vmid}`); the role joins its service-keyed feature map against that at run time and only touches vmids actually present per `pct list`. The 6-digit renumber flows through `tofu_inventory.json` with zero role-logic change.
- **New: shared data-root POSIX layer.** The dataset itself (recordsize 1M, auto-snapshot off, quota) stays IaC-declared and `zfs_pools`-realized; this role now owns what's inside it: the shared `media` group at **fixed GID 13000** (must map identically in every guest the path is bind-mounted into) and the `torrents/{movies,tv}` + `media/{movies,tv}` skeleton, `root:media 2775`. No prior role managed `/rpool/data/*` ownership — the closest convention is `nas_storage` (owner root, shared group, group-writable 0775); replicated with setgid added so app-created content keeps the `media` group. Gated on `/bulk/data` existing, so non-bulk nodes skip and a plain directory is never invented on the rootfs.

### roles/proxmox_monitoring (ZFS >85% capacity alerting)

The repo's existing host-metric path is this role's ntfy-based ZFS capacity monitor (cron + band-change state files) — extended natively, no new script:

- **Quota'd datasets** now alert on bands `[85, 90]` (`used/quota`, raw bytes). `bulk/data` is the motivating case: this fires before writes hit the quota wall.
- **Pool bands** gain 85 (`[50, 75, 85, 90]`): quota-less datasets share their pool's free space, so their ">85% moment" *is* the pool's — per-dataset bands there would only duplicate the pool alert once per dataset (noise). Between the two, `bulk/data` alerts above 85% whether or not it carries a quota.
- One-time effect: pool state files moved from `<pool>.band` to `pool_<pool>.band`, so each pool re-announces its current band once after deploy.

### molecule (CI-only; not run locally per repo policy)

`converge.yml`/`verify.yml` updated to the new 6-digit VMIDs and `seerr` key; assertions now pin the single-mount contract, a new shared-dataset invariant (all mounts resolve to one source — the hardlink prerequisite), the data-root defaults (GID 13000, 2775, skeleton), and that the data-root prep never creates `/bulk/data` under Docker.

### inventory/host_vars/pve2.yml

Comment-only: documents why `bulk/data` is absent from `sanoid_datasets`. No sanoid/syncoid config touched — pve2's existing jobs (splunk replication, `bulk/databases`) don't reference `bulk/data`, so nothing breaks.

## Decisions flagged for the maintainer

1. **Snapshots — library vs torrent churn on one dataset.** `bulk/data` deliberately ships `com.sun:auto-snapshot=false` in IaC (not flipped here). But the unified dataset now mixes the re-acquirable torrent churn with the curated library. Options: (a) accept no snapshots (current state, this PR); (b) add `bulk/data` to pve2 `sanoid_datasets` with a short-retention template (bounded churn bloat, some rollback safety). Not decided here.
2. **Config backups — follow-up.** No vzdump/PBS pattern exists in this repo (`pve_snapshot` snapshots the host OS root dataset only; `syncoid` replicates explicitly listed datasets). The media DATA is re-acquirable, but the five new LXCs' **rootfs/app configs are not** — they currently have no backup path. Suggest a follow-up: either a vzdump/PBS job covering the new VMIDs or syncoid jobs for their rootfs subvol datasets.
3. **Alert routing**: dataset alerts reuse the existing ntfy channel (`proxmox_monitoring_ntfy_url`, secret, empty-disabled) — no new telemetry sink. If alerting should instead land in Splunk/HEC, that's a different (larger) pattern this repo doesn't have today.

## Overlap with #260

Read `gh pr diff 260` first: it only **adds** `.github/workflows/converge-media-features.yml` (the rebuild-dispatch hop) and touches no role files — zero conflicting hunks. The workflow runs `--tags media_lxc_features`, which after this PR also covers the data-root prep; compatible, since the prep is a no-op until `zfs_pools` mounts the dataset.

## Validation

- `ansible-lint` (production profile): **Passed: 0 failure(s), 0 warning(s) on 75 files** — includes both touched roles, the molecule scenario, `site.yml`, and `pve2.yml`.
- Rendered `zfs-capacity-monitor.sh` passes `bash -n`.
- No real IPs/domains/secrets in committed content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)