### PR TITLE
fix(lxc_features): per-node vmid filter + LLM fabric docker guests

### DIFF
--- a/inventory/group_vars/proxmox.yml
+++ b/inventory/group_vars/proxmox.yml
@@ -46,6 +46,16 @@ lxc_features_containers:
   "110": "nesting=1,keyctl=1,fuse=1" # mailpit - Docker SMTP relay
   "111": "nesting=1,keyctl=1,fuse=1" # ntfy - Docker push notifications
   "130": "nesting=1,keyctl=1,fuse=1" # mssql - Docker MS SQL Server
+  # LLM fabric Docker-in-LXC guests (tofu creates them nesting-only; keyctl
+  # and fuse are root@pam-only, so this role applies them post-create)
+  "405000": "nesting=1,keyctl=1,fuse=1" # langfuse - Docker LLM observability
+  "505000": "nesting=1,keyctl=1,fuse=1" # open-webui - Docker chat UI
+  "505010": "nesting=1,keyctl=1,fuse=1" # dify - Docker LLMOps platform
+  "505020": "nesting=1,keyctl=1,fuse=1" # langflow - Docker flow builder
+  "512000": "nesting=1,keyctl=1,fuse=1" # llm-router-1 - Docker LiteLLM proxy
+  "512010": "nesting=1,keyctl=1,fuse=1" # llm-router-2 - Docker LiteLLM proxy
+  "512020": "nesting=1,keyctl=1,fuse=1" # llm-router-3 - Docker LiteLLM proxy
+  "514000": "nesting=1,keyctl=1,fuse=1" # qdrant - Docker vector database
 
 # Common packages to install
 common_packages:

--- a/roles/lxc_features/tasks/main.yml
+++ b/roles/lxc_features/tasks/main.yml
@@ -3,9 +3,20 @@
 # Uses pct set to apply feature flags (nesting, keyctl, fuse, etc.)
 # Requires stopping the container, so will briefly interrupt service.
 
+# The map in group_vars spans the whole cluster; only apply entries whose
+# container actually lives on this node (same pattern as lxc_gpu_features).
+- name: Build the set of vmids present on this host
+  ansible.builtin.command: pct list
+  register: lxc_features_pct_list
+  changed_when: false
+  when: lxc_features_containers | length > 0
+
 - name: Configure LXC container features
   ansible.builtin.include_tasks: configure_container.yml
   loop: "{{ lxc_features_containers | dict2items }}"
   loop_control:
     label: "Container {{ item.key }}: {{ item.value }}"
-  when: lxc_features_containers | length > 0
+  when:
+    - lxc_features_containers | length > 0
+    - item.key in (lxc_features_pct_list.stdout_lines[1:]
+        | map('trim') | map('split') | map('first') | list)

--- a/roles/lxc_features/tasks/main.yml
+++ b/roles/lxc_features/tasks/main.yml
@@ -18,5 +18,5 @@
     label: "Container {{ item.key }}: {{ item.value }}"
   when:
     - lxc_features_containers | length > 0
-    - item.key in (lxc_features_pct_list.stdout_lines[1:]
+    - item.key in (lxc_features_pct_list.stdout_lines | default([])
         | map('trim') | map('split') | map('first') | list)


### PR DESCRIPTION
First converge of the rebuilt fabric guests fails at `docker compose up` with `fuse: device not found` — the fabric Docker-in-LXC guests were created nesting-only (keyctl/fuse are root@pam-only, deliberately applied out-of-band by this role, see the derivation comment in terraform's proxmox-container module).

- Add the 8 fabric docker guests to `lxc_features_containers`.
- Make the role skip map entries whose container is not on the current node (`pct list` presence filter, same pattern as `lxc_gpu_features`) — the map is cluster-wide now, and a bare `pct config <absent-id>` would fail the play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj