### PR TITLE
fix(pve_ha): derive HA config host from cluster primary, not literal pve

### DIFF
--- a/roles/pve_ha/defaults/main.yml
+++ b/roles/pve_ha/defaults/main.yml
@@ -27,9 +27,13 @@
 pve_ha_enabled: false
 
 # Inventory hostname of the SINGLE node the ha-manager commands run on. HA state
-# is cluster-wide, so one node is sufficient and correct. Defaults to the
-# cluster primary (same default identity the pve_cluster role uses).
-pve_ha_config_host: pve
+# is cluster-wide, so one node is sufficient and correct. Defaults to
+# pve_cluster_primary_host (the pve_cluster role's own primary, set in
+# inventory/group_vars/pve_cluster_members.yml as "{{ proxmox_node_prefix }}1")
+# so the two roles always agree on which node is primary. Falls back to the
+# same "{{ proxmox_node_prefix }}1" expression directly when pve_cluster_primary_host
+# is undefined (e.g. a playbook run without the pve_cluster group vars loaded).
+pve_ha_config_host: "{{ pve_cluster_primary_host | default(proxmox_node_prefix ~ '1', true) }}"
 
 # Per-guest HA restart/relocate bounds and desired state.
 pve_ha_max_restart: 3


### PR DESCRIPTION
## Summary

- `pve_ha_config_host` defaulted to the literal `pve`, but live cluster nodes are `pve1`..`pve4` — the HA-config block (gated on `inventory_hostname == pve_ha_config_host`) silently no-ops unless the operator passes `-e pve_ha_config_host=pve1`. Hit live when enabling HA (W5).
- Default now derives from `pve_cluster_primary_host` (the `pve_cluster` role's own primary, `inventory/group_vars/pve_cluster_members.yml`: `"{{ proxmox_node_prefix }}1"`), falling back to the same `proxmox_node_prefix ~ '1'` expression directly if that var is undefined.
- The two roles now always agree on which node is primary; `playbooks/ha.yml` works unmodified with no `-e` override needed.
- No-op against the current live HA state: `PROXMOX_NODE_PREFIX=pve` (Doppler `iac-conf-mgmt/prd`) → resolves to `pve1`, the same node HA was enabled on this session via the `-e` override.

## Test plan

- [x] `ansible-lint` (production profile): 0 failures / 0 warnings on the 5 `pve_ha` role files.
- [ ] No `molecule` scenario exists for `pve_ha` (only `pve_cluster` has one) — nothing to run.
- [ ] Confirm on next `playbooks/ha.yml` converge (without `-e pve_ha_config_host=`) that the role targets `pve1` as before.