### PR TITLE
chore(release): normalize release-please-config to canonical

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,14 +6,14 @@
       "version-file": "VERSION",
       "include-v-in-tag": true,
       "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance" },
-        { "type": "docs", "section": "Documentation", "hidden": true },
-        { "type": "chore", "section": "Miscellaneous", "hidden": true },
-        { "type": "refactor", "section": "Refactoring", "hidden": true },
-        { "type": "test", "section": "Tests", "hidden": true },
-        { "type": "ci", "section": "CI", "hidden": true }
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance"},
+        {"type": "docs", "section": "Documentation", "hidden": true},
+        {"type": "chore", "section": "Miscellaneous", "hidden": true},
+        {"type": "refactor", "section": "Refactoring", "hidden": true},
+        {"type": "test", "section": "Tests", "hidden": true},
+        {"type": "ci", "section": "CI", "hidden": true}
       ]
     }
   }


### PR DESCRIPTION
Whitespace-only alignment to the canonical `release-please-config.json` now in `dryvist/.github` (`configs/release-please-config.json`). Semantically identical — no behavior change. Part of the release-please standardization (Refs: dryvist/.github#27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)