### PR TITLE
docs: genericize Doppler config reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ doppler run -- ansible-playbook playbooks/site.yml
 - **Swap management**: Configures swappiness and ZFS swap devices
 - **Monitoring setup**: Installs sysstat, atop, and crash-monitor
 
-Note: All playbooks use `doppler run` to inject secrets (SSH credentials, API tokens) from the Doppler `iac-conf-mgmt` project.
+Note: All playbooks use `doppler run` to inject secrets (SSH credentials, API tokens) from your Doppler config.
 
 ## Development Environment
 


### PR DESCRIPTION
## What

Replace the specific Doppler project name in `AGENTS.md` with a generic reference (`your Doppler config`).

## Why

This is a public repo. The line disclosed an internal Doppler vault/project name. Genericizing removes the disclosure while preserving meaning — playbooks still inject secrets via `doppler run`.

## Scope

- Single line in `AGENTS.md`. Docs-only, no code/workflow changes.
- Individual secret KEY names (e.g. `PROXMOX_VE_*`) are unaffected.
- Verified `grep` for the old reference returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019whZYTbrt4DnoyXVE5gCF9