### PR TITLE
fix: point callers at renamed cc- reusable workflows

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -29,7 +29,7 @@ jobs:
     #   github.event.workflow_run.head_branch != 'main' &&
     #   github.event.workflow_run.head_repository.full_name == github.repository
     # --- END DISABLED ---
-    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-ci-fix.yml@main
     with:
       repo_context: "Ansible playbooks and roles for configuring Proxmox VE host"
       ci_structure: "ansible-lint.yml (Ansible Lint checks) + molecule.yml (Molecule Test integration tests)"

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   simplify:
-    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -84,7 +84,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "Ansible playbooks and roles for configuring Proxmox VE host"

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   next-steps:
-    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-next-steps.yml@main
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -38,7 +38,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: write
-    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-post-merge-docs-review.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -38,7 +38,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: write
-    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/cc-post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
## Problem
Callers referenced `dryvist/ai-workflows/.github/workflows/<name>.yml@main` for
reusables that were renamed with a `cc-` prefix. The old names no longer exist,
so those runs failed at **startup** (0 jobs, "workflow file issue").

## Fix
Repoint the stale `uses:` refs to the current `cc-`-prefixed names
(cc-ci-fix / cc-code-simplifier / cc-issue-resolver / cc-next-steps /
cc-post-merge-docs-review / cc-post-merge-tests). Reusables that were never
renamed (issue-triage, best-practices, ci-fail-issue, issue-hygiene,
issue-sweeper) are left untouched. Pure reference rename, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)