### PR TITLE
feat(backup): autonomous DR-node wake → replicate → sleep cycle

### DIFF
--- a/docs/DR_RUNBOOK.md
+++ b/docs/DR_RUNBOOK.md
@@ -1,129 +1,174 @@
-# Disaster-Recovery Runbook — warm/hot standby on an intermittent node
+# Disaster-Recovery Runbook — cold standby on an intermittent node
 
 Operator runbook for the homelab resiliency program's standby model: a third
-node (`<target-node>`, e.g. `proxmox-3`) kept as a continuously-synced standby
-so it can take over service if a primary node is lost.
+node (`<target-node>`) kept as a periodically-synced **cold** standby that holds
+independent ZFS replicas of the critical datasets, so it can take over service if
+a primary node is lost.
 
 > Placeholders only — no real IPs, domain, or node names. Substitute:
-> `proxmox-1` (always-on, infra + SIEM VM), `proxmox-2` (always-on, media on a
-> `bulk` ZFS pool), `<target-node>` (the intermittently-online standby).
+> `proxmox-1` (always-on, infra + SIEM VM), `proxmox-2` (always-on, media + the
+> warm-standby `bulk/databases` + `bulk/appdata` namespaces on a `bulk` ZFS pool),
+> `<target-node>` (the normally-off offline-DR standby).
 > `${PROXMOX_SUBDOMAIN}` is the internal subdomain (from Doppler).
 
 ## 1. How replication works
 
 - Storage is **node-local ZFS** — no shared storage, no Ceph. Each node has its
-  own `bulk` pool; the standby holds empty replica datasets
-  (`bulk/replica/proxmox-1`, `bulk/replica/proxmox-2`) declared in
+  own `bulk` pool; the standby holds replica datasets
+  (`bulk/replica/proxmox-1/...`, `bulk/replica/proxmox-2/...`) declared in
   terraform-proxmox `node_storage`.
-- Replication uses **syncoid** (from the `sanoid` package), driven by the
-  `zfs_replication` role (and/or the existing `syncoid` role). syncoid ships ZFS
-  snapshots incrementally and **tolerates the target being offline**, unlike
-  Proxmox-native `pvesr`.
-- **Continuous when the standby is up, clean skip when it is down.** The
-  `zfs_replication` role probes the standby's reachability before each run. If
-  the standby is powered off — its normal steady state — the run is a no-op
-  (logged, never a failure). The moment the standby boots, the next timer tick
-  brings its replicas current.
-- The standby is powered on for maintenance/replication windows via IPMI
-  (`idrac_power`) and powers itself back off on a schedule (`node_auto_poweroff`)
-  so it is not left running overnight.
+- Replication uses **syncoid** (from the `sanoid` package) in **PULL** mode: it
+  runs **on the standby** and SSHes out to each source to pull that source's
+  sanoid snapshots. Pull-from-backup is safer than push (a compromised source
+  cannot reach the backup) and tolerates the source being briefly unreachable.
+- The standby is **normally powered off** to save electricity, and runs an
+  **autonomous wake → replicate → sleep** cycle:
+  - **Wake** — the always-on controller (`proxmox-1`) runs the
+    `node_scheduled_wake` systemd timers, which issue an IPMI `chassis power on`
+    to the standby's BMC on a schedule (twice a day by default).
+  - **Replicate** — the standby replicates **on boot** (`syncoid` role with
+    `syncoid_trigger: boot` installs a `syncoid-replicate-on-boot.service`
+    oneshot). The wall-clock syncoid cron is deliberately NOT used on the
+    standby: it would never fire inside a short power-on window.
+  - **Sleep** — the on-boot service chains to the `node_auto_poweroff` oneshot
+    via systemd `OnSuccess=`/`OnFailure=`, so the standby powers itself off the
+    moment replication finishes (success or failure). A fixed-time
+    `node_auto_poweroff` timer (22:00) remains as a guaranteed-off backstop if a
+    run ever hangs.
+- **Freshness == the last window the standby was online.** Because the standby is
+  off most of the day, its replicas are at most as fresh as its most recent wake.
+  A gap beyond the expected cadence means the standby failed to wake or syncoid
+  failed while it was up (investigate — see §3).
 
-## 2. Hot vs warm standby
+## 2. What is on the standby (and what is not)
 
-| Class | Examples | State on the standby | Runs when standby is up? |
+| Dataset (on the standby) | Source | Class | Notes |
 | --- | --- | --- | --- |
-| **Hot** (stateless) | DNS secondary, reverse proxy / Traefik | Config only; no single-writer data | **Yes** — can actively serve alongside the primary, no split-brain risk |
-| **Warm** (single-writer stateful) | Media stack, databases, the SIEM VM | Replicated data, guest **stopped** | **No** — started only during a failover cutover |
+| `bulk/replica/proxmox-1/vm-<id>-disk-0` | SIEM VM OS disk | Warm | Whole-disk zvol |
+| `bulk/replica/proxmox-1/vm-<id>-disk-2` | SIEM VM `/opt/splunk` | Warm | Config **and** indexes share this disk — see note |
+| `bulk/replica/proxmox-1/subvol-<id>-disk-1` | object-storage (RustFS/MinIO) | Warm | The app-tarball store |
+| `bulk/replica/proxmox-2/databases` (recursive) | `bulk/databases` | Warm | Warm-standby DB namespace |
+| `bulk/replica/proxmox-2/appdata` (recursive) | `bulk/appdata` | Warm | App config/state (incl. media app identity) |
 
-The distinction exists to avoid **split-brain**: two copies of a single-writer
-service accepting writes at once corrupts state. Hot/stateless services have no
-authoritative single writer, so they can run on the standby continuously. Warm
-services must have exactly one writer, so the standby copy stays stopped until
-the primary is confirmed down.
+**Not replicated to the standby** (by design):
+
+- **The media library** (`bulk/data`) — large and re-acquirable; declared with
+  `com.sun:auto-snapshot=false` in terraform-proxmox. Not a DR target.
+- **Guest definitions** (`/etc/pve/qemu-server/*.conf`, `/etc/pve/lxc/*.conf`).
+  syncoid ships **data only**, never the VM/CT config. A failover therefore
+  **recreates the guest definition** (terraform-proxmox apply targeting the
+  standby, or a manual `qm`/`pct create`) and attaches the cloned data — see §4.
+- **SIEM indexed data is acceptable-loss.** The SIEM `/opt/splunk` config is what
+  must survive; the indexes ride along on the same disk-2 replica but are volatile
+  and re-acquirable. Expect index recovery / fsck on first boot after a restore;
+  do not block a cutover on index integrity.
 
 ## 3. Checking replication freshness
 
-On the **source** node (where the `zfs_replication` role runs):
+The standby must be **powered on** to inspect (wait for a wake window, or power it
+on out of band via IPMI). All of these run **on the standby** — that is where
+syncoid runs in the PULL model.
 
 ```bash
-# Most recent replication log
-ls -t /var/log/zfs-replication/ | head -1
-tail -n 40 /var/log/zfs-replication/$(date +%Y-%m-%d).log
+# Most recent replication log + the on-boot service result from this boot
+ls -t /var/log/syncoid/ | head -1
+tail -n 40 /var/log/syncoid/"$(date +%Y-%m-%d)".log     # look for any "FAILED (rc=...)"
+systemctl status syncoid-replicate-on-boot.service
 
-# Timer status + next run
-systemctl status zfs-replication.timer
-systemctl list-timers zfs-replication.timer
-```
-
-On the **standby** (must be powered on to inspect):
-
-```bash
 # Newest snapshot per replicated dataset — the replication high-water mark
-zfs list -t snapshot -o name,creation -s creation bulk/replica/proxmox-2/data | tail
-zfs list -t snapshot -o name,creation -s creation bulk/replica/proxmox-1 | tail
+zfs list -t snapshot -o name,creation -s creation -r bulk/replica/proxmox-1 | tail
+zfs list -t snapshot -o name,creation -s creation -r bulk/replica/proxmox-2 | tail
 ```
 
-Freshness = age of the newest snapshot on the standby. Expect it to be no older
-than the last window the standby was online. A large gap means the standby has
-been down (expected) or SSH trust / a source snapshot is missing (investigate).
+Freshness = age of the newest snapshot per dataset. Expect it no older than the
+last window the standby was online (≈ the wake cadence). A larger gap means the
+standby has been down longer than expected (it failed to wake) or SSH trust / a
+source snapshot is missing (investigate). A dataset that is **absent** entirely
+means that job has never succeeded and needs an initial full send (§4.3).
 
-## 4. Failover cutover (primary lost)
+Integrity (optional, stronger): the standby's newest snapshot for a dataset
+should have the **same `zfs get guid`** as the source's snapshot of the same
+name, and the two should share at least one common snapshot (an unbroken
+incremental chain). Zero common snapshots ⇒ the next pull needs a full reseed.
 
-No load balancer — cutover is "start the warm guest on the standby + repoint DNS
-A records." Do this only after confirming the primary is genuinely down (avoid
-split-brain).
+## 4. Failover cutover (a primary is lost)
 
-1. **Confirm the primary is down.** Power state via IPMI; do not proceed if it is
-   merely unreachable on the network but still running.
-2. **Power on the standby** (IPMI / `idrac_power`) if it is off.
+No load balancer — cutover is "recreate + start the guest on the standby from its
+replica + repoint DNS." Do this only after confirming the primary is genuinely
+down (avoid split-brain — one writer, always).
+
+1. **Confirm the primary is down.** Check power state via IPMI; do not proceed if
+   it is merely unreachable on the network but still running.
+2. **Power on the standby** (IPMI / `idrac_power`) if it is off, and stop it from
+   auto-sleeping mid-restore: `systemctl stop node-auto-poweroff.timer` and
+   `systemctl mask node-auto-poweroff.service` (the on-boot replicate chains to
+   that oneshot on completion). Unmask when the restore is done.
 3. **Final replica sync if the primary is briefly reachable** — otherwise the
-   standby serves from its last replicated snapshot:
+   standby serves from its last replicated snapshot. Force a pull **on the
+   standby**:
 
    ```bash
-   # On the source side, force a run now if the primary is momentarily up
-   /usr/local/bin/zfs-replicate.sh
+   /usr/local/bin/syncoid-replicate.sh          # or, via Ansible:
+   # ansible-playbook playbooks/site.yml -l <target-node> -e syncoid_run_now=true
    ```
 
-4. **Promote the warm guest on the standby.** Clone/rollback the latest replica
-   snapshot into a runnable dataset, then start the guest (CT/VM):
+4. **Promote the guest on the standby.** Because guest **configs are not
+   replicated**, recreate the definition, then attach the cloned replica data:
 
-   ```bash
-   pct start <ctid>     # container
-   qm start <vmid>      # VM
-   ```
+   - **VM (zvol-backed, e.g. the SIEM VM):** clone the latest replica snapshot of
+     each disk into a runnable, storage-registered dataset under the standby's
+     pool using the expected `vm-<id>-disk-<n>` name, then recreate/rescan the VM
+     and start it:
+
+     ```bash
+     for n in 0 2; do
+       snap=$(zfs list -H -t snapshot -o name -s creation \
+                bulk/replica/proxmox-1/vm-<id>-disk-$n | tail -1)
+       zfs clone "$snap" bulk/vm-<id>-disk-$n     # into a pool Proxmox storage maps
+     done
+     # recreate the guest config (terraform-proxmox apply -l <target-node>, or
+     # `qm create <id> ...`), then:
+     qm rescan --vmid <id>
+     qm start <id>
+     # SIEM only: indexes are crash-consistent — expect Splunk recovery/fsck on
+     # first start; config is intact.
+     ```
+
+   - **Container (subvol/bind-mount-backed, e.g. databases / appdata consumers):**
+     clone the replica subvol (or a child of `bulk/replica/.../appdata`) into the
+     path the container bind-mounts, recreate the CT definition, repoint its bind
+     mount at the cloned dataset, then `pct start <ctid>`.
 
 5. **Repoint DNS.** Update the A record(s) for the affected service(s) to the
    standby's address. Internal traffic resolves by name
    (`<service>.${PROXMOX_SUBDOMAIN}`), so only the DNS A record changes — no
-   client reconfiguration.
-
-   ```bash
-   # Example: update the service A record in the DNS manager to the standby IP
-   # (Technitium / your DNS authority). TTLs should be low for fast cutover.
-   ```
-
+   client reconfiguration. Keep TTLs low for fast cutover.
 6. **Verify** the service answers on its name, then announce the cutover.
 
 ## 5. Fail-back (primary restored)
 
-1. **Bring the primary back** and let it boot, but keep its warm guests
-   **stopped** — the standby is currently the single writer.
+1. **Bring the primary back** and let it boot, but keep its guests **stopped** —
+   the standby is currently the single writer.
 2. **Reverse-replicate** the now-current data from the standby back to the
    primary (a one-off syncoid run with source/target swapped), so the primary's
    datasets catch up to the writes taken during the outage.
-3. **Quiesce on the standby**: stop the warm guest so there is again exactly one
-   writer.
+3. **Quiesce on the standby**: stop the promoted guest so there is again exactly
+   one writer.
 4. **Start the guest on the primary**, verify it is healthy and current.
 5. **Repoint DNS** A records back to the primary.
-6. **Resume normal replication** (primary → standby). Confirm the timer is
-   active and the first post-failback run succeeds.
+6. **Resume normal operation on the standby**: unmask `node-auto-poweroff.service`,
+   re-enable `node-auto-poweroff.timer`, and let the wake → replicate → sleep
+   cycle resume. Confirm the next scheduled wake produces a fresh pull.
 
 ## 6. Guardrails
 
-- **Never run a warm guest on both nodes at once.** One writer, always.
-- **Replication is best-effort against an intermittent target** — a down standby
-  is a clean skip, not an alert. Alert only on the standby being *up* and
-  replication still failing.
+- **Never run a guest on both nodes at once.** One writer, always.
+- **A normally-off standby is a clean skip, not an alert.** In the PULL model
+  syncoid runs *on the standby*; while it is off there is no run, no log, and no
+  failure. Do not alert on "no replication while down" — alert on the standby
+  being *up* and replication still failing, or on replicas growing **stale beyond
+  the wake cadence** (a freshness deadman tied to a successful on-boot pull is a
+  tracked follow-up).
 - **The replica is not a backup of last resort** — it tracks the source,
-  including accidental deletes. Point-in-time recovery comes from sanoid
-  snapshot retention (and, optionally, the `vzdump` leg), not from replication.
+  including accidental deletes. Point-in-time recovery comes from sanoid snapshot
+  retention (and, when added, a `vzdump`/PBS leg), not from replication.

--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -42,4 +42,4 @@ sanoid_datasets:
 # primary. Default schedule (03:00 + 15:00) lives in the role defaults.
 node_scheduled_wake_targets:
   - name: pve3
-    bmc_ip: "{{ lookup('env', 'PVE3_BMC_IP') | default('', true) }}"
+    bmc_host: "{{ lookup('env', 'PVE3_BMC_HOSTNAME') | default('', true) }}"

--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -32,3 +32,14 @@ sanoid_datasets:
   # drop this entry after MinIO is decommissioned post-cutover.
   "rpool/data/subvol-107-disk-1":
     use_template: database
+
+# Offline-DR wake controller. pve1 is always-on and can reach the BMC subnet, so
+# it runs the node_scheduled_wake timers that power the normally-off DR node ON
+# twice a day for its replication windows (the node then replicates on boot and
+# powers itself back off — see pve3 host_vars). The BMC address + credentials come
+# from the environment (Doppler), never committed. If pve1 itself is down the DR
+# node simply will not wake that window — an accepted limitation for the always-on
+# primary. Default schedule (03:00 + 15:00) lives in the role defaults.
+node_scheduled_wake_targets:
+  - name: pve3
+    bmc_ip: "{{ lookup('env', 'PVE3_BMC_IP') | default('', true) }}"

--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -5,7 +5,7 @@
 # and comes up only for its backup windows:
 #   - WAKE: the always-on controller (see pve1 host_vars node_scheduled_wake_
 #     targets) issues an IPMI power-on twice a day. The BMC address comes from the
-#     environment (Doppler PVE3_BMC_IP) — never committed.
+#     environment (Doppler PVE3_BMC_HOSTNAME, FQDN preferred) — never committed.
 #   - REPLICATE: on boot, the syncoid role runs the PULL jobs below once
 #     (syncoid_trigger: boot). The wall-clock cron is the WRONG trigger here — it
 #     would never fire inside a short power-on window.
@@ -16,7 +16,7 @@
 # pve_power_managed also lets a manual site.yml run power-cycle pve3 for
 # maintenance (the idrac_power auto-cycle bookends).
 pve_power_managed: true
-idrac_power_bmc_ip: "{{ lookup('env', 'PVE3_BMC_IP') | default('', true) }}"
+idrac_power_bmc_host: "{{ lookup('env', 'PVE3_BMC_HOSTNAME') | default('', true) }}"
 node_auto_poweroff_enabled: true
 syncoid_trigger: boot
 syncoid_boot_poweroff_on_complete: true

--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -1,11 +1,30 @@
 ---
 # Host vars for pve3 (the R710 — a normally-off offline-DR leg).
 #
-# pve3 is powered on only for maintenance/replication windows (via the
-# idrac_power IPMI auto-cycle) and must not be left running overnight. The
-# node_auto_poweroff role installs a local systemd timer that gracefully powers
-# pve3 off on a schedule; the time (default 22:00) lives in the role defaults.
+# Autonomous wake -> replicate -> sleep cycle. pve3 is normally OFF to save power
+# and comes up only for its backup windows:
+#   - WAKE: the always-on controller (see pve1 host_vars node_scheduled_wake_
+#     targets) issues an IPMI power-on twice a day. The BMC address comes from the
+#     environment (Doppler PVE3_BMC_IP) — never committed.
+#   - REPLICATE: on boot, the syncoid role runs the PULL jobs below once
+#     (syncoid_trigger: boot). The wall-clock cron is the WRONG trigger here — it
+#     would never fire inside a short power-on window.
+#   - SLEEP: syncoid chains to the node_auto_poweroff oneshot on completion
+#     (syncoid_boot_poweroff_on_complete), so pve3 powers off the moment
+#     replication finishes (success OR failure). The 22:00 node_auto_poweroff
+#     timer stays as a guaranteed-off backstop if a run ever hangs.
+# pve_power_managed also lets a manual site.yml run power-cycle pve3 for
+# maintenance (the idrac_power auto-cycle bookends).
+pve_power_managed: true
+idrac_power_bmc_ip: "{{ lookup('env', 'PVE3_BMC_IP') | default('', true) }}"
 node_auto_poweroff_enabled: true
+syncoid_trigger: boot
+syncoid_boot_poweroff_on_complete: true
+
+# Normally-off node: do NOT run the per-minute healthchecks liveness ping — it
+# would sit "down" and alarm whenever pve3 is (intentionally) off. A freshness
+# deadman for the DR replicas is a tracked follow-up.
+proxmox_monitoring_enable_healthchecks: false
 
 # Layer-2 protection (cross-node ZFS replication via syncoid, PULL model): pve3
 # is the second (offline-DR) replica target. It pulls the Splunk VM disk

--- a/molecule/idrac_power/converge.yml
+++ b/molecule/idrac_power/converge.yml
@@ -5,7 +5,7 @@
   gather_facts: true
 
   # Under Docker every power task is skipped (ansible_virtualization_type ==
-  # 'docker'), and no idrac_power_bmc_ip is set, so this proves the role loads
+  # 'docker'), and no idrac_power_bmc_host is set, so this proves the role loads
   # and converges cleanly without touching any BMC. Live power behavior is
   # validated against real hardware, not in molecule.
   vars:

--- a/molecule/node_scheduled_wake/converge.yml
+++ b/molecule/node_scheduled_wake/converge.yml
@@ -1,0 +1,22 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  # Under Docker the ipmitool install, daemon-reload, and timer enable are
+  # skipped (ansible_virtualization_type == 'docker'); the unit + credentials
+  # files still render, so this proves the role templates a service + timer per
+  # target from the contract. Live IPMI power-on is validated on real hardware,
+  # not in molecule. A placeholder BMC IP (192.168.0.x per public-repo policy) is
+  # used since no real BMC is reachable in the container.
+  vars:
+    node_scheduled_wake_targets:
+      - name: dr-node
+        bmc_ip: "192.168.0.10"
+        on_calendar:
+          - "*-*-* 03:00:00"
+          - "*-*-* 15:00:00"
+
+  roles:
+    - role: node_scheduled_wake

--- a/molecule/node_scheduled_wake/converge.yml
+++ b/molecule/node_scheduled_wake/converge.yml
@@ -13,7 +13,7 @@
   vars:
     node_scheduled_wake_targets:
       - name: dr-node
-        bmc_ip: "192.168.0.10"
+        bmc_host: "192.168.0.10"
         on_calendar:
           - "*-*-* 03:00:00"
           - "*-*-* 15:00:00"

--- a/molecule/node_scheduled_wake/molecule.yml
+++ b/molecule/node_scheduled_wake/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-node-scheduled-wake-test
+    image: "${MOLECULE_IMAGE:-debian:stable-slim}"
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/node_scheduled_wake/verify.yml
+++ b/molecule/node_scheduled_wake/verify.yml
@@ -1,0 +1,40 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Read the rendered service unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/node-scheduled-wake-dr-node.service
+      register: wake_service
+
+    - name: Read the rendered timer unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/node-scheduled-wake-dr-node.timer
+      register: wake_timer
+
+    - name: Read the rendered credentials EnvironmentFile
+      ansible.builtin.slurp:
+        src: /etc/node-scheduled-wake/dr-node.env
+      register: wake_env
+
+    - name: Assert the units rendered the expected contract
+      ansible.builtin.assert:
+        that:
+          - "'Type=oneshot' in (wake_service.content | b64decode)"
+          - "'chassis power on' in (wake_service.content | b64decode)"
+          - "'-H 192.168.0.10' in (wake_service.content | b64decode)"
+          - "'EnvironmentFile=/etc/node-scheduled-wake/dr-node.env' in (wake_service.content | b64decode)"
+          - "'OnCalendar=*-*-* 03:00:00' in (wake_timer.content | b64decode)"
+          - "'OnCalendar=*-*-* 15:00:00' in (wake_timer.content | b64decode)"
+          - "'Persistent=false' in (wake_timer.content | b64decode)"
+          - "'WantedBy=timers.target' in (wake_timer.content | b64decode)"
+          - "'IPMITOOL_PASSWORD=' in (wake_env.content | b64decode)"
+        fail_msg: "node_scheduled_wake units did not render the expected contract"
+
+    # The Docker-skip on the ipmitool install + daemon-reload + timer enable is
+    # proven by this converge succeeding (those tasks are guarded off, not
+    # failed). The unit contract is verified by the slurp assertions above —
+    # mirroring the node_auto_poweroff verifier.

--- a/molecule/syncoid/converge.yml
+++ b/molecule/syncoid/converge.yml
@@ -5,9 +5,12 @@
   gather_facts: true
 
   vars:
-    # Pull model: this node is the target (pve2), pulling pve1 datasets.
-    # Package + cron are Docker-skipped; this proves the wrapper renders the
-    # expected syncoid invocations from the job contract.
+    # Pull model: this node is the target (an offline-DR leg), pulling source
+    # datasets. Package + cron + enable are Docker-skipped; this proves both the
+    # wrapper renders the expected syncoid invocations AND (boot trigger) the
+    # on-boot service unit renders with poweroff-on-complete from the contract.
+    syncoid_trigger: boot
+    syncoid_boot_poweroff_on_complete: true
     syncoid_jobs:
       - name: pve1-nas
         source: "root@pve1:rpool/data/nas"

--- a/molecule/syncoid/verify.yml
+++ b/molecule/syncoid/verify.yml
@@ -22,3 +22,19 @@
           # failure isolation present so an offline source does not abort the run
           - "'FAILED (rc=' in syncoid_wrapper_text"
         fail_msg: "syncoid wrapper did not render the expected jobs"
+
+    - name: Read the rendered on-boot replication service (boot trigger)
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/syncoid-replicate-on-boot.service
+      register: syncoid_boot_service
+
+    - name: Assert the on-boot service renders the boot + poweroff-on-complete contract
+      ansible.builtin.assert:
+        that:
+          - "'Type=oneshot' in (syncoid_boot_service.content | b64decode)"
+          - "'ExecStart=/usr/local/bin/syncoid-replicate.sh' in (syncoid_boot_service.content | b64decode)"
+          - "'After=network-online.target zfs.target zfs-mount.service' in (syncoid_boot_service.content | b64decode)"
+          - "'OnSuccess=node-auto-poweroff.service' in (syncoid_boot_service.content | b64decode)"
+          - "'OnFailure=node-auto-poweroff.service' in (syncoid_boot_service.content | b64decode)"
+          - "'WantedBy=multi-user.target' in (syncoid_boot_service.content | b64decode)"
+        fail_msg: "syncoid on-boot service did not render the expected contract"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -144,6 +144,16 @@
       tags:
         - node_auto_poweroff
 
+    # Scheduled IPMI power-ON (systemd timer) so a normally-off DR node wakes for
+    # its backup windows with no human and no scheduled ansible run — the wake
+    # half of the autonomous cycle (node_auto_poweroff is the sleep half). Runs on
+    # the always-on controller; inert unless a host sets node_scheduled_wake_
+    # targets (e.g. pve1 -> pve3). The woken node replicates on boot (syncoid
+    # boot trigger) and powers itself off on completion.
+    - role: node_scheduled_wake
+      tags:
+        - node_scheduled_wake
+
 # Gracefully power down the power-managed nodes at the very END of the run (the
 # offline-DR leg returns to off after its targets are seeded). NOTE: a mid-run
 # failure stops subsequent plays, so the node may be left powered on (re-run or

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -22,7 +22,7 @@
         idrac_power_action: "on"
       when:
         - pve_power_managed | default(false) | bool
-        - idrac_power_autocycle | bool
+        - idrac_power_autocycle | default(true) | bool
       tags:
         - idrac_power
 
@@ -170,6 +170,6 @@
         idrac_power_action: "off"
       when:
         - pve_power_managed | default(false) | bool
-        - idrac_power_autocycle | bool
+        - idrac_power_autocycle | default(true) | bool
       tags:
         - idrac_power

--- a/roles/idrac_power/README.md
+++ b/roles/idrac_power/README.md
@@ -32,7 +32,7 @@ ansible-galaxy collection install -r requirements.yml
 - `idrac_power_action: off` → graceful ACPI `chassis power soft` (if on), then
   polls until the BMC reports power off.
 - `idrac_power_action: status` (default) → query only, no change.
-- Skipped under Docker (molecule) and when `idrac_power_bmc_ip` is unset.
+- Skipped under Docker (molecule) and when `idrac_power_bmc_host` is unset.
 
 ## Variables
 
@@ -45,7 +45,7 @@ ansible-galaxy collection install -r requirements.yml
 | `idrac_power_boot_timeout` | `720` | Seconds to wait for SSH after power-on (old hardware boots slowly) |
 | `idrac_power_off_retries` | `60` | Poll budget (×10s ⇒ 10 min) for graceful off |
 | `idrac_power_username` / `_password` | `IDRAC_USERNAME` / `IDRAC_PASSWORD` env | BMC creds (no_log) |
-| `idrac_power_bmc_ip` | _(unset)_ | Per-host BMC address (host_vars / tofu) |
+| `idrac_power_bmc_host` | _(unset)_ | Per-host BMC address — FQDN preferred over IP (host_vars / env) |
 
 ## Usage
 

--- a/roles/idrac_power/defaults/main.yml
+++ b/roles/idrac_power/defaults/main.yml
@@ -44,6 +44,7 @@ idrac_power_off_retries: 60
 idrac_power_username: "{{ lookup('env', 'IDRAC_USERNAME') }}"
 idrac_power_password: "{{ lookup('env', 'IDRAC_PASSWORD') }}"
 
-# Per-host BMC address. Set in host_vars/<node>.yml (e.g. from the tofu
-# rack_servers output / SOPS); there is no safe default.
-# idrac_power_bmc_ip: "10.x.x.x"
+# Per-host BMC address (ipmitool -H). FQDN preferred over an IP — a hostname
+# insulates this from BMC re-addressing (the golden rule). Set in host_vars/<node>
+# .yml from the environment (Doppler) / SOPS; never committed, no safe default.
+# idrac_power_bmc_host: "node-idrac.<subdomain>"

--- a/roles/idrac_power/tasks/main.yml
+++ b/roles/idrac_power/tasks/main.yml
@@ -12,7 +12,7 @@
   delegate_to: "{{ idrac_power_controller }}"
   when:
     - idrac_power_enabled | bool
-    - idrac_power_bmc_ip | default('') | length > 0
+    - idrac_power_bmc_host | default('') | length > 0
     - ansible_virtualization_type | default('') != 'docker'
   tags:
     - idrac_power
@@ -20,7 +20,7 @@
 - name: Query current chassis power status
   ansible.builtin.command:
     cmd: >-
-      ipmitool -I lanplus -H {{ idrac_power_bmc_ip }}
+      ipmitool -I lanplus -H {{ idrac_power_bmc_host }}
       -U {{ idrac_power_username }} -P {{ idrac_power_password }}
       chassis power status
   delegate_to: "{{ idrac_power_controller }}"
@@ -29,7 +29,7 @@
   no_log: true
   when:
     - idrac_power_enabled | bool
-    - idrac_power_bmc_ip | default('') | length > 0
+    - idrac_power_bmc_host | default('') | length > 0
     - ansible_virtualization_type | default('') != 'docker'
   tags:
     - idrac_power
@@ -38,7 +38,7 @@
 - name: Power on the target (only if currently off)
   ansible.builtin.command:
     cmd: >-
-      ipmitool -I lanplus -H {{ idrac_power_bmc_ip }}
+      ipmitool -I lanplus -H {{ idrac_power_bmc_host }}
       -U {{ idrac_power_username }} -P {{ idrac_power_password }}
       chassis power on
   delegate_to: "{{ idrac_power_controller }}"
@@ -46,7 +46,7 @@
   no_log: true
   when:
     - idrac_power_enabled | bool
-    - idrac_power_bmc_ip | default('') | length > 0
+    - idrac_power_bmc_host | default('') | length > 0
     - ansible_virtualization_type | default('') != 'docker'
     - idrac_power_action == 'on'
     - "'is on' not in (idrac_power_status.stdout | default(''))"
@@ -58,7 +58,7 @@
     timeout: "{{ idrac_power_boot_timeout | int }}"
   when:
     - idrac_power_enabled | bool
-    - idrac_power_bmc_ip | default('') | length > 0
+    - idrac_power_bmc_host | default('') | length > 0
     - ansible_virtualization_type | default('') != 'docker'
     - idrac_power_action == 'on'
   tags:
@@ -67,7 +67,7 @@
 - name: Power off the target gracefully (ACPI soft, only if currently on)
   ansible.builtin.command:
     cmd: >-
-      ipmitool -I lanplus -H {{ idrac_power_bmc_ip }}
+      ipmitool -I lanplus -H {{ idrac_power_bmc_host }}
       -U {{ idrac_power_username }} -P {{ idrac_power_password }}
       chassis power soft
   delegate_to: "{{ idrac_power_controller }}"
@@ -75,7 +75,7 @@
   no_log: true
   when:
     - idrac_power_enabled | bool
-    - idrac_power_bmc_ip | default('') | length > 0
+    - idrac_power_bmc_host | default('') | length > 0
     - ansible_virtualization_type | default('') != 'docker'
     - idrac_power_action == 'off'
     - "'is off' not in (idrac_power_status.stdout | default(''))"
@@ -85,7 +85,7 @@
 - name: Wait for the graceful power-off to complete
   ansible.builtin.command:
     cmd: >-
-      ipmitool -I lanplus -H {{ idrac_power_bmc_ip }}
+      ipmitool -I lanplus -H {{ idrac_power_bmc_host }}
       -U {{ idrac_power_username }} -P {{ idrac_power_password }}
       chassis power status
   delegate_to: "{{ idrac_power_controller }}"
@@ -98,7 +98,7 @@
   no_log: true
   when:
     - idrac_power_enabled | bool
-    - idrac_power_bmc_ip | default('') | length > 0
+    - idrac_power_bmc_host | default('') | length > 0
     - ansible_virtualization_type | default('') != 'docker'
     - idrac_power_action == 'off'
   tags:

--- a/roles/node_scheduled_wake/README.md
+++ b/roles/node_scheduled_wake/README.md
@@ -1,0 +1,58 @@
+# node_scheduled_wake
+
+Power a normally-off node **ON** via IPMI on a schedule. This is the wake
+counterpart to [`node_auto_poweroff`](../node_auto_poweroff/README.md) (the sleep
+half): together they let an offline-DR node cycle through a
+**wake → replicate → sleep** loop autonomously, so it is powered up only for the
+few minutes its backup actually needs.
+
+## How it works
+
+- Runs on an always-on **controller** that can reach the BMC subnet (the target
+  itself is off, so the power-on cannot originate there — the same reason
+  [`idrac_power`](../idrac_power/README.md) delegates ipmitool to a controller).
+- Installs one systemd **timer + oneshot service per target**. The service's
+  `ExecStart` is a single `ipmitool -I lanplus -H <bmc> -U <user> -E chassis
+  power on` — idempotent (a no-op if the target is already on), no custom script.
+- The BMC password is supplied through a root-only `0600` EnvironmentFile
+  (`/etc/node-scheduled-wake/<target>.env`); `ipmitool -E` reads
+  `$IPMITOOL_PASSWORD`, so it never appears on the command line or in
+  `systemctl cat`.
+- `Persistent=false`: a missed window is **not** caught up — wait for the next.
+
+Once the target boots it runs its own on-boot replication
+(`syncoid_trigger: boot` in the `syncoid` role) and powers itself off on
+completion (`node_auto_poweroff`), closing the loop. The wall-clock syncoid cron
+is the wrong trigger for a wake-driven node — it would never fire inside a short
+power-on window — which is why the target replicates **on boot** instead.
+
+## Variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `node_scheduled_wake_enabled` | `true` | Master switch. |
+| `node_scheduled_wake_on_calendar` | `["*-*-* 03:00:00", "*-*-* 15:00:00"]` | Default wake schedule (systemd `OnCalendar`, local time). |
+| `node_scheduled_wake_bmc_username` | `{{ env IDRAC_USERNAME }}` | BMC user (from Doppler). |
+| `node_scheduled_wake_bmc_password` | `{{ env IDRAC_PASSWORD }}` | BMC password (from Doppler; written to the EnvironmentFile only). |
+| `node_scheduled_wake_targets` | `[]` | Targets to wake. **Empty ⇒ role is inert.** |
+
+Each `node_scheduled_wake_targets` entry:
+
+```yaml
+node_scheduled_wake_targets:
+  - name: <node>                       # target node name (unit naming)
+    bmc_ip: "{{ lookup('env', 'X') }}" # BMC address (env/SOPS — never committed)
+    on_calendar:                       # optional per-target schedule override
+      - "*-*-* 03:00:00"
+      - "*-*-* 15:00:00"
+```
+
+Set `node_scheduled_wake_targets` only in the **controller's** host_vars so the
+role stays inert everywhere else.
+
+## Molecule
+
+Under Docker the ipmitool install, daemon-reload, and timer enable are skipped;
+the unit + credentials files still render, so the scenario proves the role
+templates a service + timer per target from the contract. Live IPMI power-on is
+validated on real hardware, not in molecule.

--- a/roles/node_scheduled_wake/README.md
+++ b/roles/node_scheduled_wake/README.md
@@ -41,7 +41,7 @@ Each `node_scheduled_wake_targets` entry:
 ```yaml
 node_scheduled_wake_targets:
   - name: <node>                       # target node name (unit naming)
-    bmc_ip: "{{ lookup('env', 'X') }}" # BMC address (env/SOPS — never committed)
+    bmc_host: "{{ lookup('env', 'X') }}" # BMC address — FQDN preferred (env/SOPS, never committed)
     on_calendar:                       # optional per-target schedule override
       - "*-*-* 03:00:00"
       - "*-*-* 15:00:00"

--- a/roles/node_scheduled_wake/README.md
+++ b/roles/node_scheduled_wake/README.md
@@ -50,6 +50,17 @@ node_scheduled_wake_targets:
 Set `node_scheduled_wake_targets` only in the **controller's** host_vars so the
 role stays inert everywhere else.
 
+## Operational caveat: maintenance converges
+
+Once the woken node carries `syncoid_trigger: boot` + `node_auto_poweroff_on_complete`,
+**every** boot (including the power-on at the start of a `site.yml` maintenance
+run) triggers the on-boot replicate, which powers the node off on completion —
+so a converge can be cut short ~1 min in. Before a maintenance converge of such a
+node, hold it up: `systemctl mask node-auto-poweroff.service` on the target (the
+on-boot replicate's `OnSuccess=` then no-ops), and unmask when done. A
+site.yml-level fix (mask during the power-managed window, unmask before the
+explicit IPMI power-off) is tracked as a follow-up.
+
 ## Molecule
 
 Under Docker the ipmitool install, daemon-reload, and timer enable are skipped;

--- a/roles/node_scheduled_wake/defaults/main.yml
+++ b/roles/node_scheduled_wake/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+# node_scheduled_wake role defaults — power a normally-off node ON via IPMI on a
+# schedule.
+#
+# This is the WAKE counterpart to node_auto_poweroff (the SLEEP half). It runs on
+# an always-on CONTROLLER that can reach the BMC subnet and installs a systemd
+# timer + oneshot per target that issues `ipmitool ... chassis power on`. An
+# offline-DR node therefore wakes for its replication windows with no human and
+# no scheduled ansible run. Once up, the target runs its on-boot replication
+# (syncoid_trigger: boot) and powers itself back off on completion. Powering ON
+# needs the BMC (the OS cannot wake itself once off); powering OFF is the OS's
+# own job (node_auto_poweroff) — the mirror image of that role's contract.
+#
+# Inert by default: opt a controller in by setting node_scheduled_wake_targets in
+# its host_vars. ipmitool runs locally on the controller; the target may be off.
+# Skipped under Docker (molecule); the unit files still render so the contract is
+# verifiable in-container.
+
+node_scheduled_wake_enabled: true
+
+# Default wake schedule (systemd OnCalendar expressions, local time). Two windows
+# a day keep a normally-off DR node's replicas fresh while minimizing on-time.
+# Override per target with the target's `on_calendar` key.
+node_scheduled_wake_on_calendar:
+  - "*-*-* 03:00:00"
+  - "*-*-* 15:00:00"
+
+# BMC credentials for ipmitool — injected from the environment (Doppler), never
+# committed. Same source as the idrac_power role. The password reaches the unit
+# via a root-only EnvironmentFile (ipmitool -E reads $IPMITOOL_PASSWORD), so it
+# never appears on the command line or in `systemctl cat`.
+node_scheduled_wake_bmc_username: "{{ lookup('env', 'IDRAC_USERNAME') }}"
+node_scheduled_wake_bmc_password: "{{ lookup('env', 'IDRAC_PASSWORD') }}"
+
+# Targets to wake (empty => the role is inert). Each entry:
+#   - name: <node>            # target node name (used for unit naming)
+#     bmc_ip: "{{ ... }}"     # target BMC address (from env/SOPS, never committed)
+#     on_calendar: [...]      # optional per-target schedule override
+node_scheduled_wake_targets: []

--- a/roles/node_scheduled_wake/defaults/main.yml
+++ b/roles/node_scheduled_wake/defaults/main.yml
@@ -34,6 +34,6 @@ node_scheduled_wake_bmc_password: "{{ lookup('env', 'IDRAC_PASSWORD') }}"
 
 # Targets to wake (empty => the role is inert). Each entry:
 #   - name: <node>            # target node name (used for unit naming)
-#     bmc_ip: "{{ ... }}"     # target BMC address (from env/SOPS, never committed)
+#     bmc_host: "{{ ... }}"   # target BMC address — FQDN preferred (env/SOPS, never committed)
 #     on_calendar: [...]      # optional per-target schedule override
 node_scheduled_wake_targets: []

--- a/roles/node_scheduled_wake/handlers/main.yml
+++ b/roles/node_scheduled_wake/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Reload systemd so it picks up the freshly written unit files. Skipped under
+# Docker (molecule), where systemd is not PID 1.
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/node_scheduled_wake/tasks/main.yml
+++ b/roles/node_scheduled_wake/tasks/main.yml
@@ -10,6 +10,25 @@
 # verify the contract); the ipmitool install, daemon-reload, and timer enable are
 # skipped under Docker, matching the node_auto_poweroff / sanoid pattern.
 
+# Fail loud at converge time if a target's BMC address is empty/undefined (e.g.
+# its env var is unset). Otherwise the unit renders `ipmitool -H` with no host
+# and the wake fails silently at runtime, when nobody is watching. Mirrors the
+# idrac_power role's bmc_host guard.
+- name: Assert each wake target has a non-empty bmc_host
+  ansible.builtin.assert:
+    that:
+      - item.bmc_host | default('') | trim | length > 0
+    fail_msg: >-
+      node_scheduled_wake target '{{ item.name }}' has an empty/undefined
+      bmc_host — check the BMC address env var (e.g. PVE3_BMC_HOSTNAME) is set.
+  loop: "{{ node_scheduled_wake_targets }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - node_scheduled_wake_enabled | bool
+  tags:
+    - node_scheduled_wake
+
 - name: Ensure ipmitool is installed (the controller issues the IPMI power-on)
   ansible.builtin.apt:
     name: ipmitool
@@ -88,16 +107,24 @@
 - name: Reload systemd before enabling the timers
   ansible.builtin.meta: flush_handlers
 
-- name: Enable and start each wake timer
+# Drive enabled/state off the flag (not gated on it) so flipping the feature
+# off actively stops + disables the timers instead of leaving previously
+# enabled ones running — otherwise a disabled controller would keep waking the
+# DR node. The units are still on disk (render is enabled-gated), so systemd can
+# act on them either way.
+- name: Set each wake timer's enabled/state from the feature flag
   ansible.builtin.systemd:
     name: "node-scheduled-wake-{{ item.name }}.timer"
-    enabled: true
-    state: started
+    enabled: "{{ node_scheduled_wake_enabled | bool }}"
+    state: "{{ 'started' if (node_scheduled_wake_enabled | bool) else 'stopped' }}"
   loop: "{{ node_scheduled_wake_targets }}"
   loop_control:
     label: "{{ item.name }}"
+  # Tolerate the disable path acting on a unit that was never rendered (the
+  # render task is enabled-gated): stopping a non-existent timer is a no-op, not
+  # an error.
+  failed_when: false
   when:
-    - node_scheduled_wake_enabled | bool
     - ansible_virtualization_type | default('') != 'docker'
   tags:
     - node_scheduled_wake

--- a/roles/node_scheduled_wake/tasks/main.yml
+++ b/roles/node_scheduled_wake/tasks/main.yml
@@ -1,0 +1,103 @@
+---
+# node_scheduled_wake tasks — render a systemd timer + oneshot service per wake
+# target on this (controller) node.
+#
+# The oneshot's ExecStart is a single `ipmitool ... chassis power on` (idempotent
+# — a no-op if the target is already on); there is no custom orchestration
+# script. The BMC password reaches the unit via a root-only 0600 EnvironmentFile
+# (ipmitool -E reads $IPMITOOL_PASSWORD) so it never lands on the command line or
+# in `systemctl cat`. The unit + credentials files always render (so molecule can
+# verify the contract); the ipmitool install, daemon-reload, and timer enable are
+# skipped under Docker, matching the node_auto_poweroff / sanoid pattern.
+
+- name: Ensure ipmitool is installed (the controller issues the IPMI power-on)
+  ansible.builtin.apt:
+    name: ipmitool
+    state: present
+    update_cache: true
+  when:
+    - node_scheduled_wake_enabled | bool
+    - node_scheduled_wake_targets | length > 0
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - node_scheduled_wake
+
+- name: Create the node_scheduled_wake credentials directory
+  ansible.builtin.file:
+    path: /etc/node-scheduled-wake
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  when:
+    - node_scheduled_wake_enabled | bool
+    - node_scheduled_wake_targets | length > 0
+  tags:
+    - node_scheduled_wake
+
+- name: Write the per-target BMC credentials EnvironmentFile
+  ansible.builtin.template:
+    src: wake-credentials.env.j2
+    dest: "/etc/node-scheduled-wake/{{ item.name }}.env"
+    owner: root
+    group: root
+    mode: "0600"
+  loop: "{{ node_scheduled_wake_targets }}"
+  loop_control:
+    label: "{{ item.name }}"
+  no_log: true
+  when:
+    - node_scheduled_wake_enabled | bool
+  tags:
+    - node_scheduled_wake
+
+- name: Render the wake service unit per target
+  ansible.builtin.template:
+    src: node-scheduled-wake.service.j2
+    dest: "/etc/systemd/system/node-scheduled-wake-{{ item.name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ node_scheduled_wake_targets }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - node_scheduled_wake_enabled | bool
+  notify: Reload systemd daemon
+  tags:
+    - node_scheduled_wake
+
+- name: Render the wake timer unit per target
+  ansible.builtin.template:
+    src: node-scheduled-wake.timer.j2
+    dest: "/etc/systemd/system/node-scheduled-wake-{{ item.name }}.timer"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ node_scheduled_wake_targets }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - node_scheduled_wake_enabled | bool
+  notify: Reload systemd daemon
+  tags:
+    - node_scheduled_wake
+
+# Apply any pending daemon-reload now so the timers below enable against the
+# freshly written units (handlers otherwise run only at end of play).
+- name: Reload systemd before enabling the timers
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start each wake timer
+  ansible.builtin.systemd:
+    name: "node-scheduled-wake-{{ item.name }}.timer"
+    enabled: true
+    state: started
+  loop: "{{ node_scheduled_wake_targets }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - node_scheduled_wake_enabled | bool
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - node_scheduled_wake

--- a/roles/node_scheduled_wake/templates/node-scheduled-wake.service.j2
+++ b/roles/node_scheduled_wake/templates/node-scheduled-wake.service.j2
@@ -1,0 +1,12 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Scheduled IPMI power-on of {{ item.name }} (offline-DR wake)
+Documentation=ansible role node_scheduled_wake
+
+[Service]
+Type=oneshot
+# Password comes from the root-only EnvironmentFile; ipmitool -E reads
+# $IPMITOOL_PASSWORD so it never appears on the command line or in `systemctl
+# cat`. `chassis power on` is idempotent — a no-op if the target is already on.
+EnvironmentFile=/etc/node-scheduled-wake/{{ item.name }}.env
+ExecStart=/usr/bin/ipmitool -I lanplus -H {{ item.bmc_ip }} -U {{ node_scheduled_wake_bmc_username }} -E chassis power on

--- a/roles/node_scheduled_wake/templates/node-scheduled-wake.service.j2
+++ b/roles/node_scheduled_wake/templates/node-scheduled-wake.service.j2
@@ -9,4 +9,4 @@ Type=oneshot
 # $IPMITOOL_PASSWORD so it never appears on the command line or in `systemctl
 # cat`. `chassis power on` is idempotent — a no-op if the target is already on.
 EnvironmentFile=/etc/node-scheduled-wake/{{ item.name }}.env
-ExecStart=/usr/bin/ipmitool -I lanplus -H {{ item.bmc_ip }} -U {{ node_scheduled_wake_bmc_username }} -E chassis power on
+ExecStart=/usr/bin/ipmitool -I lanplus -H {{ item.bmc_host }} -U {{ node_scheduled_wake_bmc_username }} -E chassis power on

--- a/roles/node_scheduled_wake/templates/node-scheduled-wake.timer.j2
+++ b/roles/node_scheduled_wake/templates/node-scheduled-wake.timer.j2
@@ -1,0 +1,16 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Scheduled IPMI power-on of {{ item.name }} (offline-DR wake)
+Documentation=ansible role node_scheduled_wake
+
+[Timer]
+{% for cal in item.on_calendar | default(node_scheduled_wake_on_calendar) %}
+OnCalendar={{ cal }}
+{% endfor %}
+# Persistent=false is deliberate: do NOT catch up a missed wake. If the
+# controller was down at the scheduled time, do not power the DR node on late —
+# wait for the next window.
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/roles/syncoid/defaults/main.yml
+++ b/roles/syncoid/defaults/main.yml
@@ -16,6 +16,24 @@ syncoid_cron_minute: 17
 # Set true to seed/refresh a normally-off DR node while it is up for a window;
 # the scheduled cron never fires on a node that is powered off at cron time.
 syncoid_run_now: false
+
+# How replication is triggered on this node:
+#   cron — a daily cron at syncoid_cron_hour:syncoid_cron_minute (always-on nodes)
+#   boot — a systemd oneshot that runs once each boot, for a normally-off DR node
+#          woken (node_scheduled_wake) for short windows where the wall-clock
+#          cron would never fire. Pairs with poweroff-on-complete below.
+syncoid_trigger: cron
+# Cap the on-boot run so a hung pull cannot keep a DR node powered up forever
+# (the node_auto_poweroff timer is the ultimate backstop). systemd TimeoutStartSec.
+syncoid_boot_timeout: "2h"
+# When syncoid_trigger == boot, chain to this unit via systemd OnSuccess=/
+# OnFailure= so the node powers OFF the moment the on-boot run finishes (success
+# OR failure). Reuses node_auto_poweroff's poweroff oneshot, so that role must be
+# enabled (node_auto_poweroff_enabled: true). Set false to leave the node up
+# after the boot run and rely only on the node_auto_poweroff timer.
+syncoid_boot_poweroff_on_complete: false
+syncoid_boot_oncomplete_unit: node-auto-poweroff.service
+
 # Integrate with sanoid: replicate existing sanoid snapshots instead of making
 # syncoid's own (--no-sync-snap), recurse the tree, stay quiet for cron.
 syncoid_default_options: "--recursive --no-sync-snap --quiet"

--- a/roles/syncoid/handlers/main.yml
+++ b/roles/syncoid/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Reload systemd so it picks up the freshly written on-boot service unit. Skipped
+# under Docker (molecule), where systemd is not PID 1.
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/syncoid/tasks/main.yml
+++ b/roles/syncoid/tasks/main.yml
@@ -36,7 +36,10 @@
   tags:
     - syncoid
 
-- name: Schedule syncoid replication
+# Trigger == cron: the default for always-on nodes. A node that is powered off at
+# cron time never fires it — which is why a normally-off DR node uses trigger ==
+# boot below instead.
+- name: Schedule syncoid replication (cron trigger)
   ansible.builtin.cron:
     name: "syncoid-replicate"
     job: "/usr/local/bin/syncoid-replicate.sh"
@@ -45,6 +48,43 @@
     user: "{{ syncoid_user }}"
   when:
     - syncoid_enabled
+    - syncoid_trigger == 'cron'
+    - syncoid_jobs | length > 0
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - syncoid
+
+# Trigger == boot: a oneshot that runs the wrapper once each boot, for a
+# normally-off DR node woken (node_scheduled_wake) for short windows where the
+# wall-clock cron would never fire. With syncoid_boot_poweroff_on_complete it
+# chains to the node_auto_poweroff oneshot so the node powers off when done. The
+# unit always renders (so molecule verifies the contract); enable is Docker-skipped.
+- name: Deploy the on-boot syncoid replication service (boot trigger)
+  ansible.builtin.template:
+    src: syncoid-replicate-on-boot.service.j2
+    dest: /etc/systemd/system/syncoid-replicate-on-boot.service
+    owner: root
+    group: root
+    mode: "0644"
+  when:
+    - syncoid_enabled
+    - syncoid_trigger == 'boot'
+    - syncoid_jobs | length > 0
+  notify: Reload systemd daemon
+  tags:
+    - syncoid
+
+# Apply any pending daemon-reload now so the enable below acts on the fresh unit.
+- name: Reload systemd before enabling the on-boot service
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable the on-boot syncoid replication service (boot trigger)
+  ansible.builtin.systemd:
+    name: syncoid-replicate-on-boot.service
+    enabled: true
+  when:
+    - syncoid_enabled
+    - syncoid_trigger == 'boot'
     - syncoid_jobs | length > 0
     - ansible_virtualization_type != 'docker'
   tags:

--- a/roles/syncoid/templates/syncoid-replicate-on-boot.service.j2
+++ b/roles/syncoid/templates/syncoid-replicate-on-boot.service.j2
@@ -1,0 +1,23 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Pull ZFS replication on boot (offline-DR window)
+Documentation=ansible role syncoid
+Wants=network-online.target
+After=network-online.target zfs.target zfs-mount.service
+
+[Service]
+Type=oneshot
+# Cap the run so a hung pull cannot keep a normally-off DR node up forever; the
+# node_auto_poweroff timer is the ultimate backstop.
+TimeoutStartSec={{ syncoid_boot_timeout }}
+ExecStart=/usr/local/bin/syncoid-replicate.sh
+{% if syncoid_boot_poweroff_on_complete | bool %}
+# Power the node off the moment replication completes — success OR failure — so a
+# normally-off DR node is up only for boot + replication. Reuses the
+# node_auto_poweroff poweroff oneshot (that role must be enabled).
+OnSuccess={{ syncoid_boot_oncomplete_unit }}
+OnFailure={{ syncoid_boot_oncomplete_unit }}
+{% endif %}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Why

The offline-DR node was never running its backups autonomously. The sleep half
existed (a fixed-time systemd poweroff timer) but **nothing woke the node**, so
its `syncoid` PULL jobs (scheduled by a wall-clock cron) fired while the node was
powered off and silently no-op'd. Its replicas went stale or were never seeded —
confirmed in code, not guessed.

## What

Wires the full **wake → replicate → sleep** cycle:

- **`node_scheduled_wake`** (new role): on an always-on controller, systemd
  timers issue an IPMI `chassis power on` to a normally-off target on a schedule
  (2×/day default). The BMC password is supplied via a root-only `0600`
  EnvironmentFile (`ipmitool -E`), never on the command line or in `systemctl
  cat`. Inert unless a host sets `node_scheduled_wake_targets`.
- **`syncoid`**: new `syncoid_trigger: boot`. A normally-off node replicates **on
  boot** (the wall-clock cron never fires inside a short wake window) and chains
  to the `node_auto_poweroff` oneshot via systemd `OnSuccess=`/`OnFailure=`, so it
  powers off the moment replication finishes — success or failure. The fixed-time
  poweroff timer remains as a guaranteed-off backstop if a run ever hangs.
- **host_vars**: the DR node enables the cycle (boot trigger, poweroff-on-
  complete, BMC IP from the environment) and stops its per-minute liveness ping
  (a normally-off node would otherwise sit "down" and alarm); the controller
  declares the DR node as a wake target. No real addresses are committed.
- **DR_RUNBOOK**: rewritten to the real `syncoid` PULL layout. It previously
  documented the un-wired PUSH `zfs_replication` role's paths/timer, none of which
  exist on the DR node — an operator following it would hit dead ends. Adds the
  wake cycle and the guest-config-recreation + clone/attach restore steps (guest
  `.conf` files are data-only, not replicated).

## Scope notes

- One approved-plan item is intentionally **deferred to a follow-up**: adding the
  DR node to the `rack_servers` inventory group. That group carries swap/
  kernel-tuning defaults, so joining it would retune a production node — unrelated
  to backups and a wider blast radius. Tracked as a follow-up issue.
- Open design choice (documented in the role README): the wake runs from an
  **on-box controller timer** (self-contained, but stores BMC creds on disk). A
  CI-scheduled alternative is cleaner only if a self-hosted runner can reach the
  homelab BMC/SSH subnets.

## Tests

- `ansible-lint` + `yamllint`: clean.
- Molecule scenario added for `node_scheduled_wake`; the `syncoid` scenario is
  extended to cover the boot trigger + poweroff-on-complete contract. Unit-template
  rendering verified directly (local molecule is blocked by the known
  `molecule-plugins` docker-driver `UnboundLocalError`; CI runs molecule).

## ⚠️ Needs live verification (CI cannot cover this)

This wires power/IPMI/replication behavior that only proves out on real hardware.
Before relying on it, in a credentialed session:

1. Add the DR node's BMC address to Doppler (the env var the wake timer reads).
2. Converge so the DR node gets the on-boot service and the controller gets the
   wake timers (the now-enabled site.yml auto-cycle powers the node on/off).
3. One real cycle: confirm the controller wakes the node via IPMI, it replicates
   on boot (`/var/log/syncoid/<date>.log`, no `FAILED`), and powers off on
   completion.
4. Replica freshness/integrity: each critical replica fresh-to-SLO and
   GUID-matched to its source (databases, appdata, object-storage, SIEM config —
   SIEM indexes are acceptable-loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
