### PR TITLE
docs(agents): link deployment state to the canonical ACID contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,15 @@ configured by `ansible-proxmox-apps` and `ansible-splunk`.
 
 - Physical Proxmox VE cluster (not provisioned by OpenTofu)
 
+### Upstream inventory (read-only consumer)
+
+`terraform-proxmox` provisions the hosts and publishes the inventory this repo
+consumes (`inventory/load_tofu.yml`). This repo **never reads `deployment.json`**;
+the published inventory is the source of truth, fetched fresh with no
+authoritative local copy. The upstream desired-state's ACID single-writer
+contract is documented once at
+[Deployment state contract](https://docs.jacobpevans.com/infrastructure/deployment-state-contract).
+
 ## Key Files
 
 | Path                 | Purpose                     |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ configured by `ansible-proxmox-apps` and `ansible-splunk`.
 ### Upstream inventory (read-only consumer)
 
 `terraform-proxmox` provisions the hosts and publishes the inventory this repo
-consumes (`inventory/load_tofu.yml`). This repo **never reads `deployment.json`**;
+consumes (`playbooks/load_tofu.yml`). This repo **never reads `deployment.json`**;
 the published inventory is the source of truth, fetched fresh with no
 authoritative local copy. The upstream desired-state's ACID single-writer
 contract is documented once at


### PR DESCRIPTION
Read-only inventory consumer. Points the agent docs at the single canonical deployment.json contract (dryvist/docs#88) instead of restating the upstream single-writer mechanics here. This repo never reads deployment.json directly; the tofu-published inventory is the source of truth.

Part of aligning every tofu/ansible repo to one definition of how deployment.json is read and written.

Verification: docs-only (AGENTS.md); the repo does not enforce markdownlint, and the added link line is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8De2aQvYqr5cFZ7Tz2ntG