### PR TITLE
feat(lxc_features): add n8n + langgraph feature entries

### DIFF
--- a/inventory/group_vars/proxmox.yml
+++ b/inventory/group_vars/proxmox.yml
@@ -56,6 +56,8 @@ lxc_features_containers:
   "512010": "nesting=1,keyctl=1,fuse=1" # llm-router-2 - Docker LiteLLM proxy
   "512020": "nesting=1,keyctl=1,fuse=1" # llm-router-3 - Docker LiteLLM proxy
   "514000": "nesting=1,keyctl=1,fuse=1" # qdrant - Docker vector database
+  "505030": "nesting=1,keyctl=1,fuse=1" # n8n - Docker workflow automation
+  "505040": "nesting=1,keyctl=1,fuse=1" # langgraph - Docker agent orchestration
 
 # Common packages to install
 common_packages:


### PR DESCRIPTION
## Summary
- n8n (505030) and langgraph (505040) were created nesting-only by Terraform (BPG's API-token create call 403s on keyctl/fuse, which are root@pam-only), so their fuse-overlayfs Docker storage driver can't find `/dev/fuse`.
- Adds both VMIDs to `lxc_features_containers` in `inventory/group_vars/proxmox.yml`, following the same post-create pattern already used for dify, langflow, langfuse, and the other Docker-in-LXC guests.
- Next `site.yml --tags lxc_features` run will `pct set --features nesting=1,keyctl=1,fuse=1` and restart both containers, unblocking their app-role converge in ansible-proxmox-apps.

## Test plan
- [x] `ansible-lint` (production profile) passes on the changed file
- [ ] Post-merge: run `site.yml --tags lxc_features --limit pve1,localhost --diff` and confirm both containers show the updated features via `pct config <vmid>`