### PR TITLE
fix(media): resolve appdata owner by the actual in-container user

### DIFF
--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -80,14 +80,14 @@ media_lxc_features_map:
   sonarr:  # TV PVR
     mounts:
       - { src: /bulk/data, dst: /data }
-      - { src: /bulk/appdata/sonarr, dst: /var/lib/sonarr, owner_user: sonarr }
+      - { src: /bulk/appdata/sonarr, dst: /var/lib/sonarr, owner_user: media }
     keyctl: false
     tun: false
     data_idmap: true
   radarr:  # movie PVR
     mounts:
       - { src: /bulk/data, dst: /data }
-      - { src: /bulk/appdata/radarr, dst: /var/lib/radarr, owner_user: radarr }
+      - { src: /bulk/appdata/radarr, dst: /var/lib/radarr, owner_user: media }
     keyctl: false
     tun: false
     data_idmap: true


### PR DESCRIPTION
## Summary
- `media_lxc_features_map` looked up sonarr/radarr's config-owner as `owner_user: sonarr` / `owner_user: radarr`, but both roles only create a shared `media` system user inside the container — the lookup never resolves, so the chown reconcile step has been silently no-op'ing on every converge.
- Live impact: both apps' appdata datasets are stuck on a stale pre-migration owner. Sonarr/Radarr fail to start whenever they need to rewrite their PID file, since the process's actual mapped uid doesn't own it — request UI shows "Unable to connect to radarr, sonarr."
- Fix: point both mounts at `owner_user: media`, matching `sonarr_user`/`radarr_user` in the respective app roles (same pattern already used correctly by plex/download-vpn).

## Test plan
- [x] `ansible-lint roles/media_lxc_features/` — 0 failures, 0 warnings (production profile)
- [ ] Converge `--tags media_lxc_features` and confirm the appdata datasets get recursively chowned to the mapped `media` uid/gid
- [ ] Confirm Sonarr/Radarr restart cleanly and Seerr's connectivity banner clears