### PR TITLE
feat(kernel_tuning): opt-in C6 idle-state disable via MSR at boot

### DIFF
--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -43,3 +43,7 @@ sanoid_datasets:
 node_scheduled_wake_targets:
   - name: pve3
     bmc_host: "{{ lookup('env', 'PVE3_BMC_HOSTNAME') | default('', true) }}"
+
+# Clear the CPU C6-state enable MSR bits at boot (kernel_tuning role);
+# the cmdline max_cstate limit alone does not cover this idle state.
+kernel_tuning_disable_zen_c6: true

--- a/roles/kernel_tuning/defaults/main.yml
+++ b/roles/kernel_tuning/defaults/main.yml
@@ -48,3 +48,11 @@ kernel_tuning_mce_level: 3
 
 # EDAC error reporting
 kernel_tuning_edac_report: 1
+
+# Zen1 C6 hard-lock erratum mitigation: clear the core+package C6 enable bits
+# in the AMD power-management MSRs at boot (msr-tools + a oneshot unit).
+# processor.max_cstate=1 alone does NOT prevent C6 entry on first-gen Zen —
+# this is the software equivalent of the BIOS "Global C-State Control=Disabled"
+# / "Power Supply Idle Control=Typical Current Idle" mitigations. Opt-in per
+# host (first-gen Zen parts only).
+kernel_tuning_disable_zen_c6: false

--- a/roles/kernel_tuning/tasks/main.yml
+++ b/roles/kernel_tuning/tasks/main.yml
@@ -192,3 +192,60 @@
             backup: true
           notify: Refresh proxmox boot
           when: kernel_tuning_cmdline_stat.stat.exists
+
+# ------------------------------------------------------------------------------
+# Zen1 C6 hard-lock erratum mitigation (opt-in via kernel_tuning_disable_zen_c6)
+# ------------------------------------------------------------------------------
+- name: Disable Zen1 C6 idle states via MSR
+  when: kernel_tuning_disable_zen_c6 | bool
+  block:
+    - name: Install msr-tools (rdmsr/wrmsr)
+      ansible.builtin.apt:
+        name: msr-tools
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Load the msr kernel module at boot
+      ansible.builtin.copy:
+        content: "msr\n"
+        dest: /etc/modules-load.d/msr.conf
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Load the msr kernel module now
+      community.general.modprobe:
+        name: msr
+        state: present
+
+    - name: Deploy the zen-c6-disable oneshot unit
+      ansible.builtin.template:
+        src: zen-c6-disable.service.j2
+        dest: /etc/systemd/system/zen-c6-disable.service
+        owner: root
+        group: root
+        mode: "0644"
+      register: kernel_tuning_zen_c6_unit
+
+    - name: Enable and run zen-c6-disable
+      ansible.builtin.systemd:
+        name: zen-c6-disable
+        enabled: true
+        state: "{{ 'restarted' if kernel_tuning_zen_c6_unit.changed else 'started' }}"
+        daemon_reload: true
+
+    - name: Verify the package C6 enable bit is clear
+      ansible.builtin.command:
+        cmd: rdmsr -c 0xC0010292
+      register: kernel_tuning_pkg_c6
+      changed_when: false
+      # bit 32 set would mean package C6 is still enabled
+      failed_when: ((kernel_tuning_pkg_c6.stdout | int(base=16)) // 4294967296) % 2 != 0
+  rescue:
+    - name: Fail loud — the C6 mitigation did not apply
+      ansible.builtin.fail:
+        msg: >-
+          kernel_tuning_disable_zen_c6 is enabled but the MSR mitigation could
+          not be applied/verified on this host. Do not run GPU or heavy loads
+          until this is resolved — the C6 erratum hard-locks the machine.

--- a/roles/kernel_tuning/tasks/main.yml
+++ b/roles/kernel_tuning/tasks/main.yml
@@ -240,8 +240,10 @@
         cmd: rdmsr -c 0xC0010292
       register: kernel_tuning_pkg_c6
       changed_when: false
-      # bit 32 set would mean package C6 is still enabled
-      failed_when: ((kernel_tuning_pkg_c6.stdout | int(base=16)) // 4294967296) % 2 != 0
+      # bit 32 set would mean package C6 is still enabled; trim first — a
+      # stray trailing newline would make int() silently return 0 and the
+      # verification would falsely pass.
+      failed_when: ((kernel_tuning_pkg_c6.stdout | trim | int(base=16)) // 4294967296) % 2 != 0
   rescue:
     - name: Fail loud — the C6 mitigation did not apply
       ansible.builtin.fail:
@@ -249,3 +251,14 @@
           kernel_tuning_disable_zen_c6 is enabled but the MSR mitigation could
           not be applied/verified on this host. Do not run GPU or heavy loads
           until this is resolved — the C6 erratum hard-locks the machine.
+
+# Reverse path: flipping the flag off must actually stop and disable the unit,
+# not just stop managing it. failed_when: false tolerates hosts where the unit
+# was never rendered.
+- name: Disable zen-c6-disable when the mitigation is turned off
+  ansible.builtin.systemd:
+    name: zen-c6-disable
+    enabled: false
+    state: stopped
+  failed_when: false
+  when: not (kernel_tuning_disable_zen_c6 | bool)

--- a/roles/kernel_tuning/templates/zen-c6-disable.service.j2
+++ b/roles/kernel_tuning/templates/zen-c6-disable.service.j2
@@ -1,0 +1,25 @@
+{{ ansible_managed | comment }}
+# Zen1 C6 hard-lock erratum mitigation (managed by the kernel_tuning role).
+#
+# First-generation Zen parts can hard-lock the whole host when a core enters
+# the C6 idle state under certain power transients. processor.max_cstate=1 on
+# the kernel cmdline does NOT prevent package/core C6 entry on these parts, so
+# the enable bits are cleared directly in the AMD power-management MSRs at
+# boot (same registers the BIOS "Global C-State Control" toggle drives):
+#   0xC0010292 bit 32           — package C6 enable
+#   0xC0010296 bits 22, 14, 6   — core C6 enables (CCR2/CCR1/CCR0)
+[Unit]
+Description=Disable Zen1 core+package C6 idle states (hard-lock erratum)
+DefaultDependencies=no
+After=systemd-modules-load.service
+Before=sysinit.target
+ConditionVirtualization=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c 'v=$(rdmsr -c 0xC0010292) && wrmsr -a 0xC0010292 $((v & ~(1<<32)))'
+ExecStart=/bin/sh -c 'v=$(rdmsr -c 0xC0010296) && wrmsr -a 0xC0010296 $((v & ~((1<<22)|(1<<14)|(1<<6))))'
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
## Summary
- New `kernel_tuning_disable_zen_c6` (default off): installs distro `msr-tools`, loads the `msr` module, and deploys a oneshot unit that clears the package-C6 enable bit (MSR `0xC0010292` bit 32) and the core-C6 enable bits (MSR `0xC0010296` bits 22/14/6) at boot — the software equivalent of the BIOS Global-C-State/Power-Supply-Idle mitigations for the first-gen Zen C6 hard-lock erratum.
- Verifies the package bit is actually clear after applying and **fails loud** otherwise.
- Enabled via host_vars for the one affected host, which has hard-locked four times under GPU load with `processor.max_cstate=1` already set (that cmdline limit does not gate C6 entry).

## Testing
- ansible-lint production green. Live converge + reboot + supervised load test follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj