### PR TITLE
feat(pve_repositories): ensure LXC CT templates present on every node

### DIFF
--- a/roles/pve_repositories/defaults/main.yml
+++ b/roles/pve_repositories/defaults/main.yml
@@ -15,3 +15,13 @@ pve_repositories_keyring: /usr/share/keyrings/proxmox-archive-keyring.gpg
 # caches packages and can reach upstream mirrors more reliably than each node.
 # Real value is injected per environment (see group_vars), never hardcoded here.
 pve_repositories_apt_proxy: ""
+
+# LXC (CT) appliance templates to ensure on `local` storage. OpenTofu creates
+# containers from `local:vztmpl/<template>`, so every node must have these
+# present or container creation fails on a fresh node. Each is downloaded only
+# when missing (see tasks/ct_templates.yml).
+#
+# Canonical source: terraform-proxmox deployment.json `proxmox_ct_template_debian`.
+# Keep this default in lockstep with that value when the base image is bumped.
+pve_repositories_ct_templates:
+  - debian-13-standard_13.1-2_amd64.tar.zst

--- a/roles/pve_repositories/tasks/ct_templates.yml
+++ b/roles/pve_repositories/tasks/ct_templates.yml
@@ -1,0 +1,47 @@
+---
+# Ensure the configured LXC (CT) templates are present on `local` storage so
+# OpenTofu container creation never fails with
+#   volume 'local:vztmpl/<template>' does not exist
+# on a freshly commissioned node. Idempotent: each template is checked with
+# `pveam list local` first and only downloaded when missing (no re-download,
+# no apt-style churn). Included from main.yml so it runs at node setup under
+# `hosts: proxmox` alongside the apt-repository management.
+
+- name: List CT templates already present on local storage
+  ansible.builtin.command:
+    cmd: pveam list local
+  register: pve_repositories_pveam_list
+  changed_when: false
+  check_mode: false
+  tags:
+    - pve_repositories
+    - ct_templates
+
+# `pveam update` refreshes the appliance index. Run it once, only when at least
+# one configured template is missing, so a fully-provisioned node stays a no-op.
+- name: Refresh the CT template appliance index when a template is missing
+  ansible.builtin.command:
+    cmd: pveam update
+  register: pve_repositories_pveam_update
+  changed_when: pve_repositories_pveam_update.rc == 0
+  when: >-
+    pve_repositories_ct_templates
+    | reject('in', pve_repositories_pveam_list.stdout)
+    | list | length > 0
+  tags:
+    - pve_repositories
+    - ct_templates
+
+# Download each missing template. The `when` guard keys off the same
+# `pveam list local` output, so a present template is skipped entirely and the
+# task reports ok (never changed) on a converged node.
+- name: Ensure each configured CT template is present on local storage
+  ansible.builtin.command:
+    cmd: "pveam download local {{ item }}"
+  loop: "{{ pve_repositories_ct_templates }}"
+  register: pve_repositories_pveam_download
+  changed_when: pve_repositories_pveam_download.rc == 0
+  when: item not in pve_repositories_pveam_list.stdout
+  tags:
+    - pve_repositories
+    - ct_templates

--- a/roles/pve_repositories/tasks/main.yml
+++ b/roles/pve_repositories/tasks/main.yml
@@ -77,3 +77,13 @@
   tags:
     - pve_repositories
     - repositories
+
+# Ensure the configured LXC (CT) templates are present on `local` storage so a
+# freshly commissioned node can have containers created by OpenTofu without a
+# manual `pveam download`. Gated on the same master switch as the repos above.
+- name: Ensure the configured CT templates are present
+  ansible.builtin.include_tasks: ct_templates.yml
+  when: pve_repositories_manage | bool
+  tags:
+    - pve_repositories
+    - ct_templates


### PR DESCRIPTION
## Problem

A freshly commissioned Proxmox node has no LXC template on `local` storage, so OpenTofu container creation fails with:

```
volume 'local:vztmpl/debian-13-standard_13.1-2_amd64.tar.zst' does not exist
```

until someone manually runs `pveam download local <template>` on the node. This was hit live while migrating the media stack to a second node.

## Change

The `pve_repositories` role already runs first under `hosts: proxmox` (so a fresh node is fully configurable from a single `site.yml` run) and owns node-setup of the Proxmox apt repositories. Extend it to idempotently ensure the configured CT templates are present on `local`:

- **`tasks/ct_templates.yml`** — `pveam list local` once, then `pveam update` + `pveam download local <template>` **only** for templates that are missing. A converged node is a no-op (`ok`, never `changed`); a present template is never re-downloaded.
- **default `pve_repositories_ct_templates`** — a list (looped), with a comment that the canonical source is the terraform-proxmox `deployment.json` `proxmox_ct_template_debian` value and this default must track it when the base image is bumped.
- Gated on the existing `pve_repositories_manage | bool` master switch.

## Validation

`ansible-lint` (profile: `production`) passes — 0 failures, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)