### PR TITLE
feat(media): add sortarr to media_lxc_features persistence map

### DIFF
--- a/molecule/media_lxc_features/molecule.yml
+++ b/molecule/media_lxc_features/molecule.yml
@@ -38,6 +38,7 @@ provisioner:
           sonarr: 90003
           radarr: 90004
           download-vpn: 90005
+          sortarr: 90006
 
 verifier:
   name: ansible

--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -82,7 +82,7 @@
           - >-
             media_lxc_features_map | dict2items | selectattr('value.keyctl', 'defined')
             | selectattr('value.keyctl') | map(attribute='key') | sort | list
-            == ['download-vpn', 'seerr']
+            == ['download-vpn', 'seerr', 'sortarr']
         fail_msg: "tun/keyctl drifted from the services that require them"
 
     - name: Assert the tun device numbers are the TUN/TAP allocation (10:200)

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -9,7 +9,7 @@
 # SSH, idempotently.
 #
 # The feature map is keyed by SERVICE NAME (plex, seerr, sonarr, radarr,
-# download-vpn) — NOT by raw VMID. Each service's current VMID is resolved at
+# download-vpn, sortarr) — NOT by raw VMID. Each service's current VMID is resolved at
 # run time from the tofu inventory (containers keyed by hostname, each with
 # a `vmid`), injected onto proxmox hosts by playbooks/load_tofu.yml as
 # `media_lxc_features_service_vmids_from_tofu`. A future VMID renumber needs
@@ -61,8 +61,12 @@
 #                                            auth, app-sync links)
 #   seerr         /opt/seerr/config         settings.json + db.sqlite3 (users,
 #                                            requests, service registrations)
+#   sortarr       /opt/sortarr/data         app config + cache (Sortarr calls
+#                                            Sonarr/Radarr/Plex over HTTP; no
+#                                            /data mount of its own)
 # Ownership is the app's OWN mapped host id (owner_user, or owner_uid for seerr's
-# unnamed Docker uid 1000), not the shared media GID.
+# unnamed Docker uid 1000, or sortarr's root uid 0 — its image has no
+# PUID/PGID support), not the shared media GID.
 media_lxc_features_map:
   plex:  # media streaming
     mounts:
@@ -98,6 +102,12 @@ media_lxc_features_map:
     keyctl: true
     tun: true
     data_idmap: true
+  sortarr:  # media-library insights dashboard (Docker-in-LXC); config-only persistence, no /data mount
+    mounts:
+      - { src: /bulk/appdata/sortarr, dst: /opt/sortarr/data, owner_uid: 0, owner_gid: 0 }
+    keyctl: true
+    tun: false
+    data_idmap: false
 
 # Service -> VMID resolution, sourced from the tofu inventory and injected
 # onto proxmox hosts by playbooks/load_tofu.yml. Defaults to {} when unset


### PR DESCRIPTION
## Summary

- The Sortarr role (dryvist/ansible-proxmox-apps#602, merged) fails its own converge-time persistence guard unless `/opt/sortarr/data` is a persistent mount, but no host-side appdata dataset/bind-mount was ever wired up for it in this repo's `media_lxc_features_map`.
- Adds a `sortarr` entry following the `seerr` pattern: config-only persistence (no shared `/data` mount), `keyctl` enabled for Docker-in-LXC, owned by uid/gid 0 since the upstream `ghcr.io/jaredharper1/sortarr` image has no `PUID`/`PGID` support and its entrypoint runs as root when those env vars are absent (confirmed from the upstream Dockerfile/entrypoint).
- Updates the `media_lxc_features` molecule scenario fixture (`sortarr: 90006`) and the keyctl-services assertion in `verify.yml` to include `sortarr`.

## Changes

- `roles/media_lxc_features/defaults/main.yml`: new `sortarr` map entry + doc-comment updates (service list, per-service persistence table, ownership note).
- `molecule/media_lxc_features/molecule.yml`: add `sortarr: 90006` to the service→vmid test fixture.
- `molecule/media_lxc_features/verify.yml`: keyctl-services assertion now expects `['download-vpn', 'seerr', 'sortarr']`.

No ZFS dataset provisioning is needed — `bulk/appdata` is already a recursive dataset (`inventory/host_vars/pve2.yml`), so `/bulk/appdata/sortarr` is created under it automatically the same way `seerr`'s config dir is.

Companion PRs: dryvist/terraform-proxmox#553 (merged, ingress + port constant), dryvist/ansible-proxmox-apps#602 (merged, sortarr role).

## Test Plan

- [x] `ansible-lint` (production profile) clean — 0 failures across 13 files
- [x] `ansible-playbook --syntax-check playbooks/site.yml` passes
- [x] Direct YAML load + assertion check on the new map entry (mounts/keyctl/data_idmap shape)
- [ ] `molecule test -s media_lxc_features` — blocked locally (missing python `docker` module for the driver on this machine, a known pre-existing local-only gap); relies on CI's Molecule matrix
- [ ] Live converge on the sortarr container — pending, tracked as a manual follow-up alongside the companion PRs

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01KYQyqzesxqG5L46ozuVf4K