### PR TITLE
ci: adopt the shared _ansible-ci.yml thin wrapper

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,26 +1,11 @@
 ---
-# CI Gate - Conditional Required Checks
+# CI Gate — thin wrapper around the shared ansible CI gate.
 #
-# FRAMEWORK: Merge Gatekeeper Pattern
-# ====================================
-# Solves: "Required checks that only run when relevant files change"
-#
-# Problem: GitHub branch protection only supports "always required" or "not required"
-#          Path-filtered workflows that don't run = pending forever = blocks merge
-#
-# Solution: Single workflow that:
-# 1. Always triggers on ALL PRs (no path filters at workflow level)
-# 2. Detects which file categories changed
-# 3. Calls reusable workflows conditionally (skipped = success)
-# 4. Final "Merge Gate" job aggregates all results
-#
-# Branch Protection: Set ONLY "Merge Gate" as required check
-#
-# Adding New Checks:
-# 1. Create reusable workflow: _your-check.yml with `on: workflow_call`
-# 2. Add filter pattern under `changes.steps.filter.with.filters`
-# 3. Add job that calls the reusable workflow with appropriate `if:` condition
-# 4. Add job name to `gate.needs` array and `allowed-skips`
+# All of the lint + molecule + Merge Gate logic lives in
+# dryvist/.github/.github/workflows/_ansible-ci.yml. This repo uses the defaults:
+# ansible-lint over the whole project, the `default` molecule scenario, and
+# molecule deps from requirements-ci.txt. Branch protection requires only the
+# "Merge Gate" check the shared workflow emits.
 
 name: CI Gate
 
@@ -37,84 +22,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  # ==========================================================================
-  # CHANGE DETECTION
-  # ==========================================================================
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
+  ci:
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      ansible: ${{ steps.filter.outputs.ansible }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            ansible:
-              - '**.yml'
-              - '**.yaml'
-              - '**.j2'
-              - 'roles/**'
-              - 'playbooks/**'
-              - 'inventory/**'
-              - 'molecule/**'
-              - '.ansible-lint'
-              - 'requirements.yml'
-
-  # ==========================================================================
-  # CONDITIONAL CHECKS (inline jobs)
-  # ==========================================================================
-  lint:
-    name: Ansible Lint
-    needs: changes
-    if: needs.changes.outputs.ansible == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run ansible-lint
-        uses: ansible/ansible-lint@v26
-
-  molecule:
-    name: Molecule Test
-    needs: changes
-    if: needs.changes.outputs.ansible == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements-ci.txt
-      - name: Install Ansible collections
-        run: ansible-galaxy collection install -r requirements.yml
-      - name: Run molecule test
-        run: molecule test
-        env:
-          ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"
-          PY_COLORS: "1"
-          ANSIBLE_FORCE_COLOR: "1"
-
-  # ==========================================================================
-  # MERGE GATE - The ONLY required check in branch protection
-  # ==========================================================================
-  gate:
-    name: Merge Gate
-    needs: [changes, lint, molecule]
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check all results
-        uses: re-actors/alls-green@release/v1
-        with:
-          allowed-skips: lint, molecule
-          jobs: ${{ toJSON(needs) }}
+    uses: dryvist/.github/.github/workflows/_ansible-ci.yml@main


### PR DESCRIPTION
Replaces the inline CI gate with a thin wrapper around `dryvist/.github/.github/workflows/_ansible-ci.yml` (lint + molecule + Merge Gate via off-the-shelf actions, no scripts). Uses defaults: whole-project ansible-lint, default molecule scenario, deps from requirements-ci.txt. Required check stays `Merge Gate`. First adopter — validates the shared workflow end-to-end.