### PR TITLE
fix(syncoid): move OnSuccess/OnFailure to [Unit] so the DR node auto-sleeps

### DIFF
--- a/roles/syncoid/templates/syncoid-replicate-on-boot.service.j2
+++ b/roles/syncoid/templates/syncoid-replicate-on-boot.service.j2
@@ -4,6 +4,15 @@ Description=Pull ZFS replication on boot (offline-DR window)
 Documentation=ansible role syncoid
 Wants=network-online.target
 After=network-online.target zfs.target zfs-mount.service
+{% if syncoid_boot_poweroff_on_complete | bool %}
+# Power the node off the moment replication completes — success OR failure — so a
+# normally-off DR node is up only for boot + replication. Reuses the
+# node_auto_poweroff poweroff oneshot (that role must be enabled). OnSuccess= and
+# OnFailure= are [Unit]-section directives; systemd silently ignores them (logging
+# "Unknown key ... in section [Service]") if placed under [Service].
+OnSuccess={{ syncoid_boot_oncomplete_unit }}
+OnFailure={{ syncoid_boot_oncomplete_unit }}
+{% endif %}
 
 [Service]
 Type=oneshot
@@ -11,13 +20,6 @@ Type=oneshot
 # node_auto_poweroff timer is the ultimate backstop.
 TimeoutStartSec={{ syncoid_boot_timeout }}
 ExecStart=/usr/local/bin/syncoid-replicate.sh
-{% if syncoid_boot_poweroff_on_complete | bool %}
-# Power the node off the moment replication completes — success OR failure — so a
-# normally-off DR node is up only for boot + replication. Reuses the
-# node_auto_poweroff poweroff oneshot (that role must be enabled).
-OnSuccess={{ syncoid_boot_oncomplete_unit }}
-OnFailure={{ syncoid_boot_oncomplete_unit }}
-{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Problem

The on-boot replication unit (`syncoid-replicate-on-boot.service`) placed `OnSuccess=`/`OnFailure=` in the `[Service]` section. systemd only honors those in `[Unit]` — it logs `Unknown key 'OnSuccess'/'OnFailure' in section [Service], ignoring` and drops them. The "power off the moment replication completes" chain therefore **never fired**: the offline-DR node only ever slept via the once-daily 22:00 backstop timer, so it stayed powered on far longer than the wake → replicate → sleep design intends (observed: ~22h continuous uptime).

## Fix

Move `OnSuccess=`/`OnFailure=` to `[Unit]` (systemd 257 supports `OnSuccess=`) and add a comment recording the section requirement to prevent regression. One-file change.

## Verification (live, on the DR node)

- **Before:** `systemd-analyze verify` flagged both keys; `systemctl show -p OnSuccess` resolved empty.
- **After converge:** `systemd-analyze verify` clean; `OnSuccess`/`OnFailure` resolve to the poweroff oneshot.
- **End-to-end:** manually starting the on-boot service ran replication to success, and systemd logged `Triggering OnSuccess= dependencies` → started `node-auto-poweroff.service` → graceful poweroff; BMC confirmed power off.

Note: with autosleep now functional, a maintenance converge of the DR node will be cut short by the on-boot replicate. The masking workaround is already documented in the `node_scheduled_wake` README and tracked in #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)