### PR TITLE
fix(media_lxc_features): seed config datasets before mounting; never mount a missing source

### DIFF
--- a/roles/media_lxc_features/README.md
+++ b/roles/media_lxc_features/README.md
@@ -135,9 +135,19 @@ itself from its own DB on startup — there is no export/replay step.
   never at risk — it lives outside the rootfs that the rebuild replaces.
 - **First cutover (existing live data)**: an app already running on the rootfs has
   its current DB there, not yet on the empty dataset. Mounting the empty dataset
-  over it would hide that DB. Seed each `bulk/appdata/<app>` from the app's live
-  config **once** before the mount takes over (see the repo rollout notes); after
-  that the dataset is the source of truth and every future rebuild is safe.
+  over it would hide that DB. The role handles this **automatically and safely**:
+  - It **stats every host mount source first** and only applies a bind-mount whose
+    source already exists. A missing `bulk/appdata/<app>` dataset (zfs_pools not yet
+    run) is warned and **skipped**, never `pct`-auto-created as an empty dir over a
+    live config.
+  - For each app-config mount it then runs a **one-time seed** (`seed_config_dataset.yml`):
+    if the dataset exists but is empty and the in-container config dir is populated
+    and the mount is not yet applied, it streams the live config dir into the
+    dataset **before** the mount is set. Guarded to run exactly once — once the
+    dataset is non-empty (or the mount is present) it is a no-op forever.
+  - Order on a first cutover: zfs_pools (creates the dataset) → media_lxc_features
+    (seed → mount → ownership reconcile → restart). The app restarts onto the
+    seeded dataset; every future rebuild then persists with no manual step.
 
 ### VMID resolution (renumber-proof)
 

--- a/roles/media_lxc_features/tasks/configure_container.yml
+++ b/roles/media_lxc_features/tasks/configure_container.yml
@@ -42,8 +42,8 @@
     media_lxc_features_src_exists: >-
       {{
         dict(
-          (media_lxc_features_src_stats.results | map(attribute='media_src_path') | list)
-          | zip(media_lxc_features_src_stats.results | map(attribute='stat.exists') | list)
+          (media_lxc_features_src_stats.results | default([]) | map(attribute='media_src_path') | list)
+          | zip(media_lxc_features_src_stats.results | default([]) | map(attribute='stat.exists') | list)
         )
       }}
   tags:

--- a/roles/media_lxc_features/tasks/configure_container.yml
+++ b/roles/media_lxc_features/tasks/configure_container.yml
@@ -17,6 +17,77 @@
     - media_lxc_features
 
 # ---------------------------------------------------------------------------
+# Host mount-source existence — a SAFETY GATE for the bind-mounts below
+# ---------------------------------------------------------------------------
+# A bind-mount whose host source does NOT exist makes `pct` auto-create an empty
+# directory and mount it over the in-container target. For an app-config mount
+# (bulk/appdata/<app>) that would SHADOW the app's live database with emptiness
+# and the app would re-initialise on restart (data loss). So stat every source
+# first and only mount the ones that already exist (the shared bulk/data plus any
+# appdata dataset zfs_pools has realised). A missing dataset is surfaced loudly
+# and skipped, never silently emptied.
+- name: "Stat host mount sources on {{ media_ct.key }}"
+  ansible.builtin.stat:
+    path: "{{ media_src_path }}"
+  loop: "{{ media_ct.value.mounts | default([]) | map(attribute='src') | list }}"
+  loop_control:
+    loop_var: media_src_path
+    label: "{{ media_ct.key }} src {{ media_src_path }}"
+  register: media_lxc_features_src_stats
+  tags:
+    - media_lxc_features
+
+- name: "Build the source-exists map on {{ media_ct.key }}"
+  ansible.builtin.set_fact:
+    media_lxc_features_src_exists: >-
+      {{
+        dict(
+          (media_lxc_features_src_stats.results | map(attribute='media_src_path') | list)
+          | zip(media_lxc_features_src_stats.results | map(attribute='stat.exists') | list)
+        )
+      }}
+  tags:
+    - media_lxc_features
+
+- name: "Warn on any missing host mount source on {{ media_ct.key }}"
+  ansible.builtin.debug:
+    msg: >-
+      Host mount source {{ media_missing_src }} does not exist on this node — its
+      bind-mount is SKIPPED so it cannot shadow a live config with emptiness. Run
+      the zfs_pools role first to realise the dataset.
+  loop: >-
+    {{
+      media_lxc_features_src_exists | dict2items
+      | rejectattr('value') | map(attribute='key') | list
+    }}
+  loop_control:
+    loop_var: media_missing_src
+    label: "{{ media_ct.key }} MISSING {{ media_missing_src }}"
+  tags:
+    - media_lxc_features
+
+# ---------------------------------------------------------------------------
+# ONE-TIME seed: copy a live config dir into its (empty) dataset BEFORE the mount
+# ---------------------------------------------------------------------------
+# First cutover only, per owner-bearing (app-config) mount. Guarded inside the
+# included file so it runs exactly once: mount-absent + dataset-exists-and-empty +
+# container-dir-populated. After the first run the dataset is the source of truth
+# and this is a no-op. Runs BEFORE the bind-mounts below so the mount never
+# shadows live state with an empty dataset.
+- name: "Seed config datasets from live container dirs on {{ media_ct.key }}"
+  ansible.builtin.include_tasks: seed_config_dataset.yml
+  loop: >-
+    {{
+      (media_ct.value.mounts | default([]) | selectattr('owner_user', 'defined') | list)
+      + (media_ct.value.mounts | default([]) | selectattr('owner_uid', 'defined') | list)
+    }}
+  loop_control:
+    loop_var: media_cfg_mp
+    label: "{{ media_ct.key }} seed {{ media_cfg_mp.src }}"
+  tags:
+    - media_lxc_features
+
+# ---------------------------------------------------------------------------
 # Bind-mounts (mp0, mp1, ...) — host path -> in-container target, optional ro
 # ---------------------------------------------------------------------------
 # Desired line shape (matches `pct config` readback, e.g. CT 252):
@@ -45,7 +116,11 @@
         | map('regex_replace', '^mp' ~ media_mp_idx ~ ':\s*', '')
         | list | first | default('')
       }}
-  when: media_mp_current != media_mp_desired
+  when:
+    - media_mp_current != media_mp_desired
+    # Never mount a host source that does not exist — `pct` would auto-create an
+    # empty dir and shadow a live config. A missing dataset is skipped (warned above).
+    - media_lxc_features_src_exists[media_mp.src] | default(false)
   changed_when: true
   notify: Restart changed media containers
   register: media_lxc_features_mp_set

--- a/roles/media_lxc_features/tasks/seed_config_dataset.yml
+++ b/roles/media_lxc_features/tasks/seed_config_dataset.yml
@@ -43,6 +43,39 @@
   tags:
     - media_lxc_features
 
+- name: "Seed: read the container run state on {{ media_ct.key }}"
+  ansible.builtin.command:
+    cmd: "pct status {{ media_ct.key }}"
+  register: media_lxc_features_seed_status
+  changed_when: false
+  failed_when: false
+  when:
+    - not media_lxc_features_seed_mounted
+    - media_lxc_features_src_exists[media_cfg_mp.src] | default(false)
+  tags:
+    - media_lxc_features
+
+# FAIL-LOUD safety: if the dataset is empty and the container is NOT running, we
+# cannot read its config dir to seed it, yet the bind-mount below would still
+# apply and shadow the live config with emptiness (data loss). A stopped container
+# during this converge is anomalous (terraform starts the guests; the role runs
+# while they are up), so refuse rather than risk it. A non-empty dataset (already
+# seeded / steady state) is unaffected.
+- name: "Seed: refuse to mount an empty config dataset over a stopped container on {{ media_ct.key }}"
+  ansible.builtin.fail:
+    msg: >-
+      Container {{ media_ct.key }} is not running, so {{ media_cfg_mp.dst }} cannot
+      be read to seed the empty dataset {{ media_cfg_mp.src }}. Applying the mount
+      now would shadow the live config with emptiness and lose data. Start the
+      container and re-run (or seed {{ media_cfg_mp.src }} manually first).
+  when:
+    - not media_lxc_features_seed_mounted
+    - media_lxc_features_src_exists[media_cfg_mp.src] | default(false)
+    - (media_lxc_features_seed_dst_content.matched | default(0)) == 0
+    - "'status: running' not in (media_lxc_features_seed_status.stdout | default(''))"
+  tags:
+    - media_lxc_features
+
 - name: "Seed: detect whether the in-container config dir holds state on {{ media_ct.key }}"
   ansible.builtin.command:
     cmd: >-

--- a/roles/media_lxc_features/tasks/seed_config_dataset.yml
+++ b/roles/media_lxc_features/tasks/seed_config_dataset.yml
@@ -1,0 +1,80 @@
+---
+# ONE-TIME cutover seed of a single app-config dataset. Looped from
+# configure_container.yml with:
+#   media_cfg_mp = a mount dict carrying owner_user/owner_uid (an app-private
+#                  config mount, e.g. bulk/appdata/sonarr -> /var/lib/sonarr)
+#   media_ct     = { key: <vmid>, value: {...} }
+#
+# An app-config bind-mount shadows the in-container config dir with the host
+# dataset. On the FIRST cutover the dataset is empty, so without this step the
+# mount would hide the app's live database and the app would re-initialise (data
+# loss). This copies the live config dir into the dataset BEFORE the mount is
+# applied, but ONLY when ALL of:
+#   - the mount is NOT already applied (first cutover only), AND
+#   - the host dataset EXISTS and is EMPTY (zfs_pools realised it; nothing seeded
+#     yet — a non-empty dataset is already the source of truth, never overwritten), AND
+#   - the in-container config dir EXISTS and is non-empty (there is state to save).
+# After the first successful run the dataset is non-empty, so this is a no-op
+# forever. tar preserves the tree + perms (incl. SQLite -wal/-shm for crash-safe
+# recovery on the post-mount restart); reconcile_config_owner maps ownership after
+# the mount. All tasks are skipped under Docker (the role's top-level guard).
+
+- name: "Seed: detect whether this config mount is already applied on {{ media_ct.key }}"
+  ansible.builtin.set_fact:
+    # True once the bind-mount for this dst is present in `pct config` — then the
+    # cutover already happened and we must never touch the dataset again.
+    media_lxc_features_seed_mounted: >-
+      {{
+        media_lxc_features_cfg.stdout_lines | default([])
+        | select('search', ',mp=' ~ media_cfg_mp.dst ~ '$') | list | length > 0
+      }}
+  tags:
+    - media_lxc_features
+
+- name: "Seed: list the current host config-dataset contents on {{ media_ct.key }}"
+  ansible.builtin.find:
+    paths: "{{ media_cfg_mp.src }}"
+    file_type: any
+    hidden: true
+  register: media_lxc_features_seed_dst_content
+  when:
+    - not media_lxc_features_seed_mounted
+    - media_lxc_features_src_exists[media_cfg_mp.src] | default(false)
+  tags:
+    - media_lxc_features
+
+- name: "Seed: detect whether the in-container config dir holds state on {{ media_ct.key }}"
+  ansible.builtin.command:
+    cmd: >-
+      pct exec {{ media_ct.key }} --
+      sh -c 'test -d "{{ media_cfg_mp.dst }}" && [ -n "$(ls -A "{{ media_cfg_mp.dst }}" 2>/dev/null)" ]'
+  register: media_lxc_features_seed_src_populated
+  changed_when: false
+  failed_when: false
+  when:
+    - not media_lxc_features_seed_mounted
+    - media_lxc_features_src_exists[media_cfg_mp.src] | default(false)
+  tags:
+    - media_lxc_features
+
+- name: "Seed the config dataset from the live container dir on {{ media_ct.key }}"
+  # noqa: risky-shell-pipe command-instead-of-module
+  # One-time cutover copy: stream the container's config dir into the still-empty
+  # host dataset so the bind-mount below does not shadow the live database with
+  # emptiness. `set -o pipefail` so a failed `pct exec` fails the task instead of
+  # silently extracting an empty tar over the dataset.
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail &&
+      pct exec {{ media_ct.key }} -- tar -C "{{ media_cfg_mp.dst }}" -cf - . |
+      tar -C "{{ media_cfg_mp.src }}" -xf -
+    executable: /bin/bash
+  register: media_lxc_features_seed_run
+  when:
+    - not media_lxc_features_seed_mounted
+    - media_lxc_features_src_exists[media_cfg_mp.src] | default(false)
+    - (media_lxc_features_seed_dst_content.matched | default(0)) == 0
+    - (media_lxc_features_seed_src_populated.rc | default(1)) == 0
+  changed_when: true
+  tags:
+    - media_lxc_features


### PR DESCRIPTION
## ⚠️ Fixes a live data-loss footgun introduced by #307

#307 added the `bulk/appdata/<app>` config mounts to `media_lxc_features_map`, but the role
applies a bind-mount **unconditionally and never seeds the dataset**. On a first cutover the
datasets don't exist yet, so `pct set --mp /bulk/appdata/sonarr → /var/lib/sonarr` makes Proxmox
**auto-create an empty dir and mount it over the live DB** — Sonarr/Radarr/qBittorrent/Prowlarr/
Seerr re-initialise and lose their state.

**Verified on the live cluster:** the media containers currently have only `mp0 = /bulk/data` —
the appdata mounts have **not** been applied, so the configs are still intact. This PR must land
before `media_lxc_features` next converges on pve2.

## The fix — make the role self-safe (attended or not)

- **Stat every host mount source first**; only apply a bind-mount whose source **exists**. A
  missing dataset (zfs_pools not run yet) is **warned and skipped**, never auto-created empty
  over a live config.
- **One-time guarded seed** (`seed_config_dataset.yml`) runs **before** the mount for each
  app-config (`owner_user`/`owner_uid`) mount: when the dataset exists-but-empty, the
  in-container config dir is populated, and the mount is not yet applied, it streams the live
  config dir into the dataset (`tar`, incl. SQLite `-wal`/`-shm`). Runs exactly **once** — a
  non-empty dataset or an applied mount makes it a permanent no-op.

Cutover order: `zfs_pools` (creates dataset) → `media_lxc_features` (seed → mount → ownership
reconcile → restart). The app restarts onto the seeded dataset; every future rebuild then
persists with no manual step.

## Verification

- `ansible-lint` (production profile) + `yamllint`: clean.
- `molecule verify`: passes (seed/stat tasks are Docker-skipped, so the static contract
  assertions are unchanged).
- Idempotency: a second converge skips seed (mount present) and mount (desired==current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128QwhN5mvem4ARsS55HqKH