### PR TITLE
feat(backup): protect object-storage data volume via sanoid+syncoid

### DIFF
--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -16,3 +16,12 @@ sanoid_datasets:
     use_template: critical
   "rpool/data/vm-200-disk-2":
     use_template: critical
+  # Object-storage (RustFS) data volume — the `splunk-addons` bucket (Splunkbase
+  # app tarballs + manifest). subvol-202000-disk-1 is the 100G mp0 (/srv/object-
+  # storage); disk-0 is the 8G rootfs, Ansible-reproducible, so not snapshotted.
+  # The bucket itself has object-versioning on, so this layer is volume-level DR
+  # (corruption / ransomware / fat-finger rm), not app-version history. The
+  # `database` template = daily cadence + long tail (monthly12 / yearly3); the
+  # store changes ~weekly, so hourly snapshots would be pure churn.
+  "rpool/data/subvol-202000-disk-1":
+    use_template: database

--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -25,3 +25,10 @@ sanoid_datasets:
   # store changes ~weekly, so hourly snapshots would be pure churn.
   "rpool/data/subvol-202000-disk-1":
     use_template: database
+  # MinIO (vmid 107) data volume — the CURRENT live splunk-addons store during the
+  # MinIO->RustFS migration soak. subvol-107-disk-1 is the 100G /opt/minio mount and
+  # holds the actual app tarballs + manifest TODAY (the object-storage/RustFS volume
+  # above is still empty until its role converge). Protect both during the soak;
+  # drop this entry after MinIO is decommissioned post-cutover.
+  "rpool/data/subvol-107-disk-1":
+    use_template: database

--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -34,6 +34,12 @@ syncoid_jobs:
   - name: "object-storage-disk1"
     source: "root@{{ proxmox_node_prefix }}1:rpool/data/subvol-202000-disk-1"
     target: "bulk/replica/{{ proxmox_node_prefix }}1/subvol-202000-disk-1"
+  # MinIO (vmid 107) data volume — the CURRENT live splunk-addons store during the
+  # MinIO->RustFS migration soak (holds the real app tarballs today). Same pull
+  # pattern as the object-storage job above; drop after MinIO decommission.
+  - name: "minio-disk1"
+    source: "root@{{ proxmox_node_prefix }}1:rpool/data/subvol-107-disk-1"
+    target: "bulk/replica/{{ proxmox_node_prefix }}1/subvol-107-disk-1"
 
 # Layer-1 protection (local ZFS snapshots via sanoid) for the warm-standby
 # database namespace. Recursive so any bulk/databases/<instance> child inherits

--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -25,6 +25,15 @@ syncoid_jobs:
   - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk2"
     source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
     target: "bulk/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
+  # Object-storage (RustFS) DR: pull the splunk-addons data volume
+  # (subvol-202000-disk-1 = /srv/object-storage) from node 1. The container is
+  # pinned to node 1, so the source node is fixed via proxmox_node_prefix — the
+  # same "fixed node" pattern the pve3 databases/appdata jobs use for node 2,
+  # never a hard-coded node name. bulk/replica/<node1> already exists (the
+  # splunk jobs above target it); syncoid creates the per-disk leaf.
+  - name: "object-storage-disk1"
+    source: "root@{{ proxmox_node_prefix }}1:rpool/data/subvol-202000-disk-1"
+    target: "bulk/replica/{{ proxmox_node_prefix }}1/subvol-202000-disk-1"
 
 # Layer-1 protection (local ZFS snapshots via sanoid) for the warm-standby
 # database namespace. Recursive so any bulk/databases/<instance> child inherits

--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -30,6 +30,14 @@ syncoid_jobs:
   - name: "splunk-{{ splunk_vm_from_tofu.splunk.vmid }}-disk2"
     source: "root@{{ splunk_vm_from_tofu.splunk.node }}:rpool/data/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
     target: "bulk/replica/{{ splunk_vm_from_tofu.splunk.node }}/vm-{{ splunk_vm_from_tofu.splunk.vmid }}-disk-2"
+  # Object-storage (RustFS) DR: pull the splunk-addons data volume
+  # (subvol-202000-disk-1 = /srv/object-storage) from node 1 into this offline-DR
+  # leg. The container is pinned to node 1, so the source node is fixed via
+  # proxmox_node_prefix (same pattern as the databases/appdata jobs below that fix
+  # node 2) — never a hard-coded node name. Refreshes only during power-on windows.
+  - name: "object-storage-disk1"
+    source: "root@{{ proxmox_node_prefix }}1:rpool/data/subvol-202000-disk-1"
+    target: "bulk/replica/{{ proxmox_node_prefix }}1/subvol-202000-disk-1"
   # Database warm-standby DR: pull the whole bulk/databases namespace from the
   # always-on node 2 into this offline-DR leg (recursive via default options, so
   # every bulk/databases/<instance> child comes along). The source node is fixed

--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -38,6 +38,12 @@ syncoid_jobs:
   - name: "object-storage-disk1"
     source: "root@{{ proxmox_node_prefix }}1:rpool/data/subvol-202000-disk-1"
     target: "bulk/replica/{{ proxmox_node_prefix }}1/subvol-202000-disk-1"
+  # MinIO (vmid 107) data volume — CURRENT live splunk-addons store during the
+  # MinIO->RustFS migration soak (holds the real app tarballs today). Offline-DR
+  # leg; same pull pattern as above. Drop after MinIO decommission.
+  - name: "minio-disk1"
+    source: "root@{{ proxmox_node_prefix }}1:rpool/data/subvol-107-disk-1"
+    target: "bulk/replica/{{ proxmox_node_prefix }}1/subvol-107-disk-1"
   # Database warm-standby DR: pull the whole bulk/databases namespace from the
   # always-on node 2 into this offline-DR leg (recursive via default options, so
   # every bulk/databases/<instance> child comes along). The source node is fixed


### PR DESCRIPTION
# feat(backup): protect object-storage data volume via sanoid+syncoid

## What

Add the object-storage (RustFS) `splunk-addons` data volume to the existing
`pve#`→backup-node replication process. This volume holds Splunkbase app
tarballs + the version manifest, and was the one important store with **no
snapshots and no replication**.

## Changes

- **`host_vars` (primary node)** — snapshot the 100G data volume
  (`subvol-202000-disk-1`, the `/srv/object-storage` mount) via sanoid on the
  `database` template (daily cadence + long retention tail). The rootfs
  (`disk-0`) is Ansible-reproducible and not snapshotted.
- **`host_vars` (always-on replica + offline-DR node)** — add one syncoid PULL
  job each, replicating the data volume into `bulk/replica/<primary>/…`,
  mirroring the existing Splunk-disk jobs. Source node is fixed via
  `proxmox_node_prefix` — never a hard-coded node name.

## Why this template / layout

The bucket itself has object-versioning enabled, so it keeps per-object
version history. These ZFS snapshots are therefore **volume-level disaster
recovery** (corruption / ransomware / accidental `rm`), not app-version
history — hence daily cadence rather than hourly.

## Verification (post-merge, credentialed converge)

- Snapshots appear on the primary node for the data volume.
- syncoid replicas land on the always-on and offline-DR nodes (the latter
  during its power-on window).
- Idempotent: a second converge reports zero changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
