### PR TITLE
fix(syncoid): set PATH so cron finds syncoid (silent replication outage)

### DIFF
--- a/roles/syncoid/templates/syncoid-replicate.sh.j2
+++ b/roles/syncoid/templates/syncoid-replicate.sh.j2
@@ -4,6 +4,14 @@
 # failed job (e.g. source offline) is logged and does NOT abort the rest.
 set -uo pipefail
 
+# syncoid/sanoid install to /usr/sbin on Debian, which is NOT on cron's default
+# PATH (/usr/bin:/bin). Without this, the scheduled run dies with
+# "syncoid: command not found" (rc=127) on every job — and because replicate()
+# logs the failure but keeps going, the script still exits 0, so the breakage is
+# silent. Pin a complete PATH so cron resolves the binary the same way an
+# interactive shell does.
+export PATH="/usr/sbin:/sbin:/usr/bin:/bin${PATH:+:$PATH}"
+
 LOG_DIR="{{ syncoid_log_dir }}"
 mkdir -p "$LOG_DIR"
 log="$LOG_DIR/$(date +%Y-%m-%d).log"


### PR DESCRIPTION
## Problem
ZFS replication via the `syncoid` role has been **silently failing every day**. The cron wrapper `/usr/local/bin/syncoid-replicate.sh` calls `syncoid` by bare name and never sets `PATH`. Under cron's minimal `PATH` (`/usr/bin:/bin`), the binary — installed at `/usr/sbin/syncoid` on Debian — isn't found:

```
=== 02:17:01 syncoid --recursive --no-sync-snap --quiet root@pve1:rpool/data/vm-200-disk-0 ... ===
/usr/local/bin/syncoid-replicate.sh: line 14: syncoid: command not found
  FAILED (rc=127)
```

Because `replicate()` logs the failure but keeps going, the script still **exits 0**, so nothing surfaced the outage. On the live cluster, pve2's replica of pve1 (Splunk `vm-200`) has been frozen since **~2026-06-07** while local sanoid snapshots kept advancing.

## Fix
Pin an explicit `PATH` (`/usr/sbin:/sbin:/usr/bin:/bin:$PATH`) at the top of the wrapper template so the scheduled run resolves `syncoid` the same way an interactive shell does. Minimal, no behavior change beyond fixing resolution.

## After merge
Converge the `syncoid` role on the backup nodes (pve2, and pve3 when up) to redeploy the wrapper, then the 02:17 cron resumes pulling. A manual seed run can be triggered immediately via the role's opt-in 'run now' task or `playbooks/site.yml`.

## Noted (out of scope)
The wrapper's silent `exit 0` on total failure is *why* this went unnoticed for ~10 days. A 'fail loud' exit code is worth a follow-up, but needs to respect the role's deliberate tolerance of an offline source (the intermittent pve3 DR leg) — left out of this surgical fix.

## Verification
- Root cause confirmed live (cron log rc=127; `which syncoid` → /usr/sbin/syncoid not on cron PATH).
- Template change only; pre-commit (gitleaks/lint) green locally.
