### PR TITLE
feat(pve_syslog_forwarder): forward PVE node logs to the central syslog pipeline

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -73,6 +73,15 @@
       tags:
         - crash_diagnostics
 
+    # Ship every node's journal/syslog to the central pipeline (HAProxy syslog
+    # VIP -> Cribl Edge -> Splunk os index). Target CNAME comes from
+    # PROXMOX_SUBDOMAIN (Doppler); the port default mirrors terraform-proxmox
+    # pipeline_constants.syslog_ports.linux (see the role defaults).
+    - role: pve_syslog_forwarder
+      tags:
+        - pve_syslog_forwarder
+        - syslog
+
     - role: lxc_features
       tags:
         - lxc_features

--- a/roles/pve_syslog_forwarder/README.md
+++ b/roles/pve_syslog_forwarder/README.md
@@ -1,0 +1,75 @@
+# pve_syslog_forwarder
+
+Forward each Proxmox VE node's logs to the central syslog pipeline so
+everything lands in Splunk. Installs `rsyslog`, which ingests the systemd
+journal by default on Debian, and adds one drop-in rule that ships **all**
+logs to the HAProxy syslog VIP.
+
+```text
+this PVE node (journald + rsyslog)
+  -> syslog.<PROXMOX_SUBDOMAIN>:<linux port>  (TCP, disk-assisted queue)
+     -> HAProxy syslog VIP
+        -> Cribl Edge  (syslog pipeline)
+           -> Splunk HEC  (os index)
+```
+
+Ported from the `syslog_forwarder` role in `ansible-proxmox-apps` (which covers
+the infra LXCs); this role covers the hypervisors themselves.
+
+## What It Does
+
+`rsyslog` reads the systemd journal (`imjournal`) by default on Debian, so a
+single forward rule captures host logs plus every native systemd service —
+`pveproxy`, `pvedaemon`, `pve-firewall`, `corosync`, the ZFS event daemon, and
+everything else on the node. The rule uses `omfwd` with a disk-assisted action
+queue, so a HAProxy/Cribl outage buffers (up to
+`pve_syslog_forwarder_queue_max_disk_space`) instead of dropping logs.
+
+Unlike the LXC variant in `ansible-proxmox-apps`, no systemd sandboxing
+override is needed: PVE nodes are real hosts and satisfy the stock
+`rsyslog.service` hardening.
+
+## Where It Runs
+
+Wired into `playbooks/site.yml` against the `proxmox` group — every node
+forwards on every converge. The syslog receiver chain (HAProxy, Cribl) runs in
+LXCs managed by `ansible-proxmox-apps`, so there is no forward-into-yourself
+loop at the host layer.
+
+## Usage
+
+Runs with the rest of `site.yml`, or target just this role by tag:
+
+```bash
+doppler run -- ansible-playbook -i inventory/hosts.yml playbooks/site.yml \
+  --limit proxmox,localhost --tags pve_syslog_forwarder
+```
+
+### Variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `pve_syslog_forwarder_target_host` | `syslog.{{ PROXMOX_SUBDOMAIN }}` | The `syslog` CNAME (→ HAProxy VIP). Never a literal. |
+| `pve_syslog_forwarder_target_port` | `517` | Linux-family syslog port (→ Splunk `os` index). Pinned because `load_tofu.yml` does not inject `constants`; source of truth is terraform-proxmox `pipeline_constants.syslog_ports.linux`. |
+| `pve_syslog_forwarder_protocol` | `tcp` | `tcp` (reliable) or `udp`. |
+| `pve_syslog_forwarder_config_path` | `/etc/rsyslog.d/10-forward-cribl.conf` | Drop-in rule owned by this role. |
+| `pve_syslog_forwarder_queue_max_disk_space` | `256m` | Disk-queue cap so a receiver outage buffers instead of dropping. |
+
+The role asserts `PROXMOX_SUBDOMAIN` is set (injected via Doppler, like
+`PROXMOX_NODE_PREFIX`) so the real domain is never committed.
+
+## Verification
+
+```bash
+# On a PVE node: the drop-in exists and rsyslog is happy.
+cat /etc/rsyslog.d/10-forward-cribl.conf
+rsyslogd -N1
+systemctl is-active rsyslog
+
+# End to end: this node's logs appear in Splunk under the os index
+#   index=os host=<node>
+```
+
+## License
+
+Apache-2.0, matching the repository.

--- a/roles/pve_syslog_forwarder/defaults/main.yml
+++ b/roles/pve_syslog_forwarder/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Forward each Proxmox VE node's logs (the systemd journal + everything rsyslog
+# ingests) to the central syslog pipeline: HAProxy syslog VIP -> Cribl Edge ->
+# Splunk (os index). rsyslog reads the journal by default on Debian, so
+# installing it and adding one forward rule captures host logs plus every
+# systemd service (pveproxy, pvedaemon, corosync, ...).
+#
+# No literals: the target is the stable `syslog` CNAME (-> haproxy) sized off
+# the PROXMOX_SUBDOMAIN env var (e.g. from Doppler), mirroring how
+# proxmox_node_prefix keeps the real environment value out of the repo.
+
+# Stable syslog entry point: the `syslog` CNAME (-> the HAProxy VIP). Sized off
+# PROXMOX_SUBDOMAIN, never a committed literal.
+pve_syslog_forwarder_target_host: "syslog.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
+
+# Linux-family syslog port (routes to the Splunk os index). This repo's
+# inventory loader (playbooks/load_tofu.yml) does not inject
+# tofu_data.constants, so the value is pinned here; the source of truth is
+# terraform-proxmox `locals.tf` -> pipeline_constants.syslog_ports.linux
+# (published as ansible_inventory.constants.syslog_ports.linux). Keep in sync.
+pve_syslog_forwarder_target_port: 517
+
+# tcp (omfwd protocol=tcp) is reliable; udp drops under load. Cribl accepts both.
+pve_syslog_forwarder_protocol: tcp
+
+# Drop-in rsyslog config file owned by this role.
+pve_syslog_forwarder_config_path: /etc/rsyslog.d/10-forward-cribl.conf
+
+# Disk-assisted action queue: buffer through a HAProxy/Cribl outage instead of
+# dropping logs (capped so a long outage can't fill the root filesystem).
+pve_syslog_forwarder_queue_max_disk_space: 256m

--- a/roles/pve_syslog_forwarder/handlers/main.yml
+++ b/roles/pve_syslog_forwarder/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# pve_syslog_forwarder role handlers
+
+- name: Restart rsyslog
+  ansible.builtin.systemd:
+    name: rsyslog
+    state: restarted
+    daemon_reload: true
+  listen: Restart rsyslog

--- a/roles/pve_syslog_forwarder/handlers/main.yml
+++ b/roles/pve_syslog_forwarder/handlers/main.yml
@@ -5,5 +5,4 @@
   ansible.builtin.systemd:
     name: rsyslog
     state: restarted
-    daemon_reload: true
   listen: Restart rsyslog

--- a/roles/pve_syslog_forwarder/meta/main.yml
+++ b/roles/pve_syslog_forwarder/meta/main.yml
@@ -1,0 +1,24 @@
+---
+# PVE syslog forwarder role metadata
+
+galaxy_info:
+  role_name: pve_syslog_forwarder
+  author: ansible-proxmox
+  description: Forward PVE host logs to the central syslog pipeline (HAProxy VIP -> Cribl Edge -> Splunk)
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - proxmox
+    - syslog
+    - rsyslog
+    - logging
+    - observability
+
+dependencies: []

--- a/roles/pve_syslog_forwarder/tasks/main.yml
+++ b/roles/pve_syslog_forwarder/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+# Install rsyslog and add a single forward rule so this PVE node's logs
+# (systemd journal + everything rsyslog sees) flow to the central syslog VIP ->
+# Cribl Edge -> Splunk. Ports/hostnames are never hardcoded: the target comes
+# from the PROXMOX_SUBDOMAIN env var and the port default mirrors the
+# terraform-proxmox pipeline constants (see defaults/main.yml).
+
+- name: Assert the syslog target host resolved
+  ansible.builtin.assert:
+    that:
+      - lookup('env', 'PROXMOX_SUBDOMAIN') | length > 0
+      - pve_syslog_forwarder_target_port | string | length > 0
+    fail_msg: >-
+      pve_syslog_forwarder needs PROXMOX_SUBDOMAIN (for the syslog CNAME
+      target). Run via doppler (doppler run -- ansible-playbook ...) or export
+      PROXMOX_SUBDOMAIN.
+    quiet: true
+  tags:
+    - pve_syslog_forwarder
+
+- name: Install rsyslog
+  ansible.builtin.apt:
+    name: rsyslog
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  tags:
+    - pve_syslog_forwarder
+
+- name: Deploy the Cribl syslog-forward rule
+  ansible.builtin.template:
+    src: 10-forward-cribl.conf.j2
+    dest: "{{ pve_syslog_forwarder_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+    validate: rsyslogd -N1 -f %s
+  notify: Restart rsyslog
+  tags:
+    - pve_syslog_forwarder
+
+- name: Enable and start rsyslog
+  ansible.builtin.systemd:
+    name: rsyslog
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - pve_syslog_forwarder

--- a/roles/pve_syslog_forwarder/tasks/main.yml
+++ b/roles/pve_syslog_forwarder/tasks/main.yml
@@ -44,7 +44,6 @@
     name: rsyslog
     state: started
     enabled: true
-    daemon_reload: true
   when: ansible_virtualization_type | default('') != 'docker'
   tags:
     - pve_syslog_forwarder

--- a/roles/pve_syslog_forwarder/templates/10-forward-cribl.conf.j2
+++ b/roles/pve_syslog_forwarder/templates/10-forward-cribl.conf.j2
@@ -1,0 +1,17 @@
+# {{ ansible_managed }}
+# Forward all logs to the central syslog pipeline:
+#   this node -> {{ pve_syslog_forwarder_target_host }}:{{ pve_syslog_forwarder_target_port }} ({{ pve_syslog_forwarder_protocol }})
+#   -> HAProxy syslog VIP -> Cribl Edge -> Splunk (os index).
+# rsyslog ingests the systemd journal by default on Debian, so this captures
+# host logs + every systemd service (pveproxy, pvedaemon, corosync, ZFS event
+# daemon, ...). The disk-assisted queue survives a receiver outage instead of
+# dropping logs.
+*.* action(type="omfwd"
+           target="{{ pve_syslog_forwarder_target_host }}"
+           port="{{ pve_syslog_forwarder_target_port }}"
+           protocol="{{ pve_syslog_forwarder_protocol }}"
+           queue.type="LinkedList"
+           queue.filename="cribl_fwd"
+           queue.maxDiskSpace="{{ pve_syslog_forwarder_queue_max_disk_space }}"
+           queue.saveOnShutdown="on"
+           action.resumeRetryCount="-1")


### PR DESCRIPTION
Port the ansible-proxmox-apps syslog_forwarder pattern to the hypervisors:
rsyslog omfwd TCP catch-all with a disk-assisted queue, targeting the
syslog CNAME (PROXMOX_SUBDOMAIN, via Doppler) on the linux-family port.
The port defaults to 517 because load_tofu.yml does not inject
tofu_data.constants; source of truth remains terraform-proxmox
pipeline_constants.syslog_ports.linux. Wired into site.yml for all
proxmox hosts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> Requires PROXMOX_SUBDOMAIN in this repo's Doppler config (currently only ansible-proxmox-apps has it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)