### PR TITLE
feat(inventory): commission pve4 in the homelab cluster

### DIFF
--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -29,14 +29,18 @@ all:
           ansible_host: "{{ lookup('env', 'PVE4_VE_HOSTNAME') | default(omit, true) }}"
           ansible_user: "{{ lookup('env', 'PROXMOX_VM_SSH_USERNAME') }}"
           ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') | default(omit, true) }}"
-          # Always-on AMD desktop, compute VLAN .13. Former standalone box, now a
-          # fresh Proxmox install joining the cluster. Like pve1 it stays in the
-          # default `proxmox`/`pve_cluster_members` groups (NOT `rack_servers`),
-          # so it inherits the compute-node kernel/swap/boot-param baselines from
-          # group_vars/proxmox.yml. zfs_pools stays gated until node_storage and a
-          # known disk layout exist, so it is not commissioned yet.
+          # Always-on AMD desktop, compute VLAN .14 (reconciled from the .13
+          # originally planned here — matches the node name and its live
+          # DHCP-assigned address; see tofu-unifi fixed-ips.json). Joined the
+          # 4-node homelab-cluster 2026-07-06 (4/4 quorate), no guests placed
+          # yet. Like pve1 it stays in the default `proxmox`/`pve_cluster_members`
+          # groups (NOT `rack_servers`), so it inherits the compute-node
+          # kernel/swap/boot-param baselines from group_vars/proxmox.yml.
+          # Commissioned now node bring-up is done; zfs_pools still gates pool
+          # creation on tofu node_storage carrying a disk layout for pve4, so
+          # flipping this alone does not place any storage yet.
           proxmox_node_name: pve4
-          pve_node_commissioned: false
+          pve_node_commissioned: true
           # Opt out of the group-wide AMD Zen1 stability boot params
           # (group_vars/proxmox.yml: clocksource=hpet, tsc=unstable, deep-C-state
           # disable). This node is AMD Zen 3, which has no Zen1 TSC/C-state quirk,


### PR DESCRIPTION
## Summary
- pve4 (always-on AMD Zen3 desktop) is cleanly joined to the homelab cluster (4/4 quorate, PVE 9.2.2) at 10.0.10.14.
- Flips `pve_node_commissioned` to `true` and corrects the stale `.13` comment to the reconciled `.14` (matches the node name and its live address; companion tofu-unifi PR reconciles the fixed-ip reservation).
- `deployment.json` (private S3 input) already carries `nodes.pve4.commissioned` — set to `true` directly in the S3 object per the source-of-truth flow (not part of this PR's diff).

## Test plan
- [x] `ansible-lint inventory/hosts.yml` — 0 failures, `production` profile passed
- [ ] Next converge run picks up pve4 as commissioned (no storage placement expected yet — node_storage has no pve4 disk layout)