### PR TITLE
feat(ci): re-run molecule on upstream release

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -4,6 +4,10 @@ name: Molecule Test
 on:
   push:
     branches: [main]
+  # Callable so the upstream-revalidate listener can re-run role tests when
+  # terraform-proxmox cuts a release; manual trigger for ad-hoc runs.
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/upstream-revalidate.yml
+++ b/.github/workflows/upstream-revalidate.yml
@@ -1,0 +1,27 @@
+---
+# Re-run role tests when an upstream source-of-truth repo (terraform-proxmox)
+# cuts a release. Triggered in real time via repository_dispatch
+# (event_type=upstream-released), fanned out by terraform-proxmox's release
+# workflow.
+#
+# ponytail: this repo has no inventory data-contract workflow, so it re-runs
+# molecule (roles against a MOCK inventory) — lower fidelity than the
+# apps/splunk listeners, which hit _data-contract.yml against the real schema.
+# If a _data-contract.yml lands here later, repoint `uses:` at it.
+#
+# Security: client_payload.* (sender-controlled) is not interpolated anywhere
+# here — this listener only calls a local reusable workflow with no inputs.
+name: Upstream Revalidate
+
+on:
+  repository_dispatch:
+    types: [upstream-released]
+
+permissions:
+  contents: read
+
+jobs:
+  revalidate:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/molecule.yml


### PR DESCRIPTION
Real-time `repository_dispatch` listener (`upstream-released`, fanned out by terraform-proxmox on release) that re-runs molecule role tests. `molecule.yml` made callable (workflow_call + workflow_dispatch).

Caveat: this repo has no inventory data-contract workflow, so it re-runs molecule (roles vs a **mock** inventory) — lower fidelity than apps/splunk, which validate the real schema. Repoint at a `_data-contract.yml` if one lands here later.

Part of the upstream→downstream revalidation chain (terraform-proxmox#479, dryvist/.github#47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)