### PR TITLE
feat(zfs_replication): opt-in syncoid-based standby replication to an intermittent node

### DIFF
--- a/docs/DR_RUNBOOK.md
+++ b/docs/DR_RUNBOOK.md
@@ -1,0 +1,129 @@
+# Disaster-Recovery Runbook — warm/hot standby on an intermittent node
+
+Operator runbook for the homelab resiliency program's standby model: a third
+node (`<target-node>`, e.g. `proxmox-3`) kept as a continuously-synced standby
+so it can take over service if a primary node is lost.
+
+> Placeholders only — no real IPs, domain, or node names. Substitute:
+> `proxmox-1` (always-on, infra + SIEM VM), `proxmox-2` (always-on, media on a
+> `bulk` ZFS pool), `<target-node>` (the intermittently-online standby).
+> `${PROXMOX_SUBDOMAIN}` is the internal subdomain (from Doppler).
+
+## 1. How replication works
+
+- Storage is **node-local ZFS** — no shared storage, no Ceph. Each node has its
+  own `bulk` pool; the standby holds empty replica datasets
+  (`bulk/replica/proxmox-1`, `bulk/replica/proxmox-2`) declared in
+  terraform-proxmox `node_storage`.
+- Replication uses **syncoid** (from the `sanoid` package), driven by the
+  `zfs_replication` role (and/or the existing `syncoid` role). syncoid ships ZFS
+  snapshots incrementally and **tolerates the target being offline**, unlike
+  Proxmox-native `pvesr`.
+- **Continuous when the standby is up, clean skip when it is down.** The
+  `zfs_replication` role probes the standby's reachability before each run. If
+  the standby is powered off — its normal steady state — the run is a no-op
+  (logged, never a failure). The moment the standby boots, the next timer tick
+  brings its replicas current.
+- The standby is powered on for maintenance/replication windows via IPMI
+  (`idrac_power`) and powers itself back off on a schedule (`node_auto_poweroff`)
+  so it is not left running overnight.
+
+## 2. Hot vs warm standby
+
+| Class | Examples | State on the standby | Runs when standby is up? |
+| --- | --- | --- | --- |
+| **Hot** (stateless) | DNS secondary, reverse proxy / Traefik | Config only; no single-writer data | **Yes** — can actively serve alongside the primary, no split-brain risk |
+| **Warm** (single-writer stateful) | Media stack, databases, the SIEM VM | Replicated data, guest **stopped** | **No** — started only during a failover cutover |
+
+The distinction exists to avoid **split-brain**: two copies of a single-writer
+service accepting writes at once corrupts state. Hot/stateless services have no
+authoritative single writer, so they can run on the standby continuously. Warm
+services must have exactly one writer, so the standby copy stays stopped until
+the primary is confirmed down.
+
+## 3. Checking replication freshness
+
+On the **source** node (where the `zfs_replication` role runs):
+
+```bash
+# Most recent replication log
+ls -t /var/log/zfs-replication/ | head -1
+tail -n 40 /var/log/zfs-replication/$(date +%Y-%m-%d).log
+
+# Timer status + next run
+systemctl status zfs-replication.timer
+systemctl list-timers zfs-replication.timer
+```
+
+On the **standby** (must be powered on to inspect):
+
+```bash
+# Newest snapshot per replicated dataset — the replication high-water mark
+zfs list -t snapshot -o name,creation -s creation bulk/replica/proxmox-2/data | tail
+zfs list -t snapshot -o name,creation -s creation bulk/replica/proxmox-1 | tail
+```
+
+Freshness = age of the newest snapshot on the standby. Expect it to be no older
+than the last window the standby was online. A large gap means the standby has
+been down (expected) or SSH trust / a source snapshot is missing (investigate).
+
+## 4. Failover cutover (primary lost)
+
+No load balancer — cutover is "start the warm guest on the standby + repoint DNS
+A records." Do this only after confirming the primary is genuinely down (avoid
+split-brain).
+
+1. **Confirm the primary is down.** Power state via IPMI; do not proceed if it is
+   merely unreachable on the network but still running.
+2. **Power on the standby** (IPMI / `idrac_power`) if it is off.
+3. **Final replica sync if the primary is briefly reachable** — otherwise the
+   standby serves from its last replicated snapshot:
+
+   ```bash
+   # On the source side, force a run now if the primary is momentarily up
+   /usr/local/bin/zfs-replicate.sh
+   ```
+
+4. **Promote the warm guest on the standby.** Clone/rollback the latest replica
+   snapshot into a runnable dataset, then start the guest (CT/VM):
+
+   ```bash
+   pct start <ctid>     # container
+   qm start <vmid>      # VM
+   ```
+
+5. **Repoint DNS.** Update the A record(s) for the affected service(s) to the
+   standby's address. Internal traffic resolves by name
+   (`<service>.${PROXMOX_SUBDOMAIN}`), so only the DNS A record changes — no
+   client reconfiguration.
+
+   ```bash
+   # Example: update the service A record in the DNS manager to the standby IP
+   # (Technitium / your DNS authority). TTLs should be low for fast cutover.
+   ```
+
+6. **Verify** the service answers on its name, then announce the cutover.
+
+## 5. Fail-back (primary restored)
+
+1. **Bring the primary back** and let it boot, but keep its warm guests
+   **stopped** — the standby is currently the single writer.
+2. **Reverse-replicate** the now-current data from the standby back to the
+   primary (a one-off syncoid run with source/target swapped), so the primary's
+   datasets catch up to the writes taken during the outage.
+3. **Quiesce on the standby**: stop the warm guest so there is again exactly one
+   writer.
+4. **Start the guest on the primary**, verify it is healthy and current.
+5. **Repoint DNS** A records back to the primary.
+6. **Resume normal replication** (primary → standby). Confirm the timer is
+   active and the first post-failback run succeeds.
+
+## 6. Guardrails
+
+- **Never run a warm guest on both nodes at once.** One writer, always.
+- **Replication is best-effort against an intermittent target** — a down standby
+  is a clean skip, not an alert. Alert only on the standby being *up* and
+  replication still failing.
+- **The replica is not a backup of last resort** — it tracks the source,
+  including accidental deletes. Point-in-time recovery comes from sanoid
+  snapshot retention (and, optionally, the `vzdump` leg), not from replication.

--- a/molecule/zfs_replication/converge.yml
+++ b/molecule/zfs_replication/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  # Default (inert) contract: empty jobs list, no target host. The role must
+  # converge as a clean no-op — wrapper + unit files still render under Docker
+  # (package install, daemon-reload, timer enable are guarded off), and the
+  # timer is NOT enabled because there are no jobs. Live syncoid behavior is
+  # validated on real hardware, not in molecule.
+  vars:
+    zfs_replication_jobs: []
+    zfs_replication_target_host: ""
+
+  roles:
+    - role: zfs_replication

--- a/molecule/zfs_replication/molecule.yml
+++ b/molecule/zfs_replication/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-zfs-replication-test
+    image: "${MOLECULE_IMAGE:-debian:stable-slim}"
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/zfs_replication/verify.yml
+++ b/molecule/zfs_replication/verify.yml
@@ -1,0 +1,41 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Read the rendered replication wrapper
+      ansible.builtin.slurp:
+        src: /usr/local/bin/zfs-replicate.sh
+      register: repl_wrapper
+
+    - name: Read the rendered service unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/zfs-replication.service
+      register: repl_service
+
+    - name: Read the rendered timer unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/zfs-replication.timer
+      register: repl_timer
+
+    - name: Assert the inert (no-op) contract rendered
+      ansible.builtin.assert:
+        that:
+          # Wrapper exists with the reachability gate and the no-target guard.
+          - "'clean skip' in (repl_wrapper.content | b64decode)"
+          - "'no target host configured' in (repl_wrapper.content | b64decode)"
+          # With an empty jobs list, no replicate calls were templated in.
+          - "'# job:' not in (repl_wrapper.content | b64decode)"
+          # systemd units rendered the expected contract.
+          - "'Type=oneshot' in (repl_service.content | b64decode)"
+          - "'/usr/local/bin/zfs-replicate.sh' in (repl_service.content | b64decode)"
+          - "'OnCalendar=*:0/15' in (repl_timer.content | b64decode)"
+          - "'WantedBy=timers.target' in (repl_timer.content | b64decode)"
+        fail_msg: "zfs_replication did not render the expected inert contract"
+
+    # The timer must NOT be active under the inert default. Converge succeeding
+    # (the enable task is guarded off by the empty jobs list + Docker skip)
+    # proves the no-op; the wrapper/unit assertions above prove the contract —
+    # mirroring the slurp-only sanoid / node_auto_poweroff verifiers.

--- a/roles/zfs_replication/README.md
+++ b/roles/zfs_replication/README.md
@@ -1,0 +1,120 @@
+# zfs_replication
+
+Opt-in, **reachability-gated** ZFS replication to an **intermittently-online
+standby node**, plus an optional `vzdump` guest-backup leg. Groundwork for the
+homelab resiliency program's warm/hot-standby host (see
+[`docs/DR_RUNBOOK.md`](../../docs/DR_RUNBOOK.md)).
+
+## Installation
+
+This role ships in the `ansible-proxmox` repository and is applied via
+`playbooks/site.yml`. No separate installation is required beyond cloning the
+repo and installing collection dependencies:
+
+```bash
+git clone https://github.com/dryvist/ansible-proxmox.git
+cd ansible-proxmox
+ansible-galaxy collection install -r requirements.yml
+```
+
+> Note: this role is **not yet referenced** in `playbooks/site.yml` — wiring it
+> in is a deliberate follow-up (see below).
+
+## Relationship to the `sanoid` / `syncoid` roles (read first)
+
+This repo already ships `sanoid` (snapshot retention, layer 1) and `syncoid`
+(cron-driven PULL replication, layer 2). This role is **additive groundwork, not
+a drop-in replacement**, and is **not yet wired into `playbooks/site.yml`**. It
+adds two things the existing roles do not:
+
+1. A **systemd-timer** schedule with an **explicit pre-flight reachability gate**
+   — a replication run against a powered-off standby is decided to be a clean
+   SKIP *before* `syncoid` is invoked, rather than relying on `syncoid` itself
+   failing-and-logging once the SSH connection times out.
+2. An optional **`vzdump`** backup leg.
+
+A maintainer should decide whether to **adopt this role** or **fold its additive
+pieces into the existing `syncoid` role**. Until that decision is made and the
+role is wired into `site.yml`, it is inert by default and changes nothing.
+
+## Model
+
+**PUSH from the source toward an intermittent standby** (e.g. `proxmox-3`). The
+standby is up or down at any time, independent of any failover. Whenever it is
+reachable, the configured datasets are replicated so the standby's copies are
+near-current the moment it boots. When it is down, every job is a clean skip —
+never a failure. `syncoid` (from the `sanoid` apt package) is used because it
+tolerates an offline target far more gracefully than Proxmox-native `pvesr`,
+which requires the target to be up.
+
+> The existing `syncoid` role uses a PULL model (run on the target, pull from
+> sources). This role uses PUSH (run on the source, gated on the target being
+> reachable) because the *source* is the always-on node here and the *target* is
+> the intermittent one — so the gate has to be evaluated by the always-on side.
+> This divergence is one of the things a maintainer should reconcile.
+
+## Inert by default
+
+`zfs_replication_jobs` is `[]` and `zfs_replication_target_host` is empty, so the
+role is a no-op until configured in `inventory/host_vars`. The systemd timer is
+only enabled when both a target host and at least one job are set; remove them
+and the role disables the timer again.
+
+## Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `zfs_replication_enabled` | `true` | Master enable for the role |
+| `zfs_replication_target_host` | `""` | Standby host to replicate toward. Set in host_vars; never hard-code a real node name |
+| `zfs_replication_jobs` | `[]` | List of replication jobs — **inert until set** |
+| `zfs_replication_reachability_probe` | `true` | Probe the target before replicating; skip cleanly if down |
+| `zfs_replication_probe_method` | `ssh` | `ssh` (TCP connect) or `ping` (ICMP) |
+| `zfs_replication_probe_port` / `zfs_replication_probe_timeout` | `22` / `10` | Probe port and per-probe timeout (s) |
+| `zfs_replication_default_options` | `--recursive --no-sync-snap --quiet` | syncoid options when a job omits its own |
+| `zfs_replication_timer_enabled` | `true` | Enable/start the systemd timer |
+| `zfs_replication_on_calendar` | `*:0/15` | Replication cadence (every 15 min) |
+| `zfs_replication_randomized_delay_sec` | `120` | Timer jitter so sources don't all hit the standby at once |
+| `zfs_replication_timer_persistent` | `false` | Do NOT catch up a missed trigger on boot |
+| `zfs_replication_vzdump_enabled` | `false` | Enable the optional vzdump backup leg |
+| `zfs_replication_vzdump_storage` | `<backup-storage-id>` | Proxmox storage id vzdump writes to |
+| `zfs_replication_vzdump_guests` | `[]` | vmids to back up — inert until set |
+| `zfs_replication_vzdump_on_calendar` | `*-*-* 01:30:00` | vzdump cadence |
+
+Each job in `zfs_replication_jobs`:
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `name` | yes | Human label, used in logs |
+| `source_dataset` | yes | Local source dataset (e.g. `bulk/data`) |
+| `target_dataset` | yes | Destination on the standby (e.g. `bulk/replica/proxmox-2/data`) |
+| `recursive` | no (`true`) | Replicate children |
+| `sync_snaps` | no (`false`) | Let syncoid make its own snapshots instead of shipping sanoid's |
+| `options` | no | Explicit syncoid option string; overrides `recursive`/`sync_snaps` |
+
+## Prerequisites (apply-time)
+
+- Root SSH trust from this (source) node to the standby — set up out of band
+  (the `cluster_ssh_trust` role / PVE cluster keys).
+- The destination parent datasets (`bulk/replica/<node>`) exist on the standby —
+  declared in terraform-proxmox `node_storage` and created by the `zfs_pools`
+  role; `syncoid` creates the per-dataset leaves.
+- A sanoid snapshot exists on each source (for `--no-sync-snap`).
+
+## Usage
+
+```yaml
+# inventory/host_vars/<always-on source node>.yml
+zfs_replication_target_host: "<target-node>"   # e.g. proxmox-3
+zfs_replication_jobs:
+  - name: media-data
+    source_dataset: "bulk/data"
+    target_dataset: "bulk/replica/proxmox-2/data"
+    recursive: true
+```
+
+```bash
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags zfs_replication
+```
+
+Package install, the systemd daemon-reload, and timer enablement are skipped
+under Docker so molecule can converge the contract in-container.

--- a/roles/zfs_replication/defaults/main.yml
+++ b/roles/zfs_replication/defaults/main.yml
@@ -1,0 +1,94 @@
+---
+# zfs_replication role defaults — opt-in, reachability-gated ZFS replication to
+# an intermittently-online standby node, plus an optional vzdump backup leg.
+#
+# RELATIONSHIP TO THE EXISTING sanoid/syncoid ROLES
+# -------------------------------------------------
+# This repo already ships `sanoid` (snapshot retention, layer 1) and `syncoid`
+# (cron-driven PULL replication, layer 2). This role is ADDITIVE groundwork, not
+# a replacement: it adds a systemd-timer schedule with an EXPLICIT pre-flight
+# target-reachability gate (so a job against a powered-off standby is a clean
+# SKIP, decided before syncoid is even invoked) and an optional vzdump leg.
+# It is NOT yet wired into playbooks/site.yml. A human should decide whether to
+# adopt this role or fold its additive pieces into the existing syncoid role —
+# see the role README and the PR body. Until then it is inert by default.
+#
+# Model: PUSH from the source toward an intermittent standby (e.g. proxmox-3).
+# Whenever the standby is reachable, configured datasets are replicated; when it
+# is down, every job is skipped cleanly (never a failure). syncoid (from the
+# `sanoid` apt package) is used because it tolerates an offline target far more
+# gracefully than Proxmox-native `pvesr`, which requires the target up.
+
+zfs_replication_enabled: true
+# `sanoid` provides both the sanoid and syncoid binaries.
+zfs_replication_package: sanoid
+zfs_replication_user: root
+zfs_replication_log_dir: /var/log/zfs-replication
+
+# --- Target standby node --------------------------------------------------
+# The standby host to replicate toward. Set this to the inventory hostname or
+# address of the standby in inventory/host_vars; NEVER hard-code a real node
+# name or IP in committed files. Empty by default keeps the role inert.
+#   zfs_replication_target_host: "<target-node>"   # e.g. proxmox-3
+zfs_replication_target_host: ""
+
+# Pre-flight reachability gate. Before any syncoid run the role probes the
+# target; if it does not answer within the timeout the whole replication run is
+# a clean SKIP (changed_when:false, no failure) with a debug message. This is
+# the "the standby may be down at any time" requirement.
+zfs_replication_reachability_probe: true
+# How to probe: "ping" (ICMP) or "ssh" (TCP connect to the SSH port). ssh is
+# the more meaningful check since syncoid replicates over SSH.
+zfs_replication_probe_method: ssh
+zfs_replication_probe_port: 22
+zfs_replication_probe_timeout: 10
+
+# --- syncoid options ------------------------------------------------------
+# Replicate the snapshots sanoid already took (--no-sync-snap), recurse the
+# tree, stay quiet for an unattended timer run.
+zfs_replication_default_options: "--recursive --no-sync-snap --quiet"
+
+# --- Replication jobs (EMPTY by default → role is a NO-OP) -----------------
+# Each job: { name, source_dataset, target_dataset, recursive?, sync_snaps?,
+#             options? }. `recursive`/`sync_snaps` are convenience toggles; an
+# explicit `options` string overrides them entirely.
+# Example (commented — keep the live list empty):
+#   zfs_replication_jobs:
+#     # Media library: bulk/data on the media node -> the standby's replica slot
+#     - name: media-data
+#       source_dataset: "bulk/data"
+#       target_dataset: "bulk/replica/proxmox-2/data"
+#       recursive: true
+#       sync_snaps: false
+#     # A pve1 service volume -> the standby's pve1 replica slot
+#     - name: service-volume
+#       source_dataset: "rpool/data/<service-volume>"
+#       target_dataset: "bulk/replica/proxmox-1/<service-volume>"
+#       recursive: false
+#       sync_snaps: false
+zfs_replication_jobs: []
+
+# --- systemd timer schedule -----------------------------------------------
+zfs_replication_timer_enabled: true
+# Frequent-but-sane cadence so the standby is near-current the moment it boots.
+# OnCalendar fires every 15 minutes by default; override per host if needed.
+zfs_replication_on_calendar: "*:0/15"
+# Add jitter so multiple sources do not all hammer the standby at once.
+zfs_replication_randomized_delay_sec: 120
+# Persistent=false: do NOT catch up a missed trigger after a long downtime; the
+# next scheduled tick handles it, avoiding a thundering replication on boot.
+zfs_replication_timer_persistent: false
+
+# --- Optional vzdump backup leg (separate, also off by default) -----------
+# Schedules `vzdump` of named guests to a backup storage. Independent of the
+# syncoid replication above. Disabled until explicitly enabled AND given guests.
+zfs_replication_vzdump_enabled: false
+# Proxmox storage id that vzdump writes to (must already exist on the node and
+# be backed by a dataset such as bulk/backups). No real id committed.
+zfs_replication_vzdump_storage: "<backup-storage-id>"
+zfs_replication_vzdump_mode: snapshot
+zfs_replication_vzdump_compress: zstd
+# vmid list of guests to back up (CT or VM ids). Empty → the vzdump leg no-ops.
+zfs_replication_vzdump_guests: []
+zfs_replication_vzdump_on_calendar: "*-*-* 01:30:00"
+zfs_replication_vzdump_extra_options: ""

--- a/roles/zfs_replication/handlers/main.yml
+++ b/roles/zfs_replication/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Reload systemd so it picks up freshly written unit files. Skipped under Docker
+# (molecule), where systemd is not PID 1.
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/zfs_replication/meta/main.yml
+++ b/roles/zfs_replication/meta/main.yml
@@ -1,0 +1,27 @@
+---
+# zfs_replication role metadata
+
+galaxy_info:
+  role_name: zfs_replication
+  author: ansible-proxmox
+  description: >-
+    Opt-in, reachability-gated ZFS replication (syncoid) to an intermittently
+    online standby node, plus an optional vzdump backup leg.
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - proxmox
+    - zfs
+    - replication
+    - syncoid
+    - backup
+    - disasterrecovery
+
+dependencies: []

--- a/roles/zfs_replication/tasks/main.yml
+++ b/roles/zfs_replication/tasks/main.yml
@@ -1,0 +1,109 @@
+---
+# zfs_replication tasks — install syncoid, render the reachability-gated
+# replication wrapper, schedule it via a systemd timer, and (optionally)
+# schedule vzdump backups. Package install, daemon-reload, and timer enablement
+# are skipped under Docker (molecule) where systemd is not PID 1; the templated
+# wrapper and unit files still render so the contract is verifiable in-container.
+
+- name: Install sanoid (provides syncoid)
+  ansible.builtin.apt:
+    name: "{{ zfs_replication_package }}"
+    state: present
+    update_cache: true
+  when:
+    - zfs_replication_enabled | bool
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - zfs_replication
+
+- name: Ensure the replication log directory exists
+  ansible.builtin.file:
+    path: "{{ zfs_replication_log_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: zfs_replication_enabled | bool
+  tags:
+    - zfs_replication
+
+- name: Deploy the reachability-gated replication wrapper
+  ansible.builtin.template:
+    src: zfs-replicate.sh.j2
+    dest: /usr/local/bin/zfs-replicate.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when: zfs_replication_enabled | bool
+  tags:
+    - zfs_replication
+
+- name: Render the replication service unit
+  ansible.builtin.template:
+    src: zfs-replication.service.j2
+    dest: /etc/systemd/system/zfs-replication.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: zfs_replication_enabled | bool
+  notify: Reload systemd daemon
+  tags:
+    - zfs_replication
+
+- name: Render the replication timer unit
+  ansible.builtin.template:
+    src: zfs-replication.timer.j2
+    dest: /etc/systemd/system/zfs-replication.timer
+    owner: root
+    group: root
+    mode: "0644"
+  when: zfs_replication_enabled | bool
+  notify: Reload systemd daemon
+  tags:
+    - zfs_replication
+
+# Apply any pending daemon-reload now so the timer below enables against the
+# freshly written unit (handlers otherwise run only at end of play).
+- name: Reload systemd before enabling the timer
+  ansible.builtin.meta: flush_handlers
+
+# Enable the timer only when there is something to replicate AND a target is
+# set. An empty job list or an unset target keeps the role a clean no-op.
+- name: Enable and start the replication timer
+  ansible.builtin.systemd:
+    name: zfs-replication.timer
+    enabled: true
+    state: started
+  when:
+    - zfs_replication_enabled | bool
+    - zfs_replication_timer_enabled | bool
+    - zfs_replication_jobs | length > 0
+    - zfs_replication_target_host | length > 0
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - zfs_replication
+
+# Stop/disable the timer if the role is enabled but there is nothing to do, so a
+# previously-configured node returns cleanly to inert when its jobs are removed.
+- name: Disable the replication timer when no jobs/target are configured
+  ansible.builtin.systemd:
+    name: zfs-replication.timer
+    enabled: false
+    state: stopped
+  when:
+    - zfs_replication_enabled | bool
+    - (zfs_replication_jobs | length == 0) or (zfs_replication_target_host | length == 0)
+    - ansible_virtualization_type | default('') != 'docker'
+  failed_when: false
+  changed_when: false
+  tags:
+    - zfs_replication
+
+- name: Schedule optional vzdump guest backups
+  ansible.builtin.include_tasks: vzdump.yml
+  when:
+    - zfs_replication_enabled | bool
+    - zfs_replication_vzdump_enabled | bool
+  tags:
+    - zfs_replication
+    - zfs_replication_vzdump

--- a/roles/zfs_replication/tasks/vzdump.yml
+++ b/roles/zfs_replication/tasks/vzdump.yml
@@ -1,0 +1,51 @@
+---
+# Optional vzdump backup leg — schedule periodic vzdump of named guests to a
+# backup storage. Independent of the syncoid replication. Inert unless
+# zfs_replication_vzdump_enabled is true AND guests are listed; the timer below
+# only enables when there is at least one guest to back up.
+
+- name: Render the vzdump backup wrapper
+  ansible.builtin.template:
+    src: zfs-replication-vzdump.sh.j2
+    dest: /usr/local/bin/zfs-replication-vzdump.sh
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - zfs_replication_vzdump
+
+- name: Render the vzdump service unit
+  ansible.builtin.template:
+    src: zfs-replication-vzdump.service.j2
+    dest: /etc/systemd/system/zfs-replication-vzdump.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd daemon
+  tags:
+    - zfs_replication_vzdump
+
+- name: Render the vzdump timer unit
+  ansible.builtin.template:
+    src: zfs-replication-vzdump.timer.j2
+    dest: /etc/systemd/system/zfs-replication-vzdump.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd daemon
+  tags:
+    - zfs_replication_vzdump
+
+- name: Reload systemd before enabling the vzdump timer
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start the vzdump timer
+  ansible.builtin.systemd:
+    name: zfs-replication-vzdump.timer
+    enabled: true
+    state: started
+  when:
+    - zfs_replication_vzdump_guests | length > 0
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - zfs_replication_vzdump

--- a/roles/zfs_replication/templates/zfs-replicate.sh.j2
+++ b/roles/zfs_replication/templates/zfs-replicate.sh.j2
@@ -1,0 +1,68 @@
+#!/bin/bash
+{{ ansible_managed | comment }}
+# Reachability-gated ZFS replication to an intermittently-online standby node.
+#
+# Behaviour: probe the target first. If it is unreachable (the standby is
+# powered off — the expected steady state), exit 0 immediately as a CLEAN SKIP
+# — replication is best-effort and a down standby is never an error. If it is
+# reachable, run syncoid for each configured job, logging per job; a single
+# failed job does NOT abort the rest.
+set -uo pipefail
+
+TARGET_HOST="{{ zfs_replication_target_host }}"
+PROBE="{{ zfs_replication_probe_method }}"
+PROBE_PORT="{{ zfs_replication_probe_port }}"
+PROBE_TIMEOUT="{{ zfs_replication_probe_timeout }}"
+PROBE_ENABLED="{{ zfs_replication_reachability_probe | bool | lower }}"
+LOG_DIR="{{ zfs_replication_log_dir }}"
+
+mkdir -p "$LOG_DIR"
+log="$LOG_DIR/$(date +%Y-%m-%d).log"
+say() { echo "$(date +%H:%M:%S) $*" >>"$log"; }
+
+if [ -z "$TARGET_HOST" ]; then
+  say "no target host configured; nothing to do"
+  exit 0
+fi
+
+target_reachable() {
+  case "$PROBE" in
+    ping)
+      ping -c1 -W"$PROBE_TIMEOUT" "$TARGET_HOST" >/dev/null 2>&1
+      ;;
+    ssh|*)
+      # TCP connect to the SSH port — the path syncoid actually uses. bash's
+      # /dev/tcp avoids needing nc; `timeout` bounds a hung connect.
+      timeout "$PROBE_TIMEOUT" bash -c \
+        "exec 3<>/dev/tcp/$TARGET_HOST/$PROBE_PORT" >/dev/null 2>&1
+      ;;
+  esac
+}
+
+if [ "$PROBE_ENABLED" = "true" ]; then
+  if ! target_reachable; then
+    say "standby $TARGET_HOST unreachable via $PROBE — clean skip"
+    exit 0
+  fi
+  say "standby $TARGET_HOST reachable via $PROBE — replicating"
+fi
+
+replicate() {
+  say "=== syncoid $* ==="
+  local rc=0
+  syncoid "$@" >>"$log" 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] && say "  FAILED (rc=$rc)"
+  return 0
+}
+
+{% for job in zfs_replication_jobs %}
+{%   if job.options is defined %}
+{%     set opts = job.options %}
+{%   else %}
+{%     set _recursive = '--recursive' if (job.recursive | default(true)) else '' %}
+{%     set _snaps = '' if (job.sync_snaps | default(false)) else '--no-sync-snap' %}
+{%     set opts = (_recursive ~ ' ' ~ _snaps ~ ' --quiet') | trim %}
+{%   endif %}
+# job: {{ job.name }} — PUSH local source -> standby target
+replicate {{ opts }} {{ job.source_dataset }} {{ zfs_replication_user }}@"$TARGET_HOST":{{ job.target_dataset }}
+{% endfor %}

--- a/roles/zfs_replication/templates/zfs-replication-vzdump.service.j2
+++ b/roles/zfs_replication/templates/zfs-replication-vzdump.service.j2
@@ -1,0 +1,10 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Scheduled vzdump guest backups (zfs_replication)
+Documentation=ansible role zfs_replication
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/zfs-replication-vzdump.sh
+Nice=10
+IOSchedulingClass=idle

--- a/roles/zfs_replication/templates/zfs-replication-vzdump.sh.j2
+++ b/roles/zfs_replication/templates/zfs-replication-vzdump.sh.j2
@@ -1,0 +1,28 @@
+#!/bin/bash
+{{ ansible_managed | comment }}
+# Optional vzdump backup of named guests to a backup storage. Per-guest logging;
+# a single failed guest does NOT abort the rest.
+set -uo pipefail
+
+LOG_DIR="{{ zfs_replication_log_dir }}"
+STORAGE="{{ zfs_replication_vzdump_storage }}"
+mkdir -p "$LOG_DIR"
+log="$LOG_DIR/vzdump-$(date +%Y-%m-%d).log"
+say() { echo "$(date +%H:%M:%S) $*" >>"$log"; }
+
+backup() {
+  local vmid="$1"
+  say "=== vzdump $vmid ==="
+  local rc=0
+  vzdump "$vmid" \
+    --storage "$STORAGE" \
+    --mode {{ zfs_replication_vzdump_mode }} \
+    --compress {{ zfs_replication_vzdump_compress }} \
+    {{ zfs_replication_vzdump_extra_options }} >>"$log" 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] && say "  FAILED (rc=$rc)"
+  return 0
+}
+
+{% for vmid in zfs_replication_vzdump_guests %}
+backup {{ vmid }}
+{% endfor %}

--- a/roles/zfs_replication/templates/zfs-replication-vzdump.timer.j2
+++ b/roles/zfs_replication/templates/zfs-replication-vzdump.timer.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Periodic vzdump guest backups (zfs_replication)
+Documentation=ansible role zfs_replication
+
+[Timer]
+OnCalendar={{ zfs_replication_vzdump_on_calendar }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/zfs_replication/templates/zfs-replication.service.j2
+++ b/roles/zfs_replication/templates/zfs-replication.service.j2
@@ -1,0 +1,15 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Reachability-gated ZFS replication to the standby node
+Documentation=ansible role zfs_replication
+# Best-effort: the wrapper self-skips when the standby is offline.
+After=network-online.target zfs.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/zfs-replicate.sh
+# A skip (standby down) and per-job logging both exit 0; only a wrapper crash
+# surfaces as a failed unit.
+Nice=10
+IOSchedulingClass=idle

--- a/roles/zfs_replication/templates/zfs-replication.timer.j2
+++ b/roles/zfs_replication/templates/zfs-replication.timer.j2
@@ -1,0 +1,15 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Periodic ZFS replication to the standby node
+Documentation=ansible role zfs_replication
+
+[Timer]
+OnCalendar={{ zfs_replication_on_calendar }}
+RandomizedDelaySec={{ zfs_replication_randomized_delay_sec }}
+# Persistent={{ zfs_replication_timer_persistent | bool | lower }}: when false,
+# a missed trigger (host or standby was down) is NOT caught up on boot; the next
+# scheduled tick handles it, avoiding a thundering replication right after boot.
+Persistent={{ zfs_replication_timer_persistent | bool | lower }}
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

Adds a new, **inert-by-default** `roles/zfs_replication` role plus a new
`docs/DR_RUNBOOK.md`, as groundwork (Phase 3) for the homelab resiliency
program's **warm/hot standby host** on an intermittently-online node.

**New files only.** Nothing existing is modified — no `playbooks/site.yml`, no
`load_tofu.yml`, no existing role. The role is **not yet wired into `site.yml`**;
that is a deliberate follow-up so this PR is safe to review and merge without
changing any live behavior.

## The model: warm/hot standby on an intermittent node

A third node (a Dell R710, here `<target-node>`) is kept as a continuously-synced
standby. It is **up or down at any time**, independent of any failover.

- Storage is **node-local ZFS** — no shared storage, no Ceph. The standby holds
  empty `bulk/replica/<node>` datasets (declared in terraform-proxmox
  `node_storage`).
- Replication uses **syncoid** (from the `sanoid` package), which tolerates an
  offline target — unlike Proxmox-native `pvesr`, which requires the target up.
- **Continuous when the standby is up, clean SKIP when it is down.** Before each
  run the role probes target reachability (ssh TCP-connect or ping); if the
  standby is off — its normal steady state — the run is a logged no-op, never a
  failure. The moment it boots, the next timer tick brings its replicas current.
- **Hot** (stateless: DNS secondary, Traefik) services can serve while the
  standby is up; **warm** (single-writer: media, DBs, the SIEM VM) guests stay
  stopped until a failover cutover, to avoid split-brain. The runbook covers the
  cutover (start warm guest + repoint DNS A records — no load balancer) and
  fail-back.

## Role interface (main vars)

| Variable | Default | Purpose |
| --- | --- | --- |
| `zfs_replication_jobs` | `[]` | Replication jobs — **inert until set** |
| `zfs_replication_target_host` | `""` | Standby host (set in host_vars; no real node name committed) |
| `zfs_replication_reachability_probe` / `_probe_method` | `true` / `ssh` | Pre-flight gate so a down standby is a clean skip |
| `zfs_replication_on_calendar` | `*:0/15` | systemd-timer cadence (15 min), with jitter + `Persistent=false` |
| `zfs_replication_default_options` | `--recursive --no-sync-snap --quiet` | syncoid options |
| `zfs_replication_vzdump_enabled` / `_vzdump_guests` | `false` / `[]` | Optional, separately-gated vzdump backup leg |

Each job: `{ name, source_dataset, target_dataset, recursive?, sync_snaps?, options? }`.

## INERT by default

`zfs_replication_jobs` is empty and `zfs_replication_target_host` is unset, so
the role converges as a complete no-op: wrapper + systemd units render (so the
contract is testable), but the timer is not enabled. Configure jobs + a target in
`inventory/host_vars` to activate.

## Needs human review before enabling

This is **groundwork for review**, not a finished production switch:

1. **Overlap with the existing `sanoid` + `syncoid` roles.** The repo already has
   `sanoid` (snapshot retention) and `syncoid` (cron-driven **PULL** replication,
   already used with pve3 as a DR target). This role is **additive** — it adds an
   explicit pre-flight reachability gate, a **systemd timer** (vs cron), and a
   **vzdump** leg — but a maintainer should decide whether to **adopt it** or
   **fold those additive pieces into `syncoid`** rather than carry two roles.
2. **PUSH vs PULL.** This role PUSHes from the always-on source (so the
   always-on side evaluates the reachability gate); the existing `syncoid` role
   PULLs from the target. That divergence is intentional for the
   "source is always-on, target is intermittent" case but should be reconciled.
3. **Not in CI molecule yet.** CI runs molecule scenarios by explicit name in
   `.github/workflows/molecule.yml`; since this PR touches no existing files, the
   new `molecule/zfs_replication` scenario is **locally runnable but not auto-run
   in CI**. Wiring it into the workflow is part of the same follow-up that wires
   the role into `site.yml`.
4. **Live validation pending.** syncoid behavior (SSH trust, snapshot presence,
   real replication) must be validated on hardware before enabling — not done
   here (no creds; role is inert anyway).

## Validation

- `ansible-lint roles/zfs_replication` and `ansible-lint molecule/zfs_replication`
  → **0 failures, 0 warnings, production profile**.
- `yamllint` clean; rendered wrappers pass `bash -n` and `shellcheck -S warning`.
- No real IPs / internal domain / node names in any committed file (placeholders
  `proxmox-1/2`, `<target-node>`, `${PROXMOX_SUBDOMAIN}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)