### PR TITLE
fix(media_lxc_features): reconcile TUN passthrough like idmap (pmxcfs-safe)

### DIFF
--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -85,6 +85,16 @@ media_lxc_features_service_vmids: >-
 media_lxc_features_tun_major: 10
 media_lxc_features_tun_minor: 200
 
+# Raw LXC config lines that pass /dev/net/tun through to the guest. `pct set` has
+# no flag for arbitrary device passthrough, so these live directly in
+# /etc/pve/lxc/<vmid>.conf. Reconciled the same drop-all/re-add way as the idmap
+# lines (see configure_container.yml) because pmxcfs relocates raw `lxc.*` keys
+# and strips comment markers, which makes a marker-guarded blockinfile re-append
+# duplicates on every run.
+media_lxc_features_tun_lines:
+  - "lxc.cgroup2.devices.allow: c {{ media_lxc_features_tun_major }}:{{ media_lxc_features_tun_minor }} rwm"
+  - "lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file"
+
 # ---------------------------------------------------------------------------
 # Shared media data root (host side of the bind-mount)
 # ---------------------------------------------------------------------------

--- a/roles/media_lxc_features/tasks/configure_container.yml
+++ b/roles/media_lxc_features/tasks/configure_container.yml
@@ -112,31 +112,86 @@
 # /dev/net/tun device passthrough — raw LXC config lines in the .conf file
 # ---------------------------------------------------------------------------
 # `pct set` has no flag for arbitrary device passthrough, so the standard method
-# is two raw lines appended to /etc/pve/lxc/<vmid>.conf:
+# is two raw lines in /etc/pve/lxc/<vmid>.conf:
 #   lxc.cgroup2.devices.allow: c 10:200 rwm
 #   lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
-# blockinfile is idempotent (marker-guarded) and reports changed only on edit.
+#
+# IMPORTANT: blockinfile is NOT usable here, for the same reason as the idmap
+# section below. Proxmox's pmxcfs rewrites the .conf on every change — it
+# relocates raw `lxc.*` keys to the end of the file and strips comment markers —
+# so the blockinfile markers vanish and a second run re-appends the lines,
+# duplicating the passthrough and eventually making the container refuse to
+# start. Instead, compare the present tun line-set to the desired one and only
+# rewrite (drop-all + re-add) on a difference; a converged host makes no change
+# and triggers no restart.
 
-- name: "Passthrough /dev/net/tun into container {{ media_ct.key }}"
-  ansible.builtin.blockinfile:
+# One-time cleanup of the stale blockinfile markers left by the earlier
+# (withdrawn) implementation. Idempotent: a no-op once the comment lines are gone.
+- name: "Remove stale tun blockinfile markers on {{ media_ct.key }}"
+  ansible.builtin.lineinfile:
     path: "/etc/pve/lxc/{{ media_ct.key }}.conf"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK media_lxc_features tun"
-    block: |
-      lxc.cgroup2.devices.allow: c {{ media_lxc_features_tun_major }}:{{ media_lxc_features_tun_minor }} rwm
-      lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
-    insertafter: EOF
+    regexp: "ANSIBLE MANAGED BLOCK media_lxc_features tun"
+    state: absent
   when: media_ct.value.tun | default(false)
-  notify: Restart changed media containers
-  register: media_lxc_features_tun_set
   tags:
     - media_lxc_features
 
-- name: "Record tun-passthrough change for container {{ media_ct.key }}"
-  ansible.builtin.set_fact:
-    media_lxc_features_changed: "{{ media_lxc_features_changed | default([]) + [media_ct.key] }}"
-  when: media_lxc_features_tun_set is defined and media_lxc_features_tun_set.changed
+- name: "Read the LXC config to compare the tun passthrough on {{ media_ct.key }}"
+  ansible.builtin.slurp:
+    src: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+  register: media_lxc_features_tun_conf_raw
+  when: media_ct.value.tun | default(false)
   tags:
     - media_lxc_features
+
+- name: "Compute the present tun line-set on {{ media_ct.key }}"
+  ansible.builtin.set_fact:
+    # Only the tun-specific passthrough lines: the cgroup allow for this
+    # major:minor and the /dev/net/tun mount entry. Other raw lines (idmap,
+    # unrelated mount entries) are left untouched.
+    media_lxc_features_cur_tun: >-
+      {{
+        (media_lxc_features_tun_conf_raw.content | b64decode).splitlines()
+        | map('trim')
+        | select('match', '^lxc\.cgroup2\.devices\.allow:\s*c ' ~ media_lxc_features_tun_major ~ ':' ~ media_lxc_features_tun_minor ~ ' |^lxc\.mount\.entry:\s*/dev/net/tun ')
+        | list
+      }}
+  when: media_ct.value.tun | default(false)
+  tags:
+    - media_lxc_features
+
+- name: "Reconcile the /dev/net/tun passthrough on {{ media_ct.key }}"
+  when:
+    - media_ct.value.tun | default(false)
+    - (media_lxc_features_cur_tun | sort)
+      != (media_lxc_features_tun_lines | map('trim') | sort)
+  tags:
+    - media_lxc_features
+  block:
+    - name: "Drop any existing tun cgroup-allow line on {{ media_ct.key }}"
+      ansible.builtin.lineinfile:
+        path: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+        regexp: '^lxc\.cgroup2\.devices\.allow:\s*c {{ media_lxc_features_tun_major }}:{{ media_lxc_features_tun_minor }} '
+        state: absent
+
+    - name: "Drop any existing tun mount-entry line on {{ media_ct.key }}"
+      ansible.builtin.lineinfile:
+        path: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+        regexp: '^lxc\.mount\.entry:\s*/dev/net/tun '
+        state: absent
+
+    - name: "Write the desired tun passthrough lines on {{ media_ct.key }}"
+      ansible.builtin.lineinfile:
+        path: "/etc/pve/lxc/{{ media_ct.key }}.conf"
+        line: "{{ item }}"
+        insertafter: EOF
+        state: present
+      loop: "{{ media_lxc_features_tun_lines }}"
+      notify: Restart changed media containers
+
+    - name: "Record tun-passthrough change for container {{ media_ct.key }}"
+      ansible.builtin.set_fact:
+        media_lxc_features_changed: "{{ media_lxc_features_changed | default([]) + [media_ct.key] }}"
 
 # ---------------------------------------------------------------------------
 # Shared-data GID idmap — raw LXC config lines in the .conf file


### PR DESCRIPTION
## Why

The `/dev/net/tun` passthrough in `roles/media_lxc_features/tasks/configure_container.yml` wrote its two raw `lxc.*` lines via `ansible.builtin.blockinfile`. That is unsafe against Proxmox pmxcfs behavior.

pmxcfs rewrites `/etc/pve/lxc/<vmid>.conf` on every change: it relocates raw `lxc.*` keys to the end of the file and **strips comment markers**. The blockinfile markers therefore vanish after the first apply, so on the next run blockinfile can't find its block and **re-appends** the two lines. The passthrough lines duplicate, and after enough re-runs the container refuses to start.

This is the identical failure mode that PR #276 fixed for the gid-13000 idmap, where blockinfile was replaced by a read-compare-reconcile pattern for exactly this reason. The TUN task was left on the old, broken approach — a latent bug.

## What

Mirror the idmap reconcile pattern for the TUN passthrough:

- Move the two desired lines into a derived defaults var `media_lxc_features_tun_lines`.
- One-time `lineinfile state=absent` cleanup to strip any stale blockinfile markers left behind.
- `slurp` the conf, compute the present tun line-set (scoped to the tun-specific cgroup-allow + `/dev/net/tun` mount-entry lines, leaving idmap and other lines untouched).
- Only reconcile (drop-all + re-add) when the present set differs from the desired set; notify the existing restart handler and record the vmid in `media_lxc_features_changed`.
- A converged host makes no change and triggers no restart. The `tun` gate and restart handler are unchanged.

## Validation

- `ansible-lint roles/media_lxc_features` — 0 failures, 0 warnings, production profile passed.
- No other role touched; `load_tofu.yml` untouched.

Assisted-by: Claude:claude-opus-4-8