### PR TITLE
feat: add AI docker LXC host features

### DIFF
--- a/inventory/group_vars/proxmox.yml
+++ b/inventory/group_vars/proxmox.yml
@@ -56,8 +56,7 @@ lxc_features_containers:
   "512010": "nesting=1,keyctl=1,fuse=1" # llm-router-2 - Docker LiteLLM proxy
   "512020": "nesting=1,keyctl=1,fuse=1" # llm-router-3 - Docker LiteLLM proxy
   "514000": "nesting=1,keyctl=1,fuse=1" # qdrant - Docker vector database
-  "505030": "nesting=1,keyctl=1,fuse=1" # n8n - Docker workflow automation
-  "505040": "nesting=1,keyctl=1,fuse=1" # langgraph - Docker agent orchestration
+  # AI-orchestration Docker LXCs are tag-resolved by docker_lxc_features.
 
 # Common packages to install
 common_packages:

--- a/molecule/docker_lxc_features/converge.yml
+++ b/molecule/docker_lxc_features/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    containers_from_tofu: "{{ docker_lxc_features_test_containers }}"
+
+  roles:
+    - role: docker_lxc_features

--- a/molecule/docker_lxc_features/molecule.yml
+++ b/molecule/docker_lxc_features/molecule.yml
@@ -1,0 +1,61 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: proxmox-docker-lxc-features-test
+    image: "${MOLECULE_IMAGE:-debian:stable-slim}"
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+        docker_lxc_features_test_containers:
+          n8n:
+            vmid: 90001
+          langgraph:
+            vmid: 90002
+          dify:
+            vmid: 90003
+            tags:
+              - container
+              - docker
+              - ai-orchestration
+          langflow:
+            vmid: 90004
+            tags:
+              - container
+              - docker
+              - ai-orchestration
+          assistant-01:
+            vmid: 90005
+            tags:
+              - container
+              - docker
+              - ai-orchestration
+          analytics:
+            vmid: 90006
+            tags:
+              - container
+              - docker
+              - analytics
+
+verifier:
+  name: ansible

--- a/molecule/docker_lxc_features/prepare.yml
+++ b/molecule/docker_lxc_features/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Install Python and procps
+      ansible.builtin.raw: |
+        apt-get update && apt-get install -y python3 procps
+      changed_when: true

--- a/molecule/docker_lxc_features/verify.yml
+++ b/molecule/docker_lxc_features/verify.yml
@@ -1,0 +1,89 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    containers_from_tofu: "{{ docker_lxc_features_test_containers }}"
+
+  tasks:
+    - name: Load the role defaults
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../../roles/docker_lxc_features/defaults/main.yml"
+
+    - name: Build the tagged service selection
+      ansible.builtin.set_fact:
+        docker_lxc_features_verify_selected: >-
+          {{
+            docker_lxc_features_verify_selected | default([])
+            + [item]
+          }}
+      loop: "{{ containers_from_tofu | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+      when:
+        - item.value.vmid is defined
+        - "'docker' in (item.value.tags | default([]))"
+        - "'ai-orchestration' in (item.value.tags | default([]))"
+
+    - name: Add fallback services when tags are absent
+      ansible.builtin.set_fact:
+        docker_lxc_features_verify_selected: >-
+          {{
+            docker_lxc_features_verify_selected | default([])
+            + [ { 'key': item, 'value': containers_from_tofu[item] } ]
+          }}
+      loop: "{{ docker_lxc_features_fallback_services }}"
+      loop_control:
+        label: "{{ item }}"
+      when:
+        - item in containers_from_tofu
+        - item not in (docker_lxc_features_verify_selected | default([]) | map(attribute='key') | list)
+
+    - name: Build the resolved service to vmid map
+      ansible.builtin.set_fact:
+        docker_lxc_features_verify_service_vmids: >-
+          {{
+            dict(
+              (docker_lxc_features_verify_selected | map(attribute='key') | list)
+              | zip(
+                  docker_lxc_features_verify_selected
+                  | map(attribute='value')
+                  | map(attribute='vmid')
+                  | map('string')
+                  | list
+                )
+            )
+          }}
+
+    - name: Assert the desired feature string is fixed
+      ansible.builtin.assert:
+        that:
+          - docker_lxc_features_desired_tokens == ['nesting=1', 'keyctl=1', 'fuse=1']
+          - docker_lxc_features_desired_features == 'nesting=1,keyctl=1,fuse=1'
+
+    - name: Assert tagged services and fallback services are selected
+      ansible.builtin.assert:
+        that:
+          - >-
+            docker_lxc_features_verify_service_vmids.keys() | list | sort ==
+            ['assistant-01', 'dify', 'langflow', 'langgraph', 'n8n']
+          - docker_lxc_features_verify_service_vmids['n8n'] == '90001'
+          - docker_lxc_features_verify_service_vmids['langgraph'] == '90002'
+          - docker_lxc_features_verify_service_vmids['dify'] == '90003'
+          - docker_lxc_features_verify_service_vmids['langflow'] == '90004'
+          - docker_lxc_features_verify_service_vmids['assistant-01'] == '90005'
+          - analytics not in docker_lxc_features_verify_service_vmids
+
+    - name: Assert the pct CLI is absent under Docker
+      ansible.builtin.command:
+        cmd: which pct
+      register: docker_lxc_features_pct_probe
+      changed_when: false
+      failed_when: false
+
+    - name: Assert the role skips host-side pct in Molecule
+      ansible.builtin.assert:
+        that:
+          - docker_lxc_features_pct_probe.rc != 0

--- a/playbooks/commission_rack_server.yml
+++ b/playbooks/commission_rack_server.yml
@@ -54,6 +54,13 @@
       tags:
         - lxc_features
 
+    # Root-only Docker-in-LXC features (nesting, keyctl, fuse) for the AI
+    # orchestration guests. Safe no-op here unless a rack server also hosts
+    # those LXCs.
+    - role: docker_lxc_features
+      tags:
+        - docker_lxc_features
+
     - role: nas_storage
       tags:
         - nas_storage

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -99,6 +99,13 @@
       tags:
         - media_lxc_features
 
+    # Root-only Docker-in-LXC features (nesting, keyctl, fuse) for the AI
+    # orchestration guests. Selection is tofu-tag driven and keeps the role
+    # VMID-agnostic.
+    - role: docker_lxc_features
+      tags:
+        - docker_lxc_features
+
     # Root-only AMD GPU passthrough (/dev/dri + /dev/kfd) for the inference LXC
     # (llm-fast) — same root@pam-only contract as media_lxc_features.
     # Runs after OpenTofu creates the shell, before ansible-proxmox-apps installs llama.cpp.

--- a/roles/docker_lxc_features/README.md
+++ b/roles/docker_lxc_features/README.md
@@ -1,0 +1,36 @@
+# docker_lxc_features
+
+Applies the root-only LXC features needed by AI-orchestration Docker guests:
+`nesting=1,keyctl=1,fuse=1`.
+
+The BPG Proxmox Terraform provider can create the shell, but Proxmox only lets
+`root@pam` set `keyctl` and `fuse`, so this role finishes the container on the
+host with `pct set`.
+
+## Selection
+
+The role resolves candidate containers from `containers_from_tofu`:
+
+- any container tagged `docker` and `ai-orchestration` is selected
+- `n8n` and `langgraph` remain explicit fallbacks until those tags are present
+
+That keeps the role VMID-agnostic and lets a renumber flow through from tofu
+inventory without editing the role.
+
+## Ordering
+
+Run after `playbooks/load_tofu.yml` has populated `containers_from_tofu`, and
+before the app converge that needs Docker overlayfs inside the LXC.
+
+## Idempotency
+
+The role reads `pct config` first, compares the live `features:` tokens to the
+desired set, and only issues `pct set` when `keyctl` or `fuse` are missing.
+Changed containers are restarted with a stop/start handler only when config
+actually changed.
+
+## Usage
+
+```bash
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --limit pve1,localhost --tags docker_lxc_features
+```

--- a/roles/docker_lxc_features/defaults/main.yml
+++ b/roles/docker_lxc_features/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# docker_lxc_features role defaults
+#
+# Root-only LXC feature flags for AI-orchestration Docker guests. The BPG
+# Proxmox provider's API token cannot set `keyctl` or `fuse` on these shells,
+# so this role applies the host-side `pct set --features` step after create.
+#
+# The role targets containers whose tofu inventory tags include both `docker`
+# and `ai-orchestration`. `n8n` and `langgraph` remain explicit fallbacks so
+# they stay covered even if the tags have not landed in inventory yet.
+
+docker_lxc_features_desired_tokens:
+  - nesting=1
+  - keyctl=1
+  - fuse=1
+
+docker_lxc_features_desired_features: "{{ docker_lxc_features_desired_tokens | join(',') }}"
+
+docker_lxc_features_fallback_services:
+  - n8n
+  - langgraph

--- a/roles/docker_lxc_features/handlers/main.yml
+++ b/roles/docker_lxc_features/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+# Restart only the containers whose live config changed.
+
+- name: Restart changed docker containers
+  ansible.builtin.shell:
+    cmd: |
+      set -euo pipefail
+      if pct status {{ item }} | grep -q 'status: running'; then
+        pct stop {{ item }}
+      fi
+      pct start {{ item }}
+    executable: /bin/bash
+  loop: "{{ docker_lxc_features_changed | default([]) | unique }}"
+  loop_control:
+    label: "container {{ item }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - docker_lxc_features_changed | default([]) | length > 0
+  changed_when: true

--- a/roles/docker_lxc_features/tasks/configure_container.yml
+++ b/roles/docker_lxc_features/tasks/configure_container.yml
@@ -1,0 +1,50 @@
+---
+# docker_ct.key   = service name
+# docker_ct.value = vmid
+#
+# Compare the live `features:` line first, then set the exact desired
+# `nesting=1,keyctl=1,fuse=1` string only when keyctl or fuse are missing.
+
+- name: "Read current config for container {{ docker_ct.value }}"
+  ansible.builtin.command:
+    cmd: "pct config {{ docker_ct.value }}"
+  register: docker_lxc_features_cfg
+  changed_when: false
+  tags:
+    - docker_lxc_features
+
+- name: "Parse current features for container {{ docker_ct.value }}"
+  ansible.builtin.set_fact:
+    docker_lxc_features_current_tokens: >-
+      {{
+        docker_lxc_features_cfg.stdout_lines
+        | select('match', '^features:')
+        | map('regex_replace', '^features:\s*', '')
+        | list | first | default('')
+        | split(',') | select('truthy') | list
+      }}
+  tags:
+    - docker_lxc_features
+
+- name: "Apply Docker features to container {{ docker_ct.value }}"
+  when:
+    - (docker_lxc_features_current_tokens | sort)
+      != (docker_lxc_features_desired_tokens | sort)
+  tags:
+    - docker_lxc_features
+  block:
+    - name: "Set Docker features on container {{ docker_ct.value }}"
+      ansible.builtin.command:
+        cmd: >-
+          pct set {{ docker_ct.value }} --features
+          {{ docker_lxc_features_desired_features }}
+      changed_when: true
+      notify: Restart changed docker containers
+      register: docker_lxc_features_set
+
+    - name: "Record feature change for container {{ docker_ct.value }}"
+      ansible.builtin.set_fact:
+        docker_lxc_features_changed: "{{ docker_lxc_features_changed + [docker_ct.value] }}"
+      when: docker_lxc_features_set is defined and docker_lxc_features_set.changed
+      tags:
+        - docker_lxc_features

--- a/roles/docker_lxc_features/tasks/main.yml
+++ b/roles/docker_lxc_features/tasks/main.yml
@@ -1,0 +1,100 @@
+---
+# docker_lxc_features role tasks
+#
+# Applies root-only Docker-in-LXC features on the Proxmox host. Selection is
+# driven by the tofu inventory: containers tagged `docker` + `ai-orchestration`
+# are targeted automatically, with `n8n` and `langgraph` kept as fallbacks for
+# the live guests already called out in the problem report.
+
+- name: Reset the AI Docker service accumulator
+  ansible.builtin.set_fact:
+    docker_lxc_features_selected: []
+  tags:
+    - docker_lxc_features
+
+- name: Select tagged AI Docker services from the tofu inventory
+  ansible.builtin.set_fact:
+    docker_lxc_features_selected: "{{ docker_lxc_features_selected + [item] }}"
+  loop: "{{ (containers_from_tofu | default({})) | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - item.value.vmid is defined
+    - "'docker' in (item.value.tags | default([]))"
+    - "'ai-orchestration' in (item.value.tags | default([]))"
+  tags:
+    - docker_lxc_features
+
+- name: Add fallback AI Docker services when tags are not present yet
+  ansible.builtin.set_fact:
+    docker_lxc_features_selected: >-
+      {{
+        docker_lxc_features_selected
+        + [ { 'key': item, 'value': (containers_from_tofu | default({}))[item] } ]
+      }}
+  loop: "{{ docker_lxc_features_fallback_services }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - item in (containers_from_tofu | default({}))
+    - item not in (docker_lxc_features_selected | map(attribute='key') | list)
+  tags:
+    - docker_lxc_features
+
+- name: Build the service to vmid map for AI Docker services
+  ansible.builtin.set_fact:
+    docker_lxc_features_service_vmids: >-
+      {{
+        dict(
+          (docker_lxc_features_selected | map(attribute='key') | list)
+          | zip(
+              docker_lxc_features_selected
+              | map(attribute='value')
+              | map(attribute='vmid')
+              | map('string')
+              | list
+            )
+        )
+      }}
+  tags:
+    - docker_lxc_features
+
+- name: Enumerate LXC containers present on this host
+  ansible.builtin.command:
+    cmd: pct list
+  register: docker_lxc_features_pct_list
+  changed_when: false
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - docker_lxc_features
+
+- name: Build the set of vmids present on this host
+  ansible.builtin.set_fact:
+    docker_lxc_features_present: >-
+      {{
+        docker_lxc_features_pct_list.stdout_lines | default([])
+        | map('regex_search', '^\d+')
+        | select('truthy')
+        | list
+      }}
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - docker_lxc_features
+
+- name: Reset the changed-container accumulator
+  ansible.builtin.set_fact:
+    docker_lxc_features_changed: []
+  tags:
+    - docker_lxc_features
+
+- name: Apply AI Docker features to each present container
+  ansible.builtin.include_tasks: configure_container.yml
+  loop: "{{ docker_lxc_features_service_vmids | default({}) | dict2items }}"
+  loop_control:
+    loop_var: docker_ct
+    label: "{{ docker_ct.key }} -> {{ docker_ct.value }}"
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - docker_ct.value in docker_lxc_features_present | default([])
+  tags:
+    - docker_lxc_features


### PR DESCRIPTION
Adds a host-side `docker_lxc_features` role for AI-orchestration Docker LXCs.

What changed:
- selects tagged containers from tofu inventory when tags include `docker` + `ai-orchestration`
- keeps `n8n` and `langgraph` as fallback services
- applies `nesting=1,keyctl=1,fuse=1` only when the live features line differs
- restarts changed containers with stop/start
- wires the role into `playbooks/site.yml` and `playbooks/commission_rack_server.yml`
- removes the hardcoded AI VMIDs from the generic LXC feature map
- adds Molecule coverage for the tag/fallback selection path

Validation:
- `nix develop -c ansible-lint --profile production playbooks/site.yml playbooks/commission_rack_server.yml roles/docker_lxc_features molecule/docker_lxc_features`
- `nix develop -c ansible-playbook --syntax-check playbooks/site.yml`
- `nix develop -c ansible-playbook --syntax-check playbooks/commission_rack_server.yml`
- local Docker-mode converge of `molecule/docker_lxc_features/converge.yml` twice with the same fixture: 0 changes both runs\n