### PR TITLE
feat(pve_ha): autonomous HA role for tier-0 guests (DR/HA W5)

### DIFF
--- a/playbooks/ha.yml
+++ b/playbooks/ha.yml
@@ -1,0 +1,28 @@
+---
+# Configure Proxmox VE HA (resources + anti-affinity) for the tier-0 guests.
+#
+# INERT by default — the pve_ha role does nothing unless pve_ha_enabled=true.
+# HA state is cluster-wide, so the role acts on a single node (pve_ha_config_host)
+# and is a no-op on the rest.
+#
+#   # Preview (nothing changes; role asserts-out because enabled=false):
+#   doppler run -- ansible-playbook -i inventory playbooks/ha.yml
+#
+#   # LIVE enable (gated — changes cluster HA behaviour for tier-0 guests):
+#   doppler run -- ansible-playbook -i inventory playbooks/ha.yml \
+#     -e pve_ha_enabled=true
+#
+# See roles/pve_ha/README.md for the guest set, the anti-affinity model, and the
+# non-destructive failover drill (scripts/ha-failover-drill.sh).
+
+- name: Load OpenTofu inventory (containers_from_tofu -> proxmox hosts)
+  ansible.builtin.import_playbook: load_tofu.yml
+
+- name: Configure Proxmox VE HA for tier-0 guests
+  hosts: proxmox
+  become: true
+  gather_facts: true
+  roles:
+    - role: pve_ha
+      tags:
+        - pve_ha

--- a/roles/pve_ha/README.md
+++ b/roles/pve_ha/README.md
@@ -1,0 +1,86 @@
+# pve_ha
+
+Configure Proxmox VE HA (High Availability) for the tier-0 guests via
+`ha-manager` (Proxmox VE 9 "HA rules", not the legacy HA groups). Part of the
+autonomous DR/HA program (wave W5): a node failure is handled with **zero manual
+action**.
+
+## Installation
+
+Ships with this repo. Reference it from a play (see `playbooks/ha.yml`):
+
+```yaml
+- hosts: proxmox
+  roles:
+    - role: pve_ha
+```
+
+## Usage
+
+Runs on a **single** node (`pve_ha_config_host`) because HA state is
+cluster-wide (`/etc/pve/ha/*`, replicated by pmxcfs).
+
+```bash
+# Preview (asserts-out, no change — inert by default):
+doppler run -- ansible-playbook -i inventory playbooks/ha.yml
+
+# LIVE enable (gated — changes cluster HA behaviour for tier-0 guests):
+doppler run -- ansible-playbook -i inventory playbooks/ha.yml -e pve_ha_enabled=true
+```
+
+When enabled it:
+
+1. Places each tier-0 LXC under HA (`ha-manager add ct:VMID --state started
+   --max_restart 3 --max_relocate 1`). VMIDs resolve from the tofu inventory by
+   hostname, so a renumber flows through with no edit.
+2. Adds `resource-affinity` **negative** rules so the two halves of each
+   redundant pair never share a node.
+
+Guests (default `pve_ha_ct_hostnames`): `openbao-01`, `openbao-02`,
+`technitium-dns`, `technitium-dns-2`, `traefik`. Anti-affinity pairs
+(`pve_ha_anti_affinity_groups`): the two OpenBao Raft voters, the two Technitium
+DNS instances, and the Traefik ingress pair (the last auto-activates once
+`traefik-2` exists). A pair whose members do not all resolve is skipped.
+
+## Why anti-affinity is the real payload (and relocation is not)
+
+These tier-0 guests sit on **local ZFS**, not shared storage, and each already
+has a redundant PEER on another node (OpenBao Raft quorum, the second Technitium
+instance, the keepalived VRRP VIP). So:
+
+- On a **crash**, HA auto-restarts the guest in place (`max_restart`).
+- On a **node loss**, the surviving PEER carries the service; the failed guest
+  returns when its node heals. HA cannot start it on another node without the
+  rootfs being there (PVE storage replication / `pvesr`), which is a tracked
+  follow-up — deliberately **not** required for the node-loss story. Hence
+  `max_relocate` is intentionally low.
+- **Anti-affinity** is what keeps the redundancy real: it stops HA (or a manual
+  migrate) from ever collapsing both peers onto one node.
+
+With 4 quorate nodes, HA fencing is safe — losing one node keeps quorum, so no
+surviving node self-fences.
+
+## Safety
+
+**Inert by default.** Nothing happens unless `pve_ha_enabled=true`. Enabling is a
+deliberate, gated step. All CLI work is skipped under Docker so the role is
+molecule-testable.
+
+## Failover drill (non-destructive)
+
+`scripts/ha-failover-drill.sh <test-sid> <other-node-name>` proves both
+auto-restart and relocation against a **disposable** test container (never a
+tier-0 guest — it hard-refuses). It adds the test guest to HA, stops it and
+confirms HA restarts it, migrates it to another node and back, then removes it.
+No real service is touched.
+
+## Key variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `pve_ha_enabled` | `false` | Master switch (inert until true). |
+| `pve_ha_config_host` | `pve` | Single node the ha-manager commands run on. |
+| `pve_ha_ct_hostnames` | tier-0 list | LXC guests to HA-manage (by hostname). |
+| `pve_ha_extra_sids` | `[]` | Verbatim extra SIDs (e.g. `vm:NNN`). |
+| `pve_ha_anti_affinity_groups` | pairs | Redundant pairs to keep apart. |
+| `pve_ha_max_restart` / `pve_ha_max_relocate` | `3` / `1` | Per-guest bounds. |

--- a/roles/pve_ha/defaults/main.yml
+++ b/roles/pve_ha/defaults/main.yml
@@ -1,0 +1,73 @@
+---
+# pve_ha — Proxmox VE HA (High Availability) resource + affinity manager.
+#
+# Configures ha-manager (Proxmox VE 9 "HA rules", not the legacy HA groups) for
+# the tier-0 guests so a node failure is handled with ZERO manual action:
+#   * a crashed guest auto-restarts (max_restart), and
+#   * the redundant PAIRS (the two OpenBao Raft voters, the two Technitium DNS
+#     instances, the two Traefik ingress LXCs) are pinned to SEPARATE nodes by
+#     anti-affinity, so a single node loss can never take out both halves.
+#
+# SAFETY: this role is INERT by default. It does nothing unless pve_ha_enabled is
+# true. HA config is CLUSTER-WIDE (/etc/pve/ha/*, replicated by pmxcfs) so it is
+# applied ONCE from a single node (run_once against pve_ha_config_host), never
+# per-node. All CLI work is skipped under Docker so the role is molecule-testable
+# in containers without a live cluster.
+#
+# STORAGE NOTE (why max_relocate is deliberately low): these tier-0 guests live
+# on LOCAL ZFS, not shared storage. On a node FAILURE ha-manager can only start
+# a guest on another node if that guest's rootfs already exists there (PVE
+# storage replication, pvesr). Today it does not — and that is fine: every
+# tier-0 guest has a redundant PEER on another node (OpenBao Raft quorum after
+# the third voter lands / the second Technitium instance / the keepalived VRRP
+# VIP), so the surviving peer covers the outage and the failed guest returns
+# when its node heals. Real cross-node relocation via pvesr is a tracked
+# follow-up, NOT required for the node-loss story. So the payload here is
+# anti-affinity + in-place auto-restart + orderly return-home, not migration.
+pve_ha_enabled: false
+
+# Inventory hostname of the SINGLE node the ha-manager commands run on. HA state
+# is cluster-wide, so one node is sufficient and correct. Defaults to the
+# cluster primary (same default identity the pve_cluster role uses).
+pve_ha_config_host: pve
+
+# Per-guest HA restart/relocate bounds and desired state.
+pve_ha_max_restart: 3
+pve_ha_max_relocate: 1
+pve_ha_state: started
+
+# Tier-0 LXC guests to place under HA, identified by HOSTNAME (stable across a
+# VMID renumber). The VMID + "ct:" SID are resolved in tasks/main.yml from the
+# tofu inventory (containers_from_tofu, injected by load_tofu.yml), so a
+# renumber flows through with no edit here. A hostname absent from the inventory
+# is skipped with a warning rather than failing the run.
+pve_ha_ct_hostnames:
+  - openbao-01
+  - openbao-02
+  - technitium-dns
+  - technitium-dns-2
+  - traefik
+# Extra HA SIDs to manage verbatim (e.g. a VM the tofu container map does not
+# cover: "vm:110130"). Merged with the resolved CT SIDs. Empty by default.
+pve_ha_extra_sids: []
+
+# Anti-affinity groups: guests that must NEVER share a node (redundant pairs).
+# Each: {name, hostnames:[...]}. Rendered as ha-manager resource-affinity rules
+# with affinity=negative over the resolved SIDs. A group whose members do not
+# all currently resolve is skipped (a half-present pair has nothing to separate).
+pve_ha_anti_affinity_groups:
+  - name: openbao-voters
+    hostnames:
+      - openbao-01
+      - openbao-02
+  - name: technitium-dns
+    hostnames:
+      - technitium-dns
+      - technitium-dns-2
+  # The Traefik ingress pair — activates automatically once traefik-2 exists in
+  # deployment.json (the VRRP VIP peer). With a single ingress node it is a
+  # no-op (skipped: not both members resolve).
+  - name: ingress-traefik
+    hostnames:
+      - traefik
+      - traefik-2

--- a/roles/pve_ha/meta/main.yml
+++ b/roles/pve_ha/meta/main.yml
@@ -1,0 +1,19 @@
+---
+# pve_ha role metadata
+galaxy_info:
+  role_name: pve_ha
+  author: ansible-proxmox
+  description: Configure Proxmox VE HA resources and anti-affinity rules for tier-0 guests
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+  galaxy_tags:
+    - proxmox
+    - ha
+    - availability
+
+dependencies: []

--- a/roles/pve_ha/tasks/main.yml
+++ b/roles/pve_ha/tasks/main.yml
@@ -1,0 +1,146 @@
+---
+# pve_ha — configure Proxmox VE HA resources + anti-affinity rules for tier-0
+# guests. HA state is CLUSTER-WIDE (/etc/pve/ha/*, replicated by pmxcfs), so all
+# work runs on exactly ONE node (pve_ha_config_host). Inert unless
+# pve_ha_enabled; all CLI work is skipped under Docker so the role is
+# molecule-testable without a live cluster.
+
+- name: Refuse to run unless explicitly enabled
+  ansible.builtin.assert:
+    that:
+      - pve_ha_enabled | bool
+    fail_msg: >-
+      pve_ha is inert by default. Set pve_ha_enabled=true only when you intend to
+      place tier-0 guests under Proxmox HA — this changes live cluster behaviour
+      (guests become ha-manager-controlled: auto-restart, fence-on-node-loss).
+    quiet: true
+  tags:
+    - pve_ha
+
+- name: Configure cluster-wide HA from the single config host
+  when:
+    - pve_ha_enabled | bool
+    - inventory_hostname == pve_ha_config_host
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - pve_ha
+  block:
+    # Reuse the same hostname -> vmid projection load_tofu.yml builds for the
+    # media/GPU feature maps, so a VMID renumber flows through with no edit.
+    - name: Map container hostname -> vmid from the tofu inventory
+      ansible.builtin.set_fact:
+        pve_ha_vmid_by_host: >-
+          {{
+            dict(
+              (containers_from_tofu | default({})) | dict2items
+              | selectattr('value.vmid', 'defined')
+              | map(attribute='key') | list
+              | zip(
+                  (containers_from_tofu | default({})) | dict2items
+                  | selectattr('value.vmid', 'defined')
+                  | map(attribute='value.vmid') | list
+                )
+            )
+          }}
+
+    - name: Resolve managed tier-0 SIDs (present hosts only) + any extra SIDs
+      ansible.builtin.set_fact:
+        pve_ha_managed_sids: >-
+          {{ (pve_ha_ct_hostnames | select('in', pve_ha_vmid_by_host)
+              | map('extract', pve_ha_vmid_by_host) | map('string')
+              | map('regex_replace', '^(.+)$', 'ct:\1') | list)
+             + (pve_ha_extra_sids | default([])) }}
+
+    - name: Warn about tier-0 hostnames missing from the inventory (skipped)
+      ansible.builtin.debug:
+        msg: >-
+          pve_ha: these tier-0 hostnames are not in the tofu inventory and are
+          SKIPPED: {{ pve_ha_ct_hostnames | reject('in', pve_ha_vmid_by_host)
+          | list }}
+      when: (pve_ha_ct_hostnames | reject('in', pve_ha_vmid_by_host) | list)
+        | length > 0
+
+    - name: Read current HA resources
+      ansible.builtin.command: pvesh get /cluster/ha/resources --output-format json
+      register: pve_ha_resources_raw
+      changed_when: false
+
+    - name: Parse existing HA resource SIDs
+      ansible.builtin.set_fact:
+        pve_ha_existing_sids: >-
+          {{ (pve_ha_resources_raw.stdout | from_json)
+             | map(attribute='sid') | list }}
+
+    - name: Add tier-0 guests to HA (only those not yet managed)
+      ansible.builtin.command: >-
+        ha-manager add {{ item }}
+        --state {{ pve_ha_state }}
+        --max_restart {{ pve_ha_max_restart }}
+        --max_relocate {{ pve_ha_max_relocate }}
+      loop: "{{ pve_ha_managed_sids }}"
+      when: item not in pve_ha_existing_sids
+      changed_when: true
+
+    - name: Enforce HA params on already-managed guests
+      ansible.builtin.command: >-
+        ha-manager set {{ item }}
+        --state {{ pve_ha_state }}
+        --max_restart {{ pve_ha_max_restart }}
+        --max_relocate {{ pve_ha_max_relocate }}
+      loop: "{{ pve_ha_managed_sids }}"
+      when: item in pve_ha_existing_sids
+      # ponytail: ha-manager set is idempotent server-side; we do not diff each
+      # field, so report unchanged rather than a spurious change every converge.
+      changed_when: false
+
+    - name: Resolve anti-affinity rule SID sets (present members only)
+      ansible.builtin.set_fact:
+        pve_ha_affinity_rules: >-
+          {{ pve_ha_affinity_rules | default([]) + [ {
+               'name': item.name,
+               'sids': (item.hostnames | select('in', pve_ha_vmid_by_host)
+                        | map('extract', pve_ha_vmid_by_host) | map('string')
+                        | map('regex_replace', '^(.+)$', 'ct:\1') | list)
+             } ] }}
+      loop: "{{ pve_ha_anti_affinity_groups }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Read current HA rules
+      ansible.builtin.command: pvesh get /cluster/ha/rules --output-format json
+      register: pve_ha_rules_raw
+      changed_when: false
+
+    - name: Parse existing HA rule names
+      ansible.builtin.set_fact:
+        pve_ha_existing_rules: >-
+          {{ (pve_ha_rules_raw.stdout | from_json)
+             | map(attribute='rule') | list }}
+
+    - name: Add anti-affinity (negative) rules for redundant pairs
+      ansible.builtin.command: >-
+        ha-manager rules add resource-affinity {{ item.name }}
+        --resources {{ item.sids | join(',') }}
+        --affinity negative
+        --comment 'pve_ha: keep {{ item.name }} members on separate nodes'
+      loop: "{{ pve_ha_affinity_rules }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when:
+        - item.sids | length >= 2
+        - item.name not in pve_ha_existing_rules
+      changed_when: true
+
+    - name: Enforce membership on existing anti-affinity rules
+      ansible.builtin.command: >-
+        ha-manager rules set resource-affinity {{ item.name }}
+        --resources {{ item.sids | join(',') }}
+        --affinity negative
+      loop: "{{ pve_ha_affinity_rules }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when:
+        - item.sids | length >= 2
+        - item.name in pve_ha_existing_rules
+      # ponytail: idempotent enforce, same rationale as the resource set above.
+      changed_when: false

--- a/scripts/ha-failover-drill.sh
+++ b/scripts/ha-failover-drill.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# ha-failover-drill.sh — NON-DESTRUCTIVE proof that Proxmox HA auto-restart and
+# relocation actually work, WITHOUT touching any tier-0 guest or rebooting a node.
+#
+# It exercises the HA control loop against a caller-supplied DISPOSABLE test
+# container (create a throwaway CT first — e.g. a 128MB Debian LXC):
+#   1. assert the test SID is NOT a tier-0 guest (hard guard),
+#   2. place it under HA,
+#   3. stop it out-of-band and confirm ha-manager brings it back (auto-restart),
+#   4. migrate it to another node and back (relocation),
+#   5. remove it from HA and leave it stopped.
+# No real service is affected; the only guest touched is the disposable one.
+#
+# Usage (run on a cluster node; needs the ha-manager + pct/qm CLIs):
+#   ha-failover-drill.sh <test-sid> <other-node-name>
+#   e.g. ha-failover-drill.sh ct:999999 <another-cluster-node>
+#
+# Exit non-zero on any step that does not reach the expected HA state.
+set -euo pipefail
+
+SID="${1:?usage: ha-failover-drill.sh <test-sid ct:NNN> <other-node-name>}"
+OTHER_NODE="${2:?usage: ha-failover-drill.sh <test-sid ct:NNN> <other-node-name>}"
+VMID="${SID##*:}"
+KIND="${SID%%:*}"   # ct or vm
+
+# --- Guard: never drill against a tier-0 guest --------------------------------
+# Names here mirror roles/pve_ha/defaults.yml pve_ha_ct_hostnames. The guard is
+# by VMID via the running guest's hostname, so a renumber cannot sneak a real
+# guest past it.
+TIER0_RE='openbao-|technitium-dns|traefik|haproxy'
+if [ "$KIND" = "ct" ]; then
+  name="$(pct config "$VMID" 2>/dev/null | sed -n 's/^hostname: //p' || true)"
+else
+  name="$(qm config "$VMID" 2>/dev/null | sed -n 's/^name: //p' || true)"
+fi
+if printf '%s' "$name" | grep -Eq "$TIER0_RE"; then
+  echo "REFUSING: $SID ('$name') looks like a tier-0 guest. Use a disposable test guest." >&2
+  exit 2
+fi
+
+wait_state() {  # wait_state <sid> <expected-substr> <timeout-s>
+  local sid="$1" want="$2" t="${3:-120}" now
+  for _ in $(seq 1 "$t"); do
+    now="$(ha-manager status 2>/dev/null | awk -v s="$sid" '$0 ~ s {print}')"
+    if printf '%s' "$now" | grep -q "$want"; then
+      echo "  ok: $sid -> $want"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "TIMEOUT: $sid did not reach '$want' within ${t}s. Last: ${now:-<none>}" >&2
+  return 1
+}
+
+cleanup() { ha-manager remove "$SID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "1/5 add $SID to HA (started)"
+ha-manager add "$SID" --state started --max_restart 3 --max_relocate 1
+wait_state "$SID" "started" 120
+
+echo "2/5 stop $SID out-of-band; expect HA to auto-restart it"
+if [ "$KIND" = "ct" ]; then pct stop "$VMID"; else qm stop "$VMID"; fi
+wait_state "$SID" "started" 180   # HA restarts it -> back to 'started'
+
+echo "3/5 relocate $SID -> $OTHER_NODE"
+ha-manager crm-command migrate "$SID" "$OTHER_NODE"
+wait_state "$SID" "$OTHER_NODE" 180
+
+echo "4/5 relocate $SID back to the local node"
+LOCAL_NODE="$(hostname)"
+if [ "$LOCAL_NODE" != "$OTHER_NODE" ]; then
+  ha-manager crm-command migrate "$SID" "$LOCAL_NODE"
+  wait_state "$SID" "$LOCAL_NODE" 180
+fi
+
+echo "5/5 remove $SID from HA (cleanup runs on exit)"
+echo "DRILL PASSED: auto-restart + relocation both verified on $SID."


### PR DESCRIPTION
## DR/HA Wave 5 — PVE HA rules for tier-0 guests

Now that the cluster is 4/4 quorate, HA fencing is safe (losing 1 node keeps quorum). This adds an **inert-by-default** `pve_ha` role that models Proxmox VE 9 HA as IaC so a node failure needs **zero manual action**.

### What it does (when `pve_ha_enabled=true`)
- `ha-manager add ct:VMID --state started --max_restart 3 --max_relocate 1` for each tier-0 LXC (`openbao-01/02`, `technitium-dns`, `technitium-dns-2`, `traefik`). VMIDs resolve from the tofu inventory by hostname (renumber-safe).
- `resource-affinity` **negative** rules so each redundant pair (OpenBao voters, DNS pair, Traefik ingress pair) never shares a node. The ingress pair auto-activates once `traefik-2` exists.

### Design rationale
Tier-0 guests are on **local ZFS** and each has a redundant peer (Raft quorum / second DNS / VRRP VIP). So the payload is **anti-affinity + in-place auto-restart + orderly return-home**, not live cross-node migration (which would need `pvesr` replication — a tracked follow-up, not required for the node-loss story). `max_relocate` is intentionally low. Full rationale in the role README.

### Safety / gating
- **Inert by default** — asserts-out unless `pve_ha_enabled=true`. Merging changes nothing live.
- Enabling live HA on running tier-0 guests is a **deliberate gated step held for lead review** (a misconfig could trigger unwanted relocation/fence).
- Skips under Docker (molecule-safe).

### Validation
- `ansible-lint` (production profile): **Passed**, 0 failures on 7 files.
- `yamllint`: clean.
- Non-destructive failover drill `scripts/ha-failover-drill.sh` exercises auto-restart + relocation against a **disposable** test guest only (hard-refuses tier-0 SIDs).

### Not covered by CI (manual, gated)
Live enable + the failover drill run against the real cluster — held for approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)