### PR TITLE
docs: fix inventory loader path and run-ansible/env-var references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ doppler run -- ansible-playbook playbooks/site.yml
 ```
 
 > **`--limit` must include `localhost`.** The inventory loader
-> (`inventory/load_tofu.yml`) runs on `hosts: localhost` and populates the
+> (`playbooks/load_tofu.yml`) runs on `hosts: localhost` and populates the
 > dynamic inventory via `add_host`. Running with `--limit <group>` but **not**
 > `localhost` silently skips the loader, so no hosts are added and every play
 > reports "no hosts matched". Use `--limit <group>,localhost`, or invoke via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,15 +28,26 @@ Firewall rules for pipeline ports (1514-1518, 8088, 2055) are managed by `terraf
 
 ## Required Environment Variables
 
-| Variable                  | Purpose                                          |
-| ------------------------- | ------------------------------------------------ |
-| `PROXMOX_VE_HOSTNAME`     | Proxmox VE hostname                              |
-| `PROXMOX_VM_SSH_USERNAME` | SSH user for Proxmox host                        |
-| `PROXMOX_SSH_PRIVATE_KEY` | SSH private key (used by scripts/run-ansible.sh) |
-| `HEALTHCHECK_PING_KEY`    | Healthchecks.io key                              |
+Provided via Doppler (`doppler run -- …`). Grouped by purpose; not every
+variable is needed for every playbook.
 
-`scripts/run-ansible.sh` writes `PROXMOX_SSH_PRIVATE_KEY` to a temp file
-and exports `ANSIBLE_PRIVATE_KEY_FILE` pointing to it.
+| Variable | Purpose |
+| --- | --- |
+| `PVE1_VE_HOSTNAME`, `PVE2_VE_HOSTNAME`, `PVE3_VE_HOSTNAME` | Per-node Proxmox hostnames resolved in `inventory/hosts.yml` |
+| `PROXMOX_NODE_PREFIX` | Node-name prefix (without the trailing number) used to derive per-node identifiers |
+| `PROXMOX_VM_SSH_USERNAME` | SSH user for the Proxmox hosts |
+| `PROXMOX_SSH_KEY_PATH` *or* `PROXMOX_SSH_PRIVATE_KEY` | SSH auth: a key **file path**, or the key **contents** (loaded into ssh-agent by `scripts/run-ansible.sh`) |
+| `HEALTHCHECK_PING_KEY` | Healthchecks.io ping key (`proxmox_monitoring`, `sqlite_standby`) |
+| AWS creds (via `aws-vault`) + `TOFU_INVENTORY_S3_URI`, `TOFU_INVENTORY_S3_REGION` | S3-first inventory resolution in `playbooks/load_tofu.yml` |
+| `TOFU_INVENTORY_PATH`, `TOFU_INVENTORY_ALLOW_STALE` | Optional inventory overrides (pin a local file / permit a stale cache) |
+| `IDRAC_USERNAME`, `IDRAC_PASSWORD`, `PVE3_BMC_HOSTNAME` | IPMI power control for the offline-DR node (`idrac_power`, `node_scheduled_wake`) |
+| `PROXMOX_VE_HOSTNAME`, `PROXMOX_VE_NODES`, `PROXMOX_VE_USERNAME`, `PROXMOX_VE_TOKEN_ID`, `PROXMOX_VE_TOKEN_SECRET`, `PROXMOX_VE_INSECURE` | Proxmox API token (community.proxmox modules) |
+| `APT_PROXY_URL`, `NAS_HOMEASSISTANT_SMB_PASSWORD` | Optional: apt caching proxy; NAS Samba service account |
+
+`scripts/run-ansible.sh` loads `PROXMOX_SSH_PRIVATE_KEY` into an in-memory
+ssh-agent (the key never touches disk) and unsets it so Ansible authenticates via
+the agent. If `PROXMOX_SSH_KEY_PATH` points to a real file, that file is used
+directly instead.
 
 ## Commands
 

--- a/roles/nas_storage/README.md
+++ b/roles/nas_storage/README.md
@@ -40,7 +40,7 @@ sops exec-env secrets.sops.yml 'doppler run -- ./scripts/run-ansible.sh playbook
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `nas_storage_config` | OpenTofu host_services.nas | Source config injected by `inventory/load_tofu.yml` |
+| `nas_storage_config` | OpenTofu host_services.nas | Source config injected by `playbooks/load_tofu.yml` |
 | `nas_storage_group_name` | `nas` | Unix/Samba group for shared access |
 | `nas_storage_managed_users` | `[]` | Declarative Samba-backed service accounts |
 | `nas_storage_shares` | single `nas` share fallback | Declarative Samba shares |

--- a/roles/nas_storage/defaults/main.yml
+++ b/roles/nas_storage/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # NAS Storage role defaults
 
-# OpenTofu-sourced NAS config injected by inventory/load_tofu.yml.
+# OpenTofu-sourced NAS config injected by playbooks/load_tofu.yml.
 nas_storage_config: >-
   {{
     nas_storage_from_tofu

--- a/roles/zfs_pools/README.md
+++ b/roles/zfs_pools/README.md
@@ -41,7 +41,7 @@ zfs_pools_devices:
 
 ## Inputs
 
-`inventory/load_tofu.yml` injects `zfs_pools_from_tofu` onto each
+`playbooks/load_tofu.yml` injects `zfs_pools_from_tofu` onto each
 proxmox host: the `node_storage[<node>]` entry for that host, keyed by the
 host's `proxmox_node_name` (defaults to the inventory hostname). Set
 `proxmox_node_name` in `host_vars` when the inventory name differs from the

--- a/roles/zfs_pools/defaults/main.yml
+++ b/roles/zfs_pools/defaults/main.yml
@@ -3,7 +3,7 @@
 #
 # Consumes the per-node ZFS storage declaration produced by terraform-proxmox
 # (ansible_inventory.node_storage[<node>]) and injected onto the host by
-# inventory/load_tofu.yml as `zfs_pools_from_tofu`.
+# playbooks/load_tofu.yml as `zfs_pools_from_tofu`.
 
 zfs_pools_config: >-
   {{


### PR DESCRIPTION
## Summary

Documentation-only fixes that bring the repo's prose in line with the code,
part of finishing the inventory/deployment.json/S3 (ACID) transition truthfully.

## Changes

- **Inventory loader path (5 stale refs).** The loader is `playbooks/load_tofu.yml`,
  not `inventory/load_tofu.yml`. Corrected in `AGENTS.md` and the `zfs_pools` /
  `nas_storage` role READMEs + defaults. (Same class of error gemini flagged on
  #311, but these predate it and live elsewhere in the tree.)
- **`CLAUDE.md` SSH description.** `scripts/run-ansible.sh` loads the key into an
  in-memory **ssh-agent** and unsets it — it does **not** write a temp file or
  export `ANSIBLE_PRIVATE_KEY_FILE`. Rewritten to match `scripts/run-ansible.sh:30-46`.
- **`CLAUDE.md` env-var table.** Expanded from 4 rows to the variables the
  playbooks/inventory actually consume (audited via `lookup('env', …)` +
  `inventory/hosts.yml`): per-node hostnames, `PROXMOX_NODE_PREFIX`, the
  `PROXMOX_SSH_KEY_PATH`/`PROXMOX_SSH_PRIVATE_KEY` pair, the `TOFU_INVENTORY_*`
  S3 resolver vars, iDRAC/BMC power vars, and the Proxmox API token vars.

## Test Plan

- `grep -rn "inventory/load_tofu" .` → no matches.
- `ansible-lint` → Passed, 0 failures/0 warnings on 243 files (production profile).
- Verified the ACID-contract link in `AGENTS.md` now returns HTTP 200 (the prior
  404 was a docs-site deploy lag after dryvist/docs#88 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)