### PR TITLE
feat(media_lxc_features): persist *arr/qBittorrent/Prowlarr/Seerr config on bulk/appdata

### DIFF
--- a/molecule/media_lxc_features/converge.yml
+++ b/molecule/media_lxc_features/converge.yml
@@ -6,16 +6,11 @@
 
   vars:
     # Stand in for the tofu inventory's service -> vmid resolution that
-    # playbooks/load_tofu.yml injects on a real host. Uses the NEW 6-digit
-    # Media-node VMID mapping (703040 plex, 736030 seerr, 715240 sonarr,
-    # 715340 radarr, 725140 download-vpn) so converge proves the role follows
-    # a renumber with no change to the service-keyed feature map.
-    media_lxc_features_service_vmids_from_tofu:
-      plex: 703040
-      seerr: 736030
-      sonarr: 715240
-      radarr: 715340
-      download-vpn: 725140
+    # playbooks/load_tofu.yml injects on a real host. The fixture
+    # (media_lxc_features_test_service_vmids) is defined ONCE in molecule.yml and
+    # holds arbitrary ids — never the real production VMIDs — so converge proves
+    # the role follows ANY renumber with no change to the service-keyed map.
+    media_lxc_features_service_vmids_from_tofu: "{{ media_lxc_features_test_service_vmids }}"
 
   roles:
     # Under Docker the role short-circuits every `pct`/blockinfile task AND

--- a/molecule/media_lxc_features/molecule.yml
+++ b/molecule/media_lxc_features/molecule.yml
@@ -27,6 +27,17 @@ provisioner:
     group_vars:
       all:
         ansible_connection: docker
+        # SINGLE source for the test's service -> vmid fixture, inherited by both
+        # converge and verify (a vmid is therefore defined in exactly one place).
+        # These are ARBITRARY test ids — NEVER the real production VMIDs, which
+        # live only in deployment.json. Using arbitrary ids is precisely what
+        # proves the service-keyed feature map follows ANY renumber unchanged.
+        media_lxc_features_test_service_vmids:
+          plex: 90001
+          seerr: 90002
+          sonarr: 90003
+          radarr: 90004
+          download-vpn: 90005
 
 verifier:
   name: ansible

--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -46,50 +46,71 @@
           - not (media_lxc_features_map['plex'].tun | bool)
         fail_msg: "plex feature contract did not resolve as expected"
 
-    - name: Assert seerr gets keyctl only, no bind-mounts, no tun
+    - name: Assert seerr persists only its own config dataset (no shared /data mount)
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['seerr'].mounts | default([]) | length == 0
+          - media_lxc_features_map['seerr'].mounts | length == 1
+          - media_lxc_features_map['seerr'].mounts[0].src == '/bulk/appdata/seerr'
+          - media_lxc_features_map['seerr'].mounts[0].dst == '/opt/seerr/config'
+          # seerr's Docker `node` has no named LXC user — owned by raw uid/gid 1000.
+          - media_lxc_features_map['seerr'].mounts[0].owner_uid | int == 1000
+          - media_lxc_features_map['seerr'].mounts[0].owner_gid | int == 1000
           - media_lxc_features_map['seerr'].keyctl | bool
           - not (media_lxc_features_map['seerr'].tun | bool)
         fail_msg: "seerr feature contract did not resolve as expected"
 
-    - name: Assert sonarr/radarr get the single unified data mount, no keyctl, no tun
+    - name: Assert sonarr/radarr get the unified data mount plus their appdata config mount
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['sonarr'].mounts | length == 1
+          - media_lxc_features_map['sonarr'].mounts | length == 2
           - media_lxc_features_map['sonarr'].mounts[0].src == '/bulk/data'
           - media_lxc_features_map['sonarr'].mounts[0].dst == '/data'
-          - media_lxc_features_map['radarr'].mounts | length == 1
+          - media_lxc_features_map['sonarr'].mounts[1].src == '/bulk/appdata/sonarr'
+          - media_lxc_features_map['sonarr'].mounts[1].dst == '/var/lib/sonarr'
+          - media_lxc_features_map['sonarr'].mounts[1].owner_user == 'sonarr'
+          - media_lxc_features_map['radarr'].mounts | length == 2
           - media_lxc_features_map['radarr'].mounts[0].src == '/bulk/data'
           - media_lxc_features_map['radarr'].mounts[0].dst == '/data'
+          - media_lxc_features_map['radarr'].mounts[1].src == '/bulk/appdata/radarr'
+          - media_lxc_features_map['radarr'].mounts[1].dst == '/var/lib/radarr'
+          - media_lxc_features_map['radarr'].mounts[1].owner_user == 'radarr'
           - not (media_lxc_features_map['sonarr'].keyctl | bool)
           - not (media_lxc_features_map['radarr'].keyctl | bool)
           - not (media_lxc_features_map['sonarr'].tun | bool)
           - not (media_lxc_features_map['radarr'].tun | bool)
         fail_msg: "sonarr/radarr feature contract did not resolve as expected"
 
-    - name: Assert download-vpn gets the single unified data mount, keyctl, and tun
+    - name: Assert download-vpn gets the data mount plus qbittorrent + prowlarr config mounts, keyctl, tun
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['download-vpn'].mounts | length == 1
+          - media_lxc_features_map['download-vpn'].mounts | length == 3
           - media_lxc_features_map['download-vpn'].mounts[0].src == '/bulk/data'
           - media_lxc_features_map['download-vpn'].mounts[0].dst == '/data'
+          - media_lxc_features_map['download-vpn'].mounts[1].src == '/bulk/appdata/qbittorrent'
+          - media_lxc_features_map['download-vpn'].mounts[1].dst == '/home/qbittorrent'
+          - media_lxc_features_map['download-vpn'].mounts[1].owner_user == 'qbittorrent'
+          - media_lxc_features_map['download-vpn'].mounts[2].src == '/bulk/appdata/prowlarr'
+          - media_lxc_features_map['download-vpn'].mounts[2].dst == '/var/lib/prowlarr'
+          # Prowlarr runs as the qbittorrent user (download_vpn_user), so both
+          # config mounts in this container share that owner.
+          - media_lxc_features_map['download-vpn'].mounts[2].owner_user == 'qbittorrent'
           - media_lxc_features_map['download-vpn'].keyctl | bool
           - media_lxc_features_map['download-vpn'].tun | bool
         fail_msg: "download-vpn feature contract did not resolve as expected"
 
-    - name: Assert every mounted service shares the SAME dataset (hardlink contract)
+    - name: Assert every shared /data mount uses the SAME dataset (hardlink contract)
       ansible.builtin.assert:
         that:
-          # qBittorrent + the *arrs can only hardlink within one dataset, so
-          # every declared mount across all services must share one source.
+          # qBittorrent + the *arrs can only hardlink within one dataset, so every
+          # shared-library (/data) mount must share one source. App-private
+          # /bulk/appdata/<app> config mounts are exempt — per-app, never hardlinked.
           - >-
             media_lxc_features_map | dict2items
             | map(attribute='value.mounts') | map('default', [])
-            | flatten | map(attribute='src') | unique | list
+            | flatten | selectattr('dst', 'eq', '/data')
+            | map(attribute='src') | unique | list
             == ['/bulk/data']
-        fail_msg: "all mounted media services must share the single /bulk/data dataset"
+        fail_msg: "all /data media mounts must share the single /bulk/data dataset"
 
     - name: Assert the tun device numbers are the TUN/TAP allocation (10:200)
       ansible.builtin.assert:
@@ -144,23 +165,23 @@
     - name: Assert the join puts each service's features on its NEW vmid
       ansible.builtin.assert:
         that:
-          # NEW: 703040 plex (single data mount, no keyctl, no tun)
+          # NEW: 703040 plex (unified data mount + persistent appdata, no keyctl, no tun)
           - "'703040' in media_lxc_features_verify_resolved"
-          - media_lxc_features_verify_resolved['703040'].mounts | length == 1
+          - media_lxc_features_verify_resolved['703040'].mounts | length == 2
           - media_lxc_features_verify_resolved['703040'].mounts[0].dst == '/data'
           - not (media_lxc_features_verify_resolved['703040'].keyctl | bool)
           - not (media_lxc_features_verify_resolved['703040'].tun | bool)
-          # NEW: 736030 seerr (keyctl only, no mounts, no tun)
-          - media_lxc_features_verify_resolved['736030'].mounts | length == 0
+          # NEW: 736030 seerr (own config mount, keyctl, no tun)
+          - media_lxc_features_verify_resolved['736030'].mounts | length == 1
           - media_lxc_features_verify_resolved['736030'].keyctl | bool
           - not (media_lxc_features_verify_resolved['736030'].tun | bool)
-          # NEW: 715240 sonarr / 715340 radarr (single data mount, no keyctl, no tun)
-          - media_lxc_features_verify_resolved['715240'].mounts | length == 1
-          - media_lxc_features_verify_resolved['715340'].mounts | length == 1
+          # NEW: 715240 sonarr / 715340 radarr (data mount + appdata config mount, no keyctl, no tun)
+          - media_lxc_features_verify_resolved['715240'].mounts | length == 2
+          - media_lxc_features_verify_resolved['715340'].mounts | length == 2
           - not (media_lxc_features_verify_resolved['715240'].keyctl | bool)
           - not (media_lxc_features_verify_resolved['715340'].tun | bool)
-          # NEW: 725140 download-vpn (single data mount + keyctl + tun)
-          - media_lxc_features_verify_resolved['725140'].mounts | length == 1
+          # NEW: 725140 download-vpn (data + qbittorrent + prowlarr mounts + keyctl + tun)
+          - media_lxc_features_verify_resolved['725140'].mounts | length == 3
           - media_lxc_features_verify_resolved['725140'].keyctl | bool
           - media_lxc_features_verify_resolved['725140'].tun | bool
         fail_msg: "service -> vmid join did not place features on the new vmids"

--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -4,99 +4,60 @@
   become: false
   gather_facts: true
 
-  vars:
-    # The NEW 6-digit media-node VMID mapping (same as converge). Used to prove
-    # the service-keyed feature map resolves onto the renumbered vmids.
-    media_lxc_features_verify_service_vmids:
-      plex: 703040
-      seerr: 736030
-      sonarr: 715240
-      radarr: 715340
-      download-vpn: 725140
+  # The synthetic service -> vmid fixture (media_lxc_features_test_service_vmids)
+  # is defined ONCE in molecule.yml (provisioner.inventory.group_vars.all) and
+  # inherited here and by converge. Its values are ARBITRARY test ids, never the
+  # real production VMIDs — those live only in deployment.json. Every assertion
+  # below is derived from the service-keyed feature map or that fixture; no vmid
+  # and no per-service value is hardcoded in this file.
 
   tasks:
     - name: Load the role defaults (service-keyed feature map)
       ansible.builtin.include_vars:
         file: "{{ playbook_dir }}/../../roles/media_lxc_features/defaults/main.yml"
 
-    - name: Assert the feature map is keyed by service, not raw vmid
+    # --- Contract invariants — derived from the map, no per-service literals ----
+    - name: Assert the feature map is keyed by service name, never a raw vmid
       ansible.builtin.assert:
         that:
-          - "'plex' in media_lxc_features_map"
-          - "'seerr' in media_lxc_features_map"
-          - "'sonarr' in media_lxc_features_map"
-          - "'radarr' in media_lxc_features_map"
-          - "'download-vpn' in media_lxc_features_map"
-          # No raw vmids leaked back in as keys.
-          - "'703040' not in media_lxc_features_map"
-          - "'725140' not in media_lxc_features_map"
+          # No map key is all-digits (a leaked vmid).
+          - media_lxc_features_map.keys() | list | select('match', '^[0-9]+$') | list | length == 0
+          # No fixture vmid value appears as a map key either.
+          - >-
+            media_lxc_features_test_service_vmids.values() | map('string') | list
+            | select('in', media_lxc_features_map.keys() | list) | list | length == 0
         fail_msg: "media_lxc_features_map must be keyed by service name, not vmid"
 
-    - name: Assert plex gets the unified data mount plus its persistent appdata mount
+    - name: Assert data_idmap is set exactly when the service bind-mounts shared /data
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['plex'].mounts | length == 2
-          - media_lxc_features_map['plex'].mounts[0].src == '/bulk/data'
-          - media_lxc_features_map['plex'].mounts[0].dst == '/data'
-          - not (media_lxc_features_map['plex'].mounts[0].ro | default(false))
-          - media_lxc_features_map['plex'].mounts[1].src == '/bulk/appdata/plex'
-          - media_lxc_features_map['plex'].mounts[1].dst == '/var/lib/plexmediaserver'
-          - media_lxc_features_map['plex'].mounts[1].owner_user == 'plex'
-          - not (media_lxc_features_map['plex'].keyctl | bool)
-          - not (media_lxc_features_map['plex'].tun | bool)
-        fail_msg: "plex feature contract did not resolve as expected"
+          - >-
+            ('/data' in (item.value.mounts | default([]) | map(attribute='dst') | list))
+            == (item.value.data_idmap | default(false) | bool)
+        fail_msg: "{{ item.key }}: data_idmap must be true exactly when /data is mounted"
+      loop: "{{ media_lxc_features_map | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
 
-    - name: Assert seerr persists only its own config dataset (no shared /data mount)
+    - name: Assert every service persists its own config on an owned bulk/appdata mount
       ansible.builtin.assert:
         that:
-          - media_lxc_features_map['seerr'].mounts | length == 1
-          - media_lxc_features_map['seerr'].mounts[0].src == '/bulk/appdata/seerr'
-          - media_lxc_features_map['seerr'].mounts[0].dst == '/opt/seerr/config'
-          # seerr's Docker `node` has no named LXC user — owned by raw uid/gid 1000.
-          - media_lxc_features_map['seerr'].mounts[0].owner_uid | int == 1000
-          - media_lxc_features_map['seerr'].mounts[0].owner_gid | int == 1000
-          - media_lxc_features_map['seerr'].keyctl | bool
-          - not (media_lxc_features_map['seerr'].tun | bool)
-        fail_msg: "seerr feature contract did not resolve as expected"
-
-    - name: Assert sonarr/radarr get the unified data mount plus their appdata config mount
-      ansible.builtin.assert:
-        that:
-          - media_lxc_features_map['sonarr'].mounts | length == 2
-          - media_lxc_features_map['sonarr'].mounts[0].src == '/bulk/data'
-          - media_lxc_features_map['sonarr'].mounts[0].dst == '/data'
-          - media_lxc_features_map['sonarr'].mounts[1].src == '/bulk/appdata/sonarr'
-          - media_lxc_features_map['sonarr'].mounts[1].dst == '/var/lib/sonarr'
-          - media_lxc_features_map['sonarr'].mounts[1].owner_user == 'sonarr'
-          - media_lxc_features_map['radarr'].mounts | length == 2
-          - media_lxc_features_map['radarr'].mounts[0].src == '/bulk/data'
-          - media_lxc_features_map['radarr'].mounts[0].dst == '/data'
-          - media_lxc_features_map['radarr'].mounts[1].src == '/bulk/appdata/radarr'
-          - media_lxc_features_map['radarr'].mounts[1].dst == '/var/lib/radarr'
-          - media_lxc_features_map['radarr'].mounts[1].owner_user == 'radarr'
-          - not (media_lxc_features_map['sonarr'].keyctl | bool)
-          - not (media_lxc_features_map['radarr'].keyctl | bool)
-          - not (media_lxc_features_map['sonarr'].tun | bool)
-          - not (media_lxc_features_map['radarr'].tun | bool)
-        fail_msg: "sonarr/radarr feature contract did not resolve as expected"
-
-    - name: Assert download-vpn gets the data mount plus qbittorrent + prowlarr config mounts, keyctl, tun
-      ansible.builtin.assert:
-        that:
-          - media_lxc_features_map['download-vpn'].mounts | length == 3
-          - media_lxc_features_map['download-vpn'].mounts[0].src == '/bulk/data'
-          - media_lxc_features_map['download-vpn'].mounts[0].dst == '/data'
-          - media_lxc_features_map['download-vpn'].mounts[1].src == '/bulk/appdata/qbittorrent'
-          - media_lxc_features_map['download-vpn'].mounts[1].dst == '/home/qbittorrent'
-          - media_lxc_features_map['download-vpn'].mounts[1].owner_user == 'qbittorrent'
-          - media_lxc_features_map['download-vpn'].mounts[2].src == '/bulk/appdata/prowlarr'
-          - media_lxc_features_map['download-vpn'].mounts[2].dst == '/var/lib/prowlarr'
-          # Prowlarr runs as the qbittorrent user (download_vpn_user), so both
-          # config mounts in this container share that owner.
-          - media_lxc_features_map['download-vpn'].mounts[2].owner_user == 'qbittorrent'
-          - media_lxc_features_map['download-vpn'].keyctl | bool
-          - media_lxc_features_map['download-vpn'].tun | bool
-        fail_msg: "download-vpn feature contract did not resolve as expected"
+          # at least one app-config mount (anything that is not the shared /data)
+          - >-
+            item.value.mounts | default([]) | selectattr('dst', 'ne', '/data') | list | length >= 1
+          # every app-config mount is owned by the app (owner_user or owner_uid)
+          - >-
+            item.value.mounts | default([]) | selectattr('dst', 'ne', '/data')
+            | rejectattr('owner_user', 'defined') | rejectattr('owner_uid', 'defined')
+            | list | length == 0
+          # and lives under the bulk/appdata tree
+          - >-
+            item.value.mounts | default([]) | selectattr('dst', 'ne', '/data')
+            | rejectattr('src', 'match', '^/bulk/appdata/') | list | length == 0
+        fail_msg: "{{ item.key }}: needs an owned /bulk/appdata/<app> config mount"
+      loop: "{{ media_lxc_features_map | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
 
     - name: Assert every shared /data mount uses the SAME dataset (hardlink contract)
       ansible.builtin.assert:
@@ -106,11 +67,23 @@
           # /bulk/appdata/<app> config mounts are exempt — per-app, never hardlinked.
           - >-
             media_lxc_features_map | dict2items
-            | map(attribute='value.mounts') | map('default', [])
-            | flatten | selectattr('dst', 'eq', '/data')
-            | map(attribute='src') | unique | list
+            | map(attribute='value.mounts') | map('default', []) | flatten
+            | selectattr('dst', 'eq', '/data') | map(attribute='src') | unique | list
             == ['/bulk/data']
         fail_msg: "all /data media mounts must share the single /bulk/data dataset"
+
+    - name: Assert tun/keyctl land on exactly the services that need them
+      ansible.builtin.assert:
+        that:
+          # /dev/net/tun only where WireGuard runs; keyctl where the keyring is needed.
+          - >-
+            media_lxc_features_map | dict2items | selectattr('value.tun', 'defined')
+            | selectattr('value.tun') | map(attribute='key') | sort | list == ['download-vpn']
+          - >-
+            media_lxc_features_map | dict2items | selectattr('value.keyctl', 'defined')
+            | selectattr('value.keyctl') | map(attribute='key') | sort | list
+            == ['download-vpn', 'seerr']
+        fail_msg: "tun/keyctl drifted from the services that require them"
 
     - name: Assert the tun device numbers are the TUN/TAP allocation (10:200)
       ansible.builtin.assert:
@@ -135,17 +108,17 @@
 
     # ---------------------------------------------------------------------------
     # Service -> vmid JOIN: the load-bearing refactor. Re-derive the resolved
-    # vmid-keyed map exactly as roles/.../tasks/main.yml does, against the NEW
-    # mapping, and prove each service's features land on its new vmid. This is
-    # what makes a renumber need no role change.
+    # vmid-keyed map exactly as roles/.../tasks/main.yml does, against the shared
+    # fixture, and prove each service's features land on its vmid unchanged. This
+    # is what makes a renumber need no role change — and it is asserted by looping
+    # the fixture, so no vmid is written out by hand.
     # ---------------------------------------------------------------------------
-    - name: Resolve the service feature map to the NEW vmids (as the role does)
+    - name: Resolve the service feature map onto the fixture vmids (as the role does)
       ansible.builtin.set_fact:
         media_lxc_features_verify_selected: >-
           {{
             media_lxc_features_map | dict2items
-            | selectattr('key', 'in', media_lxc_features_verify_service_vmids)
-            | list
+            | selectattr('key', 'in', media_lxc_features_test_service_vmids) | list
           }}
     - name: Build the resolved vmid-keyed map (as the role does)
       ansible.builtin.set_fact:
@@ -153,72 +126,41 @@
           {{
             dict(
               (
-                media_lxc_features_verify_selected
-                | map(attribute='key')
-                | map('extract', media_lxc_features_verify_service_vmids)
-                | map('string') | list
+                media_lxc_features_verify_selected | map(attribute='key')
+                | map('extract', media_lxc_features_test_service_vmids) | map('string') | list
               )
               | zip(media_lxc_features_verify_selected | map(attribute='value') | list)
             )
           }}
 
-    - name: Assert the join puts each service's features on its NEW vmid
+    - name: Assert the join places each service's features on its fixture vmid, unchanged
       ansible.builtin.assert:
         that:
-          # NEW: 703040 plex (unified data mount + persistent appdata, no keyctl, no tun)
-          - "'703040' in media_lxc_features_verify_resolved"
-          - media_lxc_features_verify_resolved['703040'].mounts | length == 2
-          - media_lxc_features_verify_resolved['703040'].mounts[0].dst == '/data'
-          - not (media_lxc_features_verify_resolved['703040'].keyctl | bool)
-          - not (media_lxc_features_verify_resolved['703040'].tun | bool)
-          # NEW: 736030 seerr (own config mount, keyctl, no tun)
-          - media_lxc_features_verify_resolved['736030'].mounts | length == 1
-          - media_lxc_features_verify_resolved['736030'].keyctl | bool
-          - not (media_lxc_features_verify_resolved['736030'].tun | bool)
-          # NEW: 715240 sonarr / 715340 radarr (data mount + appdata config mount, no keyctl, no tun)
-          - media_lxc_features_verify_resolved['715240'].mounts | length == 2
-          - media_lxc_features_verify_resolved['715340'].mounts | length == 2
-          - not (media_lxc_features_verify_resolved['715240'].keyctl | bool)
-          - not (media_lxc_features_verify_resolved['715340'].tun | bool)
-          # NEW: 725140 download-vpn (data + qbittorrent + prowlarr mounts + keyctl + tun)
-          - media_lxc_features_verify_resolved['725140'].mounts | length == 3
-          - media_lxc_features_verify_resolved['725140'].keyctl | bool
-          - media_lxc_features_verify_resolved['725140'].tun | bool
-        fail_msg: "service -> vmid join did not place features on the new vmids"
+          - media_lxc_features_verify_resolved[item.value | string] == media_lxc_features_map[item.key]
+        fail_msg: "service {{ item.key }} did not resolve onto vmid {{ item.value }} with its features"
+      loop: "{{ media_lxc_features_test_service_vmids | dict2items }}"
+      loop_control:
+        label: "{{ item.key }} -> {{ item.value }}"
 
-    - name: Build a partial resolution (only plex placed) for the absent-skip case
-      ansible.builtin.set_fact:
-        media_lxc_features_verify_partial_sel: >-
-          {{
+    - name: Assert an unresolved service is skipped (absent-skip behaviour)
+      vars:
+        media_lxc_features_verify_one: "{{ media_lxc_features_map.keys() | list | first }}"
+      ansible.builtin.assert:
+        that:
+          # Selecting a single service from the map resolves to exactly its vmid —
+          # services absent from the fixture contribute nothing.
+          - >-
             media_lxc_features_map | dict2items
-            | selectattr('key', 'in', {'plex': 703040})
-            | list
-          }}
-    - name: Resolve the partial map (as the role does)
-      ansible.builtin.set_fact:
-        media_lxc_features_verify_partial: >-
-          {{
-            dict(
-              (
-                media_lxc_features_verify_partial_sel
-                | map(attribute='key')
-                | map('extract', {'plex': 703040})
-                | map('string') | list
-              )
-              | zip(media_lxc_features_verify_partial_sel | map(attribute='value') | list)
-            )
-          }}
-
-    - name: Assert only the resolvable service appears (absent-skip behaviour)
-      ansible.builtin.assert:
-        that:
-          - media_lxc_features_verify_partial.keys() | list == ['703040']
+            | selectattr('key', 'equalto', media_lxc_features_verify_one)
+            | map(attribute='key') | map('extract', media_lxc_features_test_service_vmids)
+            | map('string') | list
+            == [media_lxc_features_test_service_vmids[media_lxc_features_verify_one] | string]
         fail_msg: "unresolved services must not appear in the effective map"
 
     # Guards the keyctl feature-merge logic (the load-bearing expression the role
     # uses to build `pct set --features` and gate its idempotent `when`). Proves
-    # keyctl=1 is merged in WITHOUT dropping a tofu-set nesting=1, the result
-    # is sorted (stable), and an already-converged host yields no change.
+    # keyctl=1 is merged in WITHOUT dropping a tofu-set nesting=1, the result is
+    # sorted (stable), and an already-converged host yields no change.
     - name: Merge keyctl into a nesting-only feature set (as the role does)
       ansible.builtin.set_fact:
         media_lxc_features_verify_cur: ["nesting=1"]
@@ -230,11 +172,8 @@
     - name: Assert keyctl-merge preserves nesting, sorts, and is idempotent
       ansible.builtin.assert:
         that:
-          # nesting preserved, keyctl added, sorted for a stable pct-set string
           - media_lxc_features_verify_merged == ['keyctl=1', 'nesting=1']
-          # a nesting-only container would change (keyctl is added)
           - (media_lxc_features_verify_cur | sort) != media_lxc_features_verify_merged
-          # an already-converged container yields no change (idempotent)
           - (['keyctl=1', 'nesting=1'] | sort) == media_lxc_features_verify_converged
         fail_msg: "keyctl feature-merge logic regressed (drop, order, or idempotency)"
 

--- a/roles/media_lxc_features/README.md
+++ b/roles/media_lxc_features/README.md
@@ -53,10 +53,10 @@ service, never a hardcoded VMID:
 | service | bind-mounts (host -> container) | keyctl | /dev/net/tun |
 | --- | --- | --- | --- |
 | plex | `/bulk/data`->`/data`, `/bulk/appdata/plex`->`/var/lib/plexmediaserver` | no | no |
-| seerr | (none) | yes | no |
-| sonarr | `/bulk/data`->`/data` | no | no |
-| radarr | `/bulk/data`->`/data` | no | no |
-| download-vpn | `/bulk/data`->`/data` | yes | yes |
+| seerr | `/bulk/appdata/seerr`->`/opt/seerr/config` | yes | no |
+| sonarr | `/bulk/data`->`/data`, `/bulk/appdata/sonarr`->`/var/lib/sonarr` | no | no |
+| radarr | `/bulk/data`->`/data`, `/bulk/appdata/radarr`->`/var/lib/radarr` | no | no |
+| download-vpn | `/bulk/data`->`/data`, `/bulk/appdata/qbittorrent`->`/home/qbittorrent`, `/bulk/appdata/prowlarr`->`/var/lib/prowlarr` | yes | yes |
 
 Every mounted service gets the unified `bulk/data` dataset -> `/data`. One
 dataset (replacing the old separate `downloads` + `media` datasets/mounts) is
@@ -64,11 +64,14 @@ what lets qBittorrent and the *arrs **hardlink** between `/data/torrents/*` and
 `/data/media/*` — hardlinks cannot cross dataset boundaries. All bind-mounts are
 **read-write** (no `ro=1`), the role's existing convention (plex is read-mostly
 by usage, not by mount flag). `/dev/net/tun` is char device **10:200** (verified
-on the primary node). Plex additionally gets a **persistent config mount** — see below.
+on the primary node). Every service additionally gets a **persistent config
+mount** — see below.
 
-A mount may carry `owner_user: <name>`. That marks an app-**private** config
-dataset that must be owned by the app *user* (not the shared `media` group), and
-the role chowns the host path to that user's mapped host uid/gid.
+A mount may carry `owner_user: <name>` (or `owner_uid`/`owner_gid` for an owner
+with no named user, e.g. seerr's Docker `node` uid 1000). That marks an
+app-**private** config dataset that must be owned by the app itself (not the
+shared `media` group), and the role chowns the host path to that owner's mapped
+host uid/gid.
 
 ## Shared data root (host side)
 
@@ -88,41 +91,53 @@ Hosts without the data root (no bulk pool, or `zfs_pools` not yet applied)
 skip these tasks entirely; the role never invents a plain directory on the
 root filesystem.
 
-## Plex config persistence (`bulk/appdata/plex`)
+## App config persistence (`bulk/appdata/<app>`)
 
-Plex stores its **identity + state** — `Preferences.xml` (the
-`machineIdentifier`, the plex.tv claim token, and the "publish to plex.tv" flag)
-and the library database (watch history) — under `/var/lib/plexmediaserver`. On
-a plain LXC that directory lives on the **disposable rootfs**, so a container
-**rebuild** wipes it: Plex comes back as a *brand-new server* (new identity →
-orphaned history + shares, a "sign in / set up again" prompt). To stop that, the
-plex service bind-mounts the dedicated **`bulk/appdata/plex`** dataset over
-`/var/lib/plexmediaserver`, so identity + history live **off the rootfs** and
-survive any restart **or** rebuild.
+Every media app keeps its **own database + settings** under a single config
+directory. On a plain LXC that directory lives on the **disposable rootfs**, so a
+container **rebuild** wipes it. To stop that, each service bind-mounts a dedicated
+**`bulk/appdata/<app>`** dataset over its config dir, so all of its state lives
+**off the rootfs** and survives any restart **or** rebuild. The app rebuilds
+itself from its own DB on startup — there is no export/replay step.
 
-- **Dataset**: `bulk/appdata` (parent) + `bulk/appdata/plex` are declared in
-  terraform-proxmox `node_storage` and realized by `zfs_pools`. `bulk/appdata` is
-  the home for app *config/state* (distinct from `bulk/databases`, which is for
-  database engines, and `bulk/data`, the re-acquirable media library).
+| service | config dir | what persists |
+| --- | --- | --- |
+| plex | `/var/lib/plexmediaserver` | identity (`machineIdentifier` + claim + publish) + watch-history DB |
+| sonarr | `/var/lib/sonarr` | `sonarr.db` (series, history, queue, blocklist) + `config.xml` |
+| radarr | `/var/lib/radarr` | `radarr.db` + `config.xml` |
+| download-vpn | `/home/qbittorrent` | qBittorrent prefs + `.local/share` `BT_backup` (active torrents / resume / seeding) |
+| download-vpn | `/var/lib/prowlarr` | `prowlarr.db` (indexers, private-tracker auth, app-sync links) |
+| seerr | `/opt/seerr/config` | `settings.json` + `db.sqlite3` (users, requests, registrations) |
+
+- **Dataset**: `bulk/appdata` (parent) + one `bulk/appdata/<app>` child per
+  service are declared in terraform-proxmox `node_storage` and realized by
+  `zfs_pools`. `bulk/appdata` is the home for app *config/state* (distinct from
+  `bulk/databases`, for database engines, and `bulk/data`, the re-acquirable
+  media library).
 - **Snapshots + DR**: `bulk/appdata` gets the **`critical`** sanoid template
-  (hourly point-in-time — right for constantly-changing watch progress) on the
-  always-on storage node, and a recursive syncoid pull to the offline-DR leg.
-  Both are configured in host_vars and cover every `bulk/appdata/<app>` child.
-- **Ownership**: the mount carries `owner_user: plex`. Plex's config is owned by
-  the `plex` *user*; the container leaves its UID map at the default offset, so
-  the role chowns the host dataset to `unpriv_base + <live in-container plex
-  uid/gid>` (resolved per container; the ids are package-assigned, never
-  hardcoded).
+  (hourly point-in-time — right for constantly-changing state) on the always-on
+  storage node, and a recursive syncoid pull to the offline-DR leg. Both are
+  configured in host_vars and cover every `bulk/appdata/<app>` child, so a new
+  child inherits hourly snapshots + DR with no extra config.
+- **Ownership**: each config mount carries `owner_user: <app>` (or
+  `owner_uid: 1000` for seerr's unnamed Docker `node`). The config is owned by the
+  app itself; the container leaves its UID map at the default offset, so the role
+  chowns the host dataset to `unpriv_base + <in-container uid/gid>` (resolved live
+  for named users; the ids are package-assigned, never hardcoded). qBittorrent and
+  Prowlarr both run as the `qbittorrent` user, so download-vpn's two config mounts
+  share that owner. WireGuard config lives at `/etc/wireguard` (outside
+  `/home/qbittorrent`), so the whole-home qBittorrent mount is safe.
 - **Fresh-build ordering caveat**: on a *from-scratch* shell this role runs
-  **before** the apps converge installs Plex, so `id plex` does not resolve yet
-  and the ownership chown is skipped (non-fatal). Run order on a new build is:
-  `media_lxc_features` (mount) → apps converge (installs Plex) →
+  **before** the apps converge installs each app, so `id <app>` does not resolve
+  yet and the ownership chown is skipped (non-fatal). Run order on a new build is:
+  `media_lxc_features` (mount) → apps converge (installs the apps) →
   `media_lxc_features` once more (ownership reconciles). The dataset **data** is
   never at risk — it lives outside the rootfs that the rebuild replaces.
-
-`bulk/appdata/<app>` is the correct future home for the Sonarr / Radarr /
-qBittorrent / Prowlarr configs too (same rootfs-only vulnerability) — add a
-second mount with `owner_user: <app>` per service to extend it.
+- **First cutover (existing live data)**: an app already running on the rootfs has
+  its current DB there, not yet on the empty dataset. Mounting the empty dataset
+  over it would hide that DB. Seed each `bulk/appdata/<app>` from the app's live
+  config **once** before the mount takes over (see the repo rollout notes); after
+  that the dataset is the source of truth and every future rebuild is safe.
 
 ### VMID resolution (renumber-proof)
 

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -21,7 +21,11 @@
 #   mounts:     list of { src: <host path>, dst: <in-container path>, ro: <bool,
 #               default false>, owner_user: <optional in-container user that must
 #               OWN this host dataset — chowns src to that user's mapped host
-#               uid/gid; for app-private config dirs, vs the shared-GID /data> }
+#               uid/gid; for app-private config dirs, vs the shared-GID /data>,
+#               owner_uid/owner_gid: <optional explicit in-container uid:gid when
+#               the owner is a raw numeric id with no named user — e.g. seerr's
+#               Docker `node` (uid 1000). Same mapped-host chown as owner_user,
+#               but skips the name lookup. Use one of owner_user OR owner_uid> }
 #   keyctl:     bool — ensure features contains keyctl=1, MERGED into existing
 #               features (tofu-set nesting=1 is preserved, never dropped)
 #   tun:        bool — passthrough /dev/net/tun (char 10:200) into the container
@@ -30,7 +34,8 @@
 #               container. Without it, host GID 13000 falls below the unpriv map
 #               base (100000) and /data appears as nobody:nogroup inside —
 #               read-only to the container's `media` user. Set on every service
-#               that bind-mounts /data (all but seerr, which has no mount).
+#               that bind-mounts /data (all but seerr, which mounts only its own
+#               config dataset, not the shared /data).
 #
 # Only vmids that actually exist on the target host are acted on; absent vmids
 # are skipped (tofu may not have created them yet). All tasks are skipped
@@ -42,12 +47,26 @@
 # boundary). All mounts stay read-write (the role's existing convention; plex is
 # read-mostly by usage, not by mount flag).
 #
-# Plex additionally bind-mounts a PERSISTENT app-config dataset (bulk/appdata/plex)
-# over its home, so its identity (Preferences.xml machineIdentifier + claim +
-# publish) and watch-history DB survive a container restart OR rebuild instead of
-# living on the disposable rootfs. The whole home is mounted (no spaces in the
-# path, so the command-module mount task stays trivial); ownership is the plex
-# USER's mapped host id (owner_user), not the shared media GID.
+# EVERY media service additionally bind-mounts a PERSISTENT app-config dataset
+# (bulk/appdata/<service>) over the directory holding its database + settings, so
+# all of its own state survives a container restart OR rebuild instead of living
+# on the disposable rootfs. The app rebuilds itself from its own DB on startup —
+# no export/replay needed. What each persists:
+#   plex          /var/lib/plexmediaserver  identity (machineIdentifier + claim +
+#                                            publish) + watch-history DB
+#   sonarr        /var/lib/sonarr           sonarr.db (series, history, queue,
+#                                            blocklist) + config.xml
+#   radarr        /var/lib/radarr           radarr.db + config.xml
+#   download-vpn  /home/qbittorrent         qBittorrent prefs + .local/share BT_backup
+#                                            (active torrents / resume / seeding)
+#   download-vpn  /var/lib/prowlarr         prowlarr.db (indexers, private-tracker
+#                                            auth, app-sync links)
+#   seerr         /opt/seerr/config         settings.json + db.sqlite3 (users,
+#                                            requests, service registrations)
+# Ownership is the app's OWN mapped host id (owner_user, or owner_uid for seerr's
+# unnamed Docker uid 1000), not the shared media GID. WireGuard config lives at
+# /etc/wireguard (outside /home/qbittorrent), so the whole-home qBittorrent mount
+# is safe.
 media_lxc_features_map:
   plex:  # media streaming
     mounts:
@@ -56,26 +75,31 @@ media_lxc_features_map:
     keyctl: false
     tun: false
     data_idmap: true
-  seerr:  # request UI (Docker-in-LXC); no bind-mounts
-    mounts: []
+  seerr:  # request UI (Docker-in-LXC); config-only persistence, no /data mount
+    mounts:
+      - { src: /bulk/appdata/seerr, dst: /opt/seerr/config, owner_uid: 1000, owner_gid: 1000 }
     keyctl: true
     tun: false
     data_idmap: false
   sonarr:  # TV PVR
     mounts:
       - { src: /bulk/data, dst: /data }
+      - { src: /bulk/appdata/sonarr, dst: /var/lib/sonarr, owner_user: sonarr }
     keyctl: false
     tun: false
     data_idmap: true
   radarr:  # movie PVR
     mounts:
       - { src: /bulk/data, dst: /data }
+      - { src: /bulk/appdata/radarr, dst: /var/lib/radarr, owner_user: radarr }
     keyctl: false
     tun: false
     data_idmap: true
-  download-vpn:  # qBittorrent + Prowlarr behind Proton WireGuard
+  download-vpn:  # qBittorrent + Prowlarr behind Proton WireGuard (both run as the qbittorrent user)
     mounts:
       - { src: /bulk/data, dst: /data }
+      - { src: /bulk/appdata/qbittorrent, dst: /home/qbittorrent, owner_user: qbittorrent }
+      - { src: /bulk/appdata/prowlarr, dst: /var/lib/prowlarr, owner_user: qbittorrent }
     keyctl: true
     tun: true
     data_idmap: true

--- a/roles/media_lxc_features/tasks/configure_container.yml
+++ b/roles/media_lxc_features/tasks/configure_container.yml
@@ -60,21 +60,30 @@
     - media_lxc_features
 
 # ---------------------------------------------------------------------------
-# Per-app config-mount ownership (mounts carrying `owner_user`)
+# Per-app config-mount ownership (mounts carrying `owner_user` or `owner_uid`)
 # ---------------------------------------------------------------------------
-# A mount whose host dataset must be owned by an in-container app USER (e.g. the
-# plex user on bulk/appdata/plex) gets chowned to that user's MAPPED host uid/gid
-# (unpriv_base + the live in-container id). Looped so future app-config mounts
-# (sonarr/radarr/...) reuse it unchanged. Per-mount logic in the included file
-# (idempotent stat-then-chown; non-fatal skip when the app user isn't installed
-# yet on a fresh build — the dataset data lives off the rootfs and is never at
-# risk).
+# A mount whose host dataset must be owned by an in-container app owner (e.g. the
+# plex user on bulk/appdata/plex, or seerr's raw uid 1000 on bulk/appdata/seerr)
+# gets chowned to that owner's MAPPED host uid/gid (unpriv_base + the in-container
+# id). Looped over every owner-bearing mount, so a container with more than one
+# app-config mount (download-vpn: qbittorrent + prowlarr) reconciles each. A mount
+# carries EITHER owner_user (named, resolved live) OR owner_uid/owner_gid
+# (explicit) — the union below selects both; no mount carries both keys.
+# Per-mount logic in the included file (idempotent stat-then-chown; non-fatal skip
+# when the app user isn't installed yet on a fresh build — the dataset data lives
+# off the rootfs and is never at risk).
 - name: "Reconcile config-mount ownership on {{ media_ct.key }}"
   ansible.builtin.include_tasks: reconcile_config_owner.yml
-  loop: "{{ media_ct.value.mounts | default([]) | selectattr('owner_user', 'defined') | list }}"
+  loop: >-
+    {{
+      (media_ct.value.mounts | default([]) | selectattr('owner_user', 'defined') | list)
+      + (media_ct.value.mounts | default([]) | selectattr('owner_uid', 'defined') | list)
+    }}
   loop_control:
     loop_var: media_cfg_mp
-    label: "{{ media_ct.key }} {{ media_cfg_mp.src }} -> owner {{ media_cfg_mp.owner_user }}"
+    label: >-
+      {{ media_ct.key }} {{ media_cfg_mp.src }} -> owner
+      {{ media_cfg_mp.owner_user | default('uid ' ~ media_cfg_mp.owner_uid | default('?')) }}
   tags:
     - media_lxc_features
 

--- a/roles/media_lxc_features/tasks/reconcile_config_owner.yml
+++ b/roles/media_lxc_features/tasks/reconcile_config_owner.yml
@@ -40,10 +40,13 @@
     # Explicit owner_uid/owner_gid take precedence; otherwise use the live `id`
     # lookups. `_resolved` gates the chown: true when an explicit id pair is given
     # OR both lookups succeeded with non-empty output (app user installed).
+    # `| trim` guards the `| int` downstream: any stray whitespace (CRLF, padding)
+    # in pct-exec output would otherwise make `| int` silently return 0 and chown
+    # the dataset to the wrong (base-offset) owner instead of failing loud.
     media_lxc_features_cfg_in_uid: >-
-      {{ media_cfg_mp.owner_uid | default(media_lxc_features_cfg_owner_uid.stdout | default('')) }}
+      {{ media_cfg_mp.owner_uid | default(media_lxc_features_cfg_owner_uid.stdout | default('')) | trim }}
     media_lxc_features_cfg_in_gid: >-
-      {{ media_cfg_mp.owner_gid | default(media_lxc_features_cfg_owner_gid.stdout | default('')) }}
+      {{ media_cfg_mp.owner_gid | default(media_lxc_features_cfg_owner_gid.stdout | default('')) | trim }}
     media_lxc_features_cfg_resolved: >-
       {{
         (media_cfg_mp.owner_uid is defined and media_cfg_mp.owner_gid is defined)

--- a/roles/media_lxc_features/tasks/reconcile_config_owner.yml
+++ b/roles/media_lxc_features/tasks/reconcile_config_owner.yml
@@ -2,12 +2,15 @@
 # Chown one host config dataset to the MAPPED host uid/gid of its in-container
 # owner. Looped from configure_container.yml with:
 #   media_cfg_mp = a mount dict carrying { src: <host path>, owner_user: <name> }
+#                  OR { src: <host path>, owner_uid: <n>, owner_gid: <n> }
 #   media_ct     = { key: <vmid>, value: {...} }
 #
 # An unprivileged LXC maps in-container uid/gid N -> host (unpriv_base + N) on the
 # default offset, so the host dataset must be owned by that mapped pair for the
-# app user to read+write its config. The in-container ids are package-assigned,
-# so resolve them LIVE (never hardcode). Idempotent (stat then chown only on
+# app user to read+write its config. With `owner_user` the in-container ids are
+# package-assigned, so resolve them LIVE (never hardcode). With `owner_uid` the
+# owner is a raw numeric id with no named user inside the LXC (e.g. seerr's
+# Docker `node` = 1000) and is used directly. Idempotent (stat then chown only on
 # drift); non-fatal (skip cleanly when the user isn't installed yet — a fresh
 # build before the apps converge installs it; the dataset data is off the rootfs
 # and never at risk).
@@ -18,6 +21,7 @@
   register: media_lxc_features_cfg_owner_uid
   changed_when: false
   failed_when: false
+  when: media_cfg_mp.owner_user is defined
   tags:
     - media_lxc_features
 
@@ -27,6 +31,29 @@
   register: media_lxc_features_cfg_owner_gid
   changed_when: false
   failed_when: false
+  when: media_cfg_mp.owner_user is defined
+  tags:
+    - media_lxc_features
+
+- name: "Normalize the in-container owner id on {{ media_ct.key }}"
+  ansible.builtin.set_fact:
+    # Explicit owner_uid/owner_gid take precedence; otherwise use the live `id`
+    # lookups. `_resolved` gates the chown: true when an explicit id pair is given
+    # OR both lookups succeeded with non-empty output (app user installed).
+    media_lxc_features_cfg_in_uid: >-
+      {{ media_cfg_mp.owner_uid | default(media_lxc_features_cfg_owner_uid.stdout | default('')) }}
+    media_lxc_features_cfg_in_gid: >-
+      {{ media_cfg_mp.owner_gid | default(media_lxc_features_cfg_owner_gid.stdout | default('')) }}
+    media_lxc_features_cfg_resolved: >-
+      {{
+        (media_cfg_mp.owner_uid is defined and media_cfg_mp.owner_gid is defined)
+        or (
+          (media_lxc_features_cfg_owner_uid.rc | default(1)) == 0
+          and (media_lxc_features_cfg_owner_gid.rc | default(1)) == 0
+          and (media_lxc_features_cfg_owner_uid.stdout | default('') | length) > 0
+          and (media_lxc_features_cfg_owner_gid.stdout | default('') | length) > 0
+        )
+      }}
   tags:
     - media_lxc_features
 
@@ -39,10 +66,7 @@
 
 - name: "Apply config-owner chown when resolved on {{ media_ct.key }}"
   when:
-    - media_lxc_features_cfg_owner_uid.rc == 0
-    - media_lxc_features_cfg_owner_gid.rc == 0
-    - media_lxc_features_cfg_owner_uid.stdout | length > 0
-    - media_lxc_features_cfg_owner_gid.stdout | length > 0
+    - media_lxc_features_cfg_resolved | bool
     - media_lxc_features_cfg_owner_stat.stat.exists | default(false)
   tags:
     - media_lxc_features
@@ -50,9 +74,9 @@
     - name: "Compute the mapped host owner on {{ media_ct.key }}"
       ansible.builtin.set_fact:
         media_lxc_features_cfg_host_uid: >-
-          {{ media_lxc_features_unpriv_base + (media_lxc_features_cfg_owner_uid.stdout | int) }}
+          {{ media_lxc_features_unpriv_base + (media_lxc_features_cfg_in_uid | int) }}
         media_lxc_features_cfg_host_gid: >-
-          {{ media_lxc_features_unpriv_base + (media_lxc_features_cfg_owner_gid.stdout | int) }}
+          {{ media_lxc_features_unpriv_base + (media_lxc_features_cfg_in_gid | int) }}
 
     - name: "Chown the host config dataset to its mapped owner on {{ media_ct.key }}"
       ansible.builtin.command:


### PR DESCRIPTION
## What

Extend the live Plex `bulk/appdata` persistence pattern to **every** media app, so a
container destroy/recreate keeps all of its own state. The app rebuilds itself from its
own database on startup — no export/replay, no manual capture step.

| service | config dir | dataset | what survives rebuild |
| --- | --- | --- | --- |
| sonarr | `/var/lib/sonarr` | `bulk/appdata/sonarr` | `sonarr.db` (series, history, queue, blocklist) + `config.xml` |
| radarr | `/var/lib/radarr` | `bulk/appdata/radarr` | `radarr.db` + `config.xml` |
| download-vpn | `/home/qbittorrent` | `bulk/appdata/qbittorrent` | qBittorrent prefs + `BT_backup` (active torrents / resume / seeding) |
| download-vpn | `/var/lib/prowlarr` | `bulk/appdata/prowlarr` | `prowlarr.db` (indexers, private-tracker auth, app-sync) |
| seerr | `/opt/seerr/config` | `bulk/appdata/seerr` | `settings.json` + `db.sqlite3` (users, requests) |

(plex `bulk/appdata/plex` already shipped — this generalizes it.)

## How

- One `owner_user` config mount per service in `media_lxc_features_map`. The existing
  reconcile-owner loop already handles >1 owner mount per container (download-vpn gets two:
  qBittorrent + Prowlarr both run as the `qbittorrent` user).
- Seerr's Docker `node` has no named LXC user, so add an `owner_uid`/`owner_gid` fast-path to
  `reconcile_config_owner.yml` (used directly, skips the `id` lookup) and widen the
  reconcile loop to select `owner_uid` mounts.
- Snapshots + DR unchanged: the `bulk/appdata` `critical` sanoid template + recursive syncoid
  pull already cover every `bulk/appdata/<app>` child.

## Molecule

Updates the feature-map and vmid-join assertions to the new mount contract. This also
**fixes a pre-existing red gate**: #293 corrected the dedicated plex assertion but missed the
vmid-join block, which still asserted plex resolved to a single mount after the appdata mount
merged.

## Depends on / follow-up

- Requires the `bulk/appdata/<app>` datasets in `node_storage` — declared in the live
  `deployment.json` (private S3 input); example updated in dryvist/terraform-proxmox.
- First cutover is a one-time seed of each dataset from the app's current live config before
  the mount takes over (rollout notes); after that every rebuild is automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QwhN5mvem4ARsS55HqKH