### PR TITLE
fix(pve3): keep pve3 powered on 24/7, disable auto-poweroff

### DIFF
--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -37,16 +37,15 @@ sanoid_datasets: >-
        'rpool/data/subvol-' ~ ((containers_from_tofu | default({}))['object-storage'] | default({})).vmid | default('902000') ~ '-disk-1': {'use_template': 'database'}
      } }}
 
-# Offline-DR wake controller. pve1 is always-on and can reach the BMC subnet, so
-# it runs the node_scheduled_wake timers that power the normally-off DR node ON
-# twice a day for its replication windows (the node then replicates on boot and
-# powers itself back off — see pve3 host_vars). The BMC address + credentials come
-# from the environment (Doppler), never committed. If pve1 itself is down the DR
-# node simply will not wake that window — an accepted limitation for the always-on
-# primary. Default schedule (03:00 + 15:00) lives in the role defaults.
-node_scheduled_wake_targets:
-  - name: pve3
-    bmc_host: "{{ lookup('env', 'PVE3_BMC_HOSTNAME') | default('', true) }}"
+# Offline-DR wake controller. This node is always-on and can reach the BMC
+# subnet, so it runs the node_scheduled_wake timers that power a normally-off
+# DR node ON for its replication windows. The BMC address + credentials come
+# from the environment (Doppler), never committed. Default schedule (03:00 +
+# 15:00) lives in the role defaults.
+#
+# Empty: the only previous target is now always-on and no longer needs waking.
+# Add an entry here again if a future normally-off DR leg needs this mechanism.
+node_scheduled_wake_targets: []
 
 # Clear the CPU C6-state enable MSR bits at boot (kernel_tuning role);
 # the cmdline max_cstate limit alone does not cover this idle state.

--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -1,29 +1,21 @@
 ---
-# Host vars for pve3 (the R710 — a normally-off offline-DR leg).
+# Host vars for this node (the R710).
 #
-# Autonomous wake -> replicate -> sleep cycle. pve3 is normally OFF to save power
-# and comes up only for its backup windows:
-#   - WAKE: the always-on controller (see pve1 host_vars node_scheduled_wake_
-#     targets) issues an IPMI power-on twice a day. The BMC address comes from the
-#     environment (Doppler PVE3_BMC_HOSTNAME, FQDN preferred) — never committed.
-#   - REPLICATE: on boot, the syncoid role runs the PULL jobs below once
-#     (syncoid_trigger: boot). The wall-clock cron is the WRONG trigger here — it
-#     would never fire inside a short power-on window.
-#   - SLEEP: syncoid chains to the node_auto_poweroff oneshot on completion
-#     (syncoid_boot_poweroff_on_complete), so pve3 powers off the moment
-#     replication finishes (success OR failure). The 22:00 node_auto_poweroff
-#     timer stays as a guaranteed-off backstop if a run ever hangs.
-# pve_power_managed also lets a manual site.yml run power-cycle pve3 for
+# This node is always-on:
+#   - node_auto_poweroff_enabled is false: no scheduled poweroff timer.
+#   - syncoid still runs its on-boot replication trigger (syncoid_trigger:
+#     boot), but syncoid_boot_poweroff_on_complete is false, so it no longer
+#     chains to a poweroff on completion.
+# pve_power_managed still lets a manual site.yml run power-cycle this node for
 # maintenance (the idrac_power auto-cycle bookends).
 pve_power_managed: true
 idrac_power_bmc_host: "{{ lookup('env', 'PVE3_BMC_HOSTNAME') | default('', true) }}"
-node_auto_poweroff_enabled: true
+node_auto_poweroff_enabled: false
 syncoid_trigger: boot
-syncoid_boot_poweroff_on_complete: true
+syncoid_boot_poweroff_on_complete: false
 
-# Normally-off node: do NOT run the per-minute healthchecks liveness ping — it
-# would sit "down" and alarm whenever pve3 is (intentionally) off. A freshness
-# deadman for the DR replicas is a tracked follow-up.
+# Per-minute healthchecks liveness ping stays off pending its own follow-up
+# (unrelated to the always-on change above).
 proxmox_monitoring_enable_healthchecks: false
 
 # Layer-2 protection (cross-node ZFS replication via syncoid, PULL model): pve3

--- a/roles/node_auto_poweroff/tasks/main.yml
+++ b/roles/node_auto_poweroff/tasks/main.yml
@@ -47,3 +47,21 @@
     - ansible_virtualization_type | default('') != 'docker'
   tags:
     - node_auto_poweroff
+
+# A host that flips node_auto_poweroff_enabled from true to false would
+# otherwise keep an already-installed timer running (the tasks above only
+# skip creating/starting it, they never touch an existing unit). Mirrors the
+# zfs_replication role's disable-when-inert pattern. failed_when: false
+# tolerates a host that never had the timer installed.
+- name: Stop and disable the auto-poweroff timer when the role is disabled
+  ansible.builtin.systemd:
+    name: node-auto-poweroff.timer
+    enabled: false
+    state: stopped
+  when:
+    - not (node_auto_poweroff_enabled | bool)
+    - ansible_virtualization_type | default('') != 'docker'
+  failed_when: false
+  changed_when: false
+  tags:
+    - node_auto_poweroff

--- a/roles/node_auto_poweroff/tasks/main.yml
+++ b/roles/node_auto_poweroff/tasks/main.yml
@@ -37,31 +37,19 @@
 - name: Reload systemd before enabling the timer
   ansible.builtin.meta: flush_handlers
 
-- name: Enable and start the auto-poweroff timer
+# Drive enabled/state off the flag (not gated on it) so flipping the feature
+# off actively stops + disables an already-installed timer instead of leaving
+# it running — the render tasks above only skip writing the unit when disabled,
+# they never touch an existing one. Same pattern as node_scheduled_wake's
+# timer-state task. failed_when: false tolerates a host whose unit was never
+# rendered (stopping a non-existent timer is a no-op, not an error).
+- name: Set the auto-poweroff timer's enabled/state from the feature flag
   ansible.builtin.systemd:
     name: node-auto-poweroff.timer
-    enabled: true
-    state: started
+    enabled: "{{ node_auto_poweroff_enabled | bool }}"
+    state: "{{ 'started' if (node_auto_poweroff_enabled | bool) else 'stopped' }}"
   when:
-    - node_auto_poweroff_enabled | bool
-    - ansible_virtualization_type | default('') != 'docker'
-  tags:
-    - node_auto_poweroff
-
-# A host that flips node_auto_poweroff_enabled from true to false would
-# otherwise keep an already-installed timer running (the tasks above only
-# skip creating/starting it, they never touch an existing unit). Mirrors the
-# zfs_replication role's disable-when-inert pattern. failed_when: false
-# tolerates a host that never had the timer installed.
-- name: Stop and disable the auto-poweroff timer when the role is disabled
-  ansible.builtin.systemd:
-    name: node-auto-poweroff.timer
-    enabled: false
-    state: stopped
-  when:
-    - not (node_auto_poweroff_enabled | bool)
     - ansible_virtualization_type | default('') != 'docker'
   failed_when: false
-  changed_when: false
   tags:
     - node_auto_poweroff

--- a/roles/node_scheduled_wake/tasks/main.yml
+++ b/roles/node_scheduled_wake/tasks/main.yml
@@ -128,3 +128,60 @@
     - ansible_virtualization_type | default('') != 'docker'
   tags:
     - node_scheduled_wake
+
+# Retire orphaned per-target units: a target dropped from
+# node_scheduled_wake_targets (e.g. a node that became always-on) would
+# otherwise leave its previously-installed timer running and waking a node that
+# no longer sleeps. Find every installed wake timer, and for any whose target
+# is no longer in the current list, stop+disable+remove its unit and env files.
+# Self-heals for any future removed target.
+- name: List installed wake timer units
+  ansible.builtin.find:
+    paths: /etc/systemd/system
+    patterns: "node-scheduled-wake-*.timer"
+    file_type: file
+  register: node_scheduled_wake_installed
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - node_scheduled_wake
+
+- name: Compute orphaned wake target names
+  ansible.builtin.set_fact:
+    node_scheduled_wake_orphans: >-
+      {{ (node_scheduled_wake_installed.files | default([]) | map(attribute='path')
+          | map('basename')
+          | map('regex_replace', '^node-scheduled-wake-(.*)\.timer$', '\1') | list)
+         | difference(node_scheduled_wake_targets | map(attribute='name') | list) }}
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - node_scheduled_wake
+
+- name: Stop and disable orphaned wake timers
+  ansible.builtin.systemd:
+    name: "node-scheduled-wake-{{ item }}.timer"
+    enabled: false
+    state: stopped
+  loop: "{{ node_scheduled_wake_orphans | default([]) }}"
+  failed_when: false
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - node_scheduled_wake
+
+- name: Remove orphaned wake unit and credential files
+  ansible.builtin.file:
+    path: "{{ item.1 | format(item.0) }}"
+    state: absent
+  loop: "{{ node_scheduled_wake_orphans | default([])
+           | product(['/etc/systemd/system/node-scheduled-wake-%s.timer',
+                      '/etc/systemd/system/node-scheduled-wake-%s.service',
+                      '/etc/node-scheduled-wake/%s.env']) }}"
+  loop_control:
+    label: "{{ item.1 | format(item.0) }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+  notify: Reload systemd daemon
+  tags:
+    - node_scheduled_wake


### PR DESCRIPTION
## Summary
Keep pve3 powered on 24/7 and remove its scheduled/auto poweroff.

- `inventory/host_vars/pve3.yml` — `node_auto_poweroff_enabled: false`, `syncoid_boot_poweroff_on_complete: false` (both were `true`). Syncoid replication itself is untouched; only the poweroff-on-complete chain is removed.
- `inventory/host_vars/pve1.yml` — `node_scheduled_wake_targets: []` (was pve3); pve3 no longer needs waking. Mechanism stays available for a future normally-off DR leg.
- `roles/node_auto_poweroff/tasks/main.yml` — the role previously only *skipped* creating/starting the timer when disabled and never touched an already-installed one. Added a stop+disable task (mirrors the `zfs_replication` disable-when-inert pattern) so a host that flips enabled to disabled has its live timer actually stopped+disabled.
- `roles/node_scheduled_wake/tasks/main.yml` — same root-cause pattern for the wake side: a target dropped from `node_scheduled_wake_targets` used to leave its installed per-target timer running. Added an orphan-cleanup step that lists every installed `node-scheduled-wake-*.timer`, and for any whose target is no longer in the list, stops+disables the timer and removes its timer/service/env files. Self-heals for any future removed target.

## Validation
- `ansible-lint` (production profile): 0 failures / 0 warnings, 245 files.
- Local `molecule test` cannot run in this dev shell (`ModuleNotFoundError: No module named 'docker'` in molecule-plugins' docker driver — pre-existing env issue, unrelated; molecule runs in CI). Substituted with `ansible-playbook --check` against a throwaway local inventory plus targeted Jinja checks of the orphan-detection expression.
- Live converge (both roles, `--limit pve1,pve3`), verified over SSH:
  - pve3: `node-auto-poweroff.timer` → `disabled` / `inactive`. The 22:00 poweroff is gone.
  - pve1: `node-scheduled-wake-pve3.timer` → `not-found` (unit + env files removed) after the orphan-cleanup converge; re-run is idempotent (changed=0).

## Test plan
- [ ] CI `ansible-lint` + Molecule (`node_auto_poweroff`, `node_scheduled_wake`) green.