### PR TITLE
feat(media_lxc_features): map shared-data GID into unprivileged media LXCs

### DIFF
--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -22,6 +22,12 @@
 #   keyctl:     bool — ensure features contains keyctl=1, MERGED into existing
 #               features (tofu-set nesting=1 is preserved, never dropped)
 #   tun:        bool — passthrough /dev/net/tun (char 10:200) into the container
+#   data_idmap: bool — punch an LXC idmap so host GID 13000 (the shared `media`
+#               group that owns /bulk/data) maps 1:1 into the unprivileged
+#               container. Without it, host GID 13000 falls below the unpriv map
+#               base (100000) and /data appears as nobody:nogroup inside —
+#               read-only to the container's `media` user. Set on every service
+#               that bind-mounts /data (all but seerr, which has no mount).
 #
 # Only vmids that actually exist on the target host are acted on; absent vmids
 # are skipped (tofu may not have created them yet). All tasks are skipped
@@ -38,25 +44,30 @@ media_lxc_features_map:
       - { src: /bulk/data, dst: /data }
     keyctl: false
     tun: false
+    data_idmap: true
   seerr:  # request UI (Docker-in-LXC); no bind-mounts
     mounts: []
     keyctl: true
     tun: false
+    data_idmap: false
   sonarr:  # TV PVR
     mounts:
       - { src: /bulk/data, dst: /data }
     keyctl: false
     tun: false
+    data_idmap: true
   radarr:  # movie PVR
     mounts:
       - { src: /bulk/data, dst: /data }
     keyctl: false
     tun: false
+    data_idmap: true
   download-vpn:  # qBittorrent + Prowlarr behind Proton WireGuard
     mounts:
       - { src: /bulk/data, dst: /data }
     keyctl: true
     tun: true
+    data_idmap: true
 
 # Service -> VMID resolution, sourced from the tofu inventory and injected
 # onto proxmox hosts by playbooks/load_tofu.yml. Defaults to {} when unset
@@ -96,8 +107,31 @@ media_lxc_features_data_gid: 13000
 media_lxc_features_data_dir_mode: "2775"
 media_lxc_features_data_directories:
   - torrents
+  - torrents/incomplete
   - torrents/movies
   - torrents/tv
   - media
   - media/movies
   - media/tv
+
+# ---------------------------------------------------------------------------
+# Unprivileged-container GID passthrough for the shared data root
+# ---------------------------------------------------------------------------
+# An unprivileged LXC maps container UID/GID 0..65535 -> host 100000..165535 by
+# default, so host GID 13000 (which owns /bulk/data) lands on the overflow id
+# (nobody:nogroup) inside the container and the `media` user cannot write. These
+# lxc.idmap lines punch GID 13000 straight through (container 13000 -> host
+# 13000) while leaving every other id on the default offset, so /data shows up
+# as media:media and stays group-writable. The UID map is left at the default.
+# The host /etc/subgid must grant root the single-GID sub-range (added by the
+# role) or the container refuses to start.
+#
+# Derived from media_lxc_features_data_gid so a GID change needs no edit here.
+media_lxc_features_data_idmap_lines:
+  - "lxc.idmap: u 0 100000 65536"
+  - "lxc.idmap: g 0 100000 {{ media_lxc_features_data_gid | int }}"
+  - "lxc.idmap: g {{ media_lxc_features_data_gid | int }} {{ media_lxc_features_data_gid | int }} 1"
+  - >-
+    lxc.idmap: g {{ media_lxc_features_data_gid | int + 1 }}
+    {{ 100000 + (media_lxc_features_data_gid | int) + 1 }}
+    {{ 65536 - (media_lxc_features_data_gid | int) - 1 }}

--- a/roles/media_lxc_features/handlers/main.yml
+++ b/roles/media_lxc_features/handlers/main.yml
@@ -1,15 +1,24 @@
 ---
 # media_lxc_features handlers
 #
-# Bind-mount, feature, and device-passthrough changes only take effect after the
-# container is restarted. Tasks that mutate a container's config notify this
-# handler and append the vmid to `media_lxc_features_changed`. The handler
-# restarts ONLY those containers (running ones), so an already-converged host
-# performs zero restarts.
+# Bind-mount, feature, device-passthrough, and idmap changes only take effect
+# after the container is restarted. Tasks that mutate a container's config notify
+# this handler and append the vmid to `media_lxc_features_changed`. The handler
+# brings each changed container into a running state with the new config: a
+# running guest is rebooted (apply pending), a stopped guest is started — so a
+# config change applied while the guest happens to be down still lands. An
+# already-converged host notifies nothing and performs zero restarts.
 
 - name: Restart changed media containers
-  ansible.builtin.command:
-    cmd: "pct reboot {{ item }}"
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      if pct status {{ item }} | grep -q 'status: running'; then
+        pct reboot {{ item }}
+      else
+        pct start {{ item }}
+      fi
+    executable: /bin/bash
   loop: "{{ media_lxc_features_changed | default([]) | unique }}"
   loop_control:
     label: "container {{ item }}"

--- a/roles/media_lxc_features/tasks/configure_container.yml
+++ b/roles/media_lxc_features/tasks/configure_container.yml
@@ -137,3 +137,77 @@
   when: media_lxc_features_tun_set is defined and media_lxc_features_tun_set.changed
   tags:
     - media_lxc_features
+
+# ---------------------------------------------------------------------------
+# Shared-data GID idmap — raw LXC config lines in the .conf file
+# ---------------------------------------------------------------------------
+# Maps host GID 13000 (owner of /bulk/data) 1:1 into the unprivileged container
+# so the bind-mounted /data is writable by the in-container `media` user instead
+# of showing up as nobody:nogroup. `pct set` has no flag for idmap, so the lines
+# live directly in /etc/pve/lxc/<vmid>.conf.
+#
+# IMPORTANT: blockinfile is NOT usable here. Proxmox's pmxcfs rewrites the .conf
+# on every change — it relocates raw `lxc.*` keys to the end of the file and
+# strips comment markers — so the blockinfile markers vanish and a second run
+# re-appends the lines, duplicating `u 0 100000 65536` and making the container
+# refuse to start. Instead, compare the present idmap line-set to the desired
+# one and only rewrite (drop-all + re-add) on a difference; a converged host
+# makes no change and triggers no restart. Apply BEFORE the apps converge so the
+# rootfs remap is harmless (no app data yet).
+
+# One-time cleanup of the stale blockinfile markers left by the earlier
+# (withdrawn) implementation. Idempotent: a no-op once the comment lines are gone.
+- name: "Remove stale idmap blockinfile markers on {{ media_ct.key }}"
+  ansible.builtin.lineinfile:
+    path: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+    regexp: "ANSIBLE MANAGED BLOCK media_lxc_features data idmap"
+    state: absent
+  when: media_ct.value.data_idmap | default(false)
+  tags:
+    - media_lxc_features
+
+- name: "Read the LXC config to compare the idmap on {{ media_ct.key }}"
+  ansible.builtin.slurp:
+    src: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+  register: media_lxc_features_conf_raw
+  when: media_ct.value.data_idmap | default(false)
+  tags:
+    - media_lxc_features
+
+- name: "Compute the present idmap line-set on {{ media_ct.key }}"
+  ansible.builtin.set_fact:
+    media_lxc_features_cur_idmap: >-
+      {{
+        (media_lxc_features_conf_raw.content | b64decode).splitlines()
+        | map('trim') | select('match', '^lxc\.idmap:') | list
+      }}
+  when: media_ct.value.data_idmap | default(false)
+  tags:
+    - media_lxc_features
+
+- name: "Reconcile the shared-data idmap on {{ media_ct.key }}"
+  when:
+    - media_ct.value.data_idmap | default(false)
+    - (media_lxc_features_cur_idmap | sort)
+      != (media_lxc_features_data_idmap_lines | map('trim') | sort)
+  tags:
+    - media_lxc_features
+  block:
+    - name: "Drop any existing idmap lines on {{ media_ct.key }}"
+      ansible.builtin.lineinfile:
+        path: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+        regexp: '^lxc\.idmap:'
+        state: absent
+
+    - name: "Write the desired idmap lines on {{ media_ct.key }}"
+      ansible.builtin.lineinfile:
+        path: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+        line: "{{ item }}"
+        insertafter: EOF
+        state: present
+      loop: "{{ media_lxc_features_data_idmap_lines }}"
+      notify: Restart changed media containers
+
+    - name: "Record idmap change for container {{ media_ct.key }}"
+      ansible.builtin.set_fact:
+        media_lxc_features_changed: "{{ media_lxc_features_changed | default([]) + [media_ct.key] }}"

--- a/roles/media_lxc_features/tasks/main.yml
+++ b/roles/media_lxc_features/tasks/main.yml
@@ -68,6 +68,23 @@
   tags:
     - media_lxc_features
 
+# Grant root the single-GID sub-range so the data-root idmap (container GID
+# 13000 -> host GID 13000) is permitted. Without this line in /etc/subgid an
+# unprivileged container carrying the lxc.idmap lines refuses to start. The
+# default `root:100000:65536` grant stays untouched; this adds the punch-through.
+- name: Permit the shared-data GID in the host subgid map
+  ansible.builtin.lineinfile:
+    path: /etc/subgid
+    line: "root:{{ media_lxc_features_data_gid | int }}:1"
+    regexp: "^root:{{ media_lxc_features_data_gid | int }}:1$"
+    state: present
+    create: false
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - media_lxc_features_data_root_stat.stat.exists | default(false)
+  tags:
+    - media_lxc_features
+
 - name: Select the services that have a vmid in the tofu inventory
   ansible.builtin.set_fact:
     # Drop any service the inventory does not currently place (not yet created /


### PR DESCRIPTION
## Why

Unprivileged media containers bind-mount the host shared-data dataset (`/bulk/data`, owned `root:media` / gid 13000, group-writable + setgid) at `/data`. But the default unprivileged idmap offsets gid 13000 below the 100000 base, so inside the container `/data` shows up as `nobody:nogroup` and the in-container `media` user **cannot write** to it. The result: the *arr / qBittorrent imports — and the roles' "ensure directories" owner tasks — fail with `EPERM`, and the media app converge aborts.

## What

- Add a per-service `data_idmap` flag (true for every `/data`-mounted service; false for the request-UI service which has no mount). When set, the role writes `lxc.idmap` lines that punch container gid 13000 → host gid 13000 while leaving all other ids on the default offset, so `/data` appears as `media:media` and stays group-writable.
- Ensure the host `/etc/subgid` grants root the single-GID sub-range (`root:13000:1`), without which a container carrying the idmap refuses to start.
- Manage the idmap lines **idempotently by reconciliation**, not `blockinfile`: Proxmox's pmxcfs rewrites the container `.conf`, relocating raw `lxc.*` keys to the end and stripping comment markers — so `blockinfile` is not idempotent and re-adds duplicate `u 0 100000 65536` lines, which make the container fail to start. The role compares the present idmap line-set to the desired one and only rewrites (drop-all + re-add) on a difference, so a converged host makes no change and triggers no restart.
- Make the restart handler bring a changed container into a running state from **either** state (reboot if running, start if stopped) so a config change applied while the guest is down still lands.
- Add `torrents/incomplete` to the host-owned `/data` skeleton so the whole shared tree is created host-side with the shared group + setgid.

## Verification

- `ansible-lint` — passes, production profile, 0 failures.
- Applied live: all media containers start with a single clean idmap; `/data` is group `media` inside and the `media` user writes successfully; the reconcile is a no-op on re-run.

Related: #275 (eliminating enumerated per-node host vars — separate follow-up).