### PR TITLE
feat(lxc_gpu_features): rename GPU LXC service to llm-fast

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -100,8 +100,8 @@
         - media_lxc_features
 
     # Root-only AMD GPU passthrough (/dev/dri + /dev/kfd) for the inference LXC
-    # (hermes-infer, vmid 167) — same root@pam-only contract as media_lxc_features.
-    # Runs after OpenTofu creates the shell, before ansible-proxmox-apps installs Ollama.
+    # (llm-fast) — same root@pam-only contract as media_lxc_features.
+    # Runs after OpenTofu creates the shell, before ansible-proxmox-apps installs llama.cpp.
     - role: lxc_gpu_features
       tags:
         - lxc_gpu_features

--- a/roles/lxc_gpu_features/README.md
+++ b/roles/lxc_gpu_features/README.md
@@ -23,10 +23,10 @@ the download-vpn LXC).
 
 ## Ordering
 
-1. `terraform-proxmox` — creates `hermes-infer` (vmid 167) as a privileged shell.
+1. `terraform-proxmox` — creates `llm-fast` as a privileged shell.
 2. **this role** — binds `/dev/dri` (226) + `/dev/kfd` (235), reboots on change.
-3. `ansible-proxmox-apps` (role `ollama`) — installs Ollama + ROCm, adds the
-   service user to `render`/`video`, pulls Hermes 4.
+3. `ansible-proxmox-apps` (role `llama_cpp`) — installs llama.cpp + llama-swap +
+   ROCm, adds the service user to `render`/`video`, stages the GGUF models.
 
 ## What it writes
 
@@ -44,7 +44,7 @@ lxc.mount.entry: /dev/kfd dev/kfd none bind,optional,create=file
 
 | Var | Default | Purpose |
 | --- | --- | --- |
-| `lxc_gpu_features_map` | `{ hermes-infer: { dri: true, kfd: true } }` | Service → which device groups to bind |
+| `lxc_gpu_features_map` | `{ llm-fast: { dri: true, kfd: true } }` | Service → which device groups to bind |
 | `lxc_gpu_features_dri_major` | `226` | `/dev/dri` char major |
 | `lxc_gpu_features_kfd_major` | `235` | `/dev/kfd` char major |
 | `lxc_gpu_features_service_vmids` | from tofu inventory | Service → current vmid (auto) |
@@ -72,8 +72,9 @@ env -u DOPPLER_PROJECT -u DOPPLER_CONFIG -u DOPPLER_ENVIRONMENT doppler run -- \
   ./scripts/run-ansible.sh playbooks/site.yml --limit pve1 --tags lxc_gpu_features
 ```
 
-Verify the devices landed inside the container:
+Verify the devices landed inside the container (substitute the `llm-fast`
+vmid the tofu inventory resolved):
 
 ```bash
-pct exec 167 -- ls -l /dev/dri /dev/kfd
+pct exec <vmid> -- ls -l /dev/dri /dev/kfd
 ```

--- a/roles/lxc_gpu_features/defaults/main.yml
+++ b/roles/lxc_gpu_features/defaults/main.yml
@@ -8,7 +8,7 @@
 # SSH, idempotently. Mirrors the media_lxc_features pattern exactly.
 #
 # Ordering: terraform-proxmox (shell) -> THIS role (devices) ->
-# ansible-proxmox-apps role: ollama (inference stack). See README.md.
+# ansible-proxmox-apps role: llama_cpp (inference stack). See README.md.
 #
 # Per-service shape:
 #   dri: bool — bind /dev/dri (card0 + renderD128, char major 226) for compute
@@ -19,7 +19,7 @@
 # needs no change here. Only vmids present on the host are acted on; every task
 # is skipped under Docker virtualization (molecule). No IPs, no secrets.
 lxc_gpu_features_map:
-  hermes-infer:  # Ollama + ROCm on the RX 6800 (privileged LXC)
+  llm-fast:  # llama.cpp + llama-swap + ROCm on the RX 6800 (privileged LXC)
     dri: true
     kfd: true
 


### PR DESCRIPTION
## What

Renames the `lxc_gpu_features` GPU-passthrough map key from `hermes-infer` to
`llm-fast`, reflecting the re-platform of the RX 6800 LXC from Ollama to
llama.cpp + llama-swap (the new light serving tier). Updates the role README
and the `site.yml` ordering comment to match.

The device-passthrough contract is unchanged: same `/dev/dri` (226) + `/dev/kfd`
(235) majors, same runtime vmid resolution from the tofu inventory (a vmid
renumber still needs no role change).

## Why now / ordering

This is the infra-layer half of the serving-fabric rework. It must **merge
before the `llm-fast` converge (W6)**: the GPU passthrough has to land on the
LXC shell before `ansible-proxmox-apps` (role `llama_cpp`) installs the
inference stack. Companion PR adds the `llama_cpp` role in `ansible-proxmox-apps`.

## Test

- `ansible-lint` (production profile): passes, 0 failures on the role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj