### PR TITLE
docs(agents): note --limit must include localhost for the inventory loader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,13 @@ configured by `ansible-proxmox-apps` and `ansible-splunk`.
 doppler run -- ansible-playbook playbooks/site.yml
 ```
 
+> **`--limit` must include `localhost`.** The inventory loader
+> (`inventory/load_tofu.yml`) runs on `hosts: localhost` and populates the
+> dynamic inventory via `add_host`. Running with `--limit <group>` but **not**
+> `localhost` silently skips the loader, so no hosts are added and every play
+> reports "no hosts matched". Use `--limit <group>,localhost`, or invoke via
+> `scripts/run-ansible.sh`, which appends `localhost` automatically.
+
 ### Common Operations
 
 - **Kernel tuning**: Updates sysctl parameters


### PR DESCRIPTION
The inventory loader (`inventory/load_tofu.yml`) runs on `hosts: localhost` and builds the dynamic inventory via `add_host`. A `--limit <group>` without `localhost` silently skips it → "no hosts matched" everywhere (a silent no-op that cost debugging time).

**Doc-only.** An earlier revision of this PR mangled `--limit` args in `run-ansible.sh`; that was scripting around a tool gap and has been reverted. The right call is to document the invariant (include `localhost`, or scope with `--tags`) — and, properly, to convert the `add_host` loader into a native Ansible dynamic inventory so `--limit` works natively (tracked in a separate issue). Companion: dryvist/ansible-proxmox-apps#426.