### PR TITLE
chore(inventory): add the offline-DR node to rack_servers

### DIFF
--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -36,3 +36,10 @@ all:
             pve1: {}
             pve2: {}
             pve3: {}
+        # Place the offline-DR node in rack_servers so it inherits the
+        # rack-server zfs_swap/kernel/ulimit baselines
+        # (group_vars/rack_servers.yml) rather than the cluster default.
+        # Backup-cycle config is host_vars-driven and unaffected by the move.
+        rack_servers:
+          hosts:
+            pve3: {}


### PR DESCRIPTION
## What

Adds the offline-DR node to the `rack_servers` group so it inherits `group_vars/rack_servers.yml` instead of the cluster-default tuning:

- `zfs_swap` 32G (create-only)
- kernel sysctls: `swappiness=10`, `vfs_cache_pressure=50`, `dirty_ratio=10`, `dirty_background_ratio=5`, `overcommit_memory=0` (boot-param management disabled)
- ulimits 65536
- NTP client mode

Backup-cycle config is host_vars-driven and unaffected by the group move. pve1/pve2 are not in `rack_servers` and are unchanged (verified: they keep the 96G swap / boot-params defaults).

Closes #306.

## Verification (live, on the DR node)

`zfs_swap`, `kernel_tuning`, and `ulimits` converged and verified: sysctls live, `rpool/swap` created at 32G, `DefaultLimitNOFILE/NPROC=65536`.

⚠️ The `ntp` role currently fails on Debian 13 with a chrony `validate` permission error (`chronyd -p -f %s` cannot read the Ansible temp file under AppArmor). This is a **pre-existing, shared-role bug unrelated to this group change** — the DR node's prior converges were tag-limited so it was never exposed. Tracked in #313. The rack-server retune (swap/kernel/ulimits) applies cleanly; only NTP-client config is deferred until #313 is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)