### PR TITLE
fix(media): update plex molecule assertion for the appdata mount

### DIFF
--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -32,13 +32,16 @@
           - "'725140' not in media_lxc_features_map"
         fail_msg: "media_lxc_features_map must be keyed by service name, not vmid"
 
-    - name: Assert plex gets the single unified data mount, read-write
+    - name: Assert plex gets the unified data mount plus its persistent appdata mount
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['plex'].mounts | length == 1
+          - media_lxc_features_map['plex'].mounts | length == 2
           - media_lxc_features_map['plex'].mounts[0].src == '/bulk/data'
           - media_lxc_features_map['plex'].mounts[0].dst == '/data'
           - not (media_lxc_features_map['plex'].mounts[0].ro | default(false))
+          - media_lxc_features_map['plex'].mounts[1].src == '/bulk/appdata/plex'
+          - media_lxc_features_map['plex'].mounts[1].dst == '/var/lib/plexmediaserver'
+          - media_lxc_features_map['plex'].mounts[1].owner_user == 'plex'
           - not (media_lxc_features_map['plex'].keyctl | bool)
           - not (media_lxc_features_map['plex'].tun | bool)
         fail_msg: "plex feature contract did not resolve as expected"


### PR DESCRIPTION
## Problem

`media_lxc_features` Molecule **verify** is red on `main`: it asserts plex has a single bind-mount, but the role default now gives plex **two** mounts — the unified `/bulk/data`→`/data` plus the persistent `/bulk/appdata/plex`→`/var/lib/plexmediaserver` appdata mount (added for Plex identity/history persistence). Main's Molecule gate has been failing since that mount merged.

```
[ERROR] plex feature contract did not resolve as expected
assertion: media_lxc_features_map['plex'].mounts | length == 1
```

## Fix

Update the verify assertion to expect both mounts (data + appdata) so the test matches the role's actual, intended contract. Role code is correct and unchanged; only the stale test is updated. sonarr/radarr/download-vpn (1 mount each) and seerr (0) assertions are still accurate and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)