### PR TITLE
fix: normalize issue-auto-resolve to the proven template and enable the loop

### DIFF
--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -7,67 +7,63 @@ on:
         description: "Issue number to resolve"
         required: true
         type: string
-  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
-  # issues:
-  #   types: [labeled]
-  # --- END DISABLED ---
+  issues:
+    types: [opened, labeled]
 
-permissions: {}
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
 
 jobs:
-  # --- DISABLED AUTOMATIC TRIGGERS (restore by uncommenting) ---
-  # dispatch:
-  #   if: github.event_name == 'issues'
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write
-  #     issues: write
-  #   steps:
-  #     - name: Dispatch as workflow_dispatch
-  #       env:
-  #         GH_TOKEN: ${{ github.token }}
-  #         WORKFLOW_NAME: ${{ github.workflow }}
-  #         REPO: ${{ github.repository }}
-  #         ISSUE_NUM: ${{ github.event.issue.number }}
-  #         EVENT_ACTION: ${{ github.event.action }}
-  #         LABEL_NAME: ${{ github.event.label.name }}
-  #       run: |
-  #         # Filter labeled events to only ai:ready
-  #         if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "ai:ready" ]]; then
-  #           echo "Label '$LABEL_NAME' is not ai:ready — skipping"
-  #           exit 0
-  #         fi
-  #
-  #         # Daily dispatch limit (cost control safety valve)
-  #         TODAY=$(date -u +%Y-%m-%d)
-  #         COUNT=$(gh run list \
-  #           --workflow "$WORKFLOW_NAME" \
-  #           --repo "$REPO" \
-  #           --event workflow_dispatch \
-  #           --created ">=$TODAY" \
-  #           --json databaseId --jq 'length')
-  #         if [[ "$COUNT" -ge 5 ]]; then
-  #           echo "Daily dispatch limit reached ($COUNT/5) — skipping"
-  #           exit 0
-  #         fi
-  #
-  #         # Remove ai:ready label so it can be re-applied to re-trigger
-  #         if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "ai:ready" ]]; then
-  #           gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "ai:ready" || true
-  #         fi
-  #
-  #         gh workflow run "$WORKFLOW_NAME" \
-  #           --repo "$REPO" \
-  #           -f issue_number="$ISSUE_NUM"
-  # --- END DISABLED ---
-
-  run-triage:
+  dispatch:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
     permissions:
       actions: write
-      contents: write
-      id-token: write
       issues: write
-      pull-requests: write
+    steps:
+      - name: Dispatch as workflow_dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          # Filter labeled events to only ai:ready
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "ai:ready" ]]; then
+            echo "Label '$LABEL_NAME' is not ai:ready — skipping"
+            exit 0
+          fi
+
+          # Daily dispatch limit (cost control safety valve)
+          TODAY=$(date -u +%Y-%m-%d)
+          COUNT=$(gh run list \
+            --workflow "$WORKFLOW_NAME" \
+            --repo "$REPO" \
+            --event workflow_dispatch \
+            --created ">=$TODAY" \
+            --json databaseId --jq 'length')
+          if [[ "$COUNT" -ge 5 ]]; then
+            echo "Daily dispatch limit reached ($COUNT/5) — skipping"
+            exit 0
+          fi
+
+          # Remove ai:ready label so it can be re-applied to re-trigger
+          if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" == "ai:ready" ]]; then
+            gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "ai:ready" || true
+          fi
+
+          gh workflow run "$WORKFLOW_NAME" \
+            --repo "$REPO" \
+            -f issue_number="$ISSUE_NUM"
+
+  run-triage:
+    if: github.event_name == 'workflow_dispatch'
     uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
     with:
@@ -77,15 +73,11 @@ jobs:
     needs: [run-triage]
     if: >-
       always() &&
+      github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    permissions:
-      actions: write
-      contents: write
-      id-token: write
-      issues: write
-      pull-requests: write
     uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "Ansible playbooks and roles for configuring Proxmox VE host"
+      extra_tools: "Bash(ansible:*)"
       issue_number: ${{ inputs.issue_number }}


### PR DESCRIPTION
Normalizes this repo's resolver to the live nix-home/nix-ai structure and enables the `issues: [opened, labeled]` trigger. Fixes a real drift: run-triage lacked the `github.event_name == 'workflow_dispatch'` guard, so an issues event would fire triage with an empty issue_number alongside the dispatched run. Sweep caller is already present; this closes the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)