### PR TITLE
feat(pve_node_exporter): install prometheus node_exporter on PVE hosts

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -82,6 +82,13 @@
         - pve_syslog_forwarder
         - syslog
 
+    # Prometheus node_exporter (pinned version, systemd) on :9100, bound to the
+    # node's management IP so host metrics stay on the management VLAN.
+    - role: pve_node_exporter
+      tags:
+        - pve_node_exporter
+        - node_exporter
+
     - role: lxc_features
       tags:
         - lxc_features

--- a/roles/pve_node_exporter/README.md
+++ b/roles/pve_node_exporter/README.md
@@ -1,0 +1,64 @@
+# pve_node_exporter
+
+Install [prometheus node_exporter](https://github.com/prometheus/node_exporter)
+on each Proxmox VE host as a pinned-version native systemd service, exposing
+host metrics (CPU, memory, disk, ZFS, network) on port `9100`.
+
+## What It Does
+
+1. Creates a dedicated no-login system user (`node-exporter`).
+2. Downloads the **pinned** upstream release tarball to a versioned path under
+   `/opt/node_exporter/` (skipped when already present; optional sha256 pin).
+3. Unpacks it (versioned, `creates:`-guarded) and installs the binary to
+   `/usr/local/bin/node_exporter` — only rewritten on a version bump.
+4. Optionally creates the textfile-collector directory so scripts can publish
+   custom metrics by dropping `*.prom` files.
+5. Deploys a hardened systemd unit and enables/starts the service.
+
+Re-runs are no-ops; bumping `pve_node_exporter_version` (plus checksum) rolls
+the fleet forward on the next converge.
+
+## Where It Runs
+
+Wired into `playbooks/site.yml` against the `proxmox` group. By default the
+exporter binds the node's **management IP** (the default-route interface fact,
+derived at runtime — never hardcoded), so metrics are only reachable on the
+management VLAN.
+
+## Usage
+
+Runs with the rest of `site.yml`, or target just this role by tag:
+
+```bash
+doppler run -- ansible-playbook -i inventory/hosts.yml playbooks/site.yml \
+  --limit proxmox,localhost --tags pve_node_exporter
+```
+
+### Variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `pve_node_exporter_version` | `1.9.1` | Pinned upstream release. |
+| `pve_node_exporter_download_url` | GitHub releases URL | Override to a local mirror if nodes must not reach the internet at converge time. |
+| `pve_node_exporter_checksum` | `""` | Optional `sha256:<hex>` pin for the tarball (from the release `sha256sums.txt`). Empty skips the check. |
+| `pve_node_exporter_listen_address` | node's mgmt IP (`ansible_default_ipv4.address`) | Bind address; set `0.0.0.0` for all interfaces. |
+| `pve_node_exporter_port` | `9100` | Listen port. |
+| `pve_node_exporter_user` | `node-exporter` | Service account. |
+| `pve_node_exporter_install_dir` | `/opt/node_exporter` | Versioned install root. |
+| `pve_node_exporter_textfile_collector_enabled` | `true` | Enable the textfile collector. |
+| `pve_node_exporter_textfile_collector_dir` | `/var/lib/node_exporter/textfile_collector` | Drop `*.prom` files here to expose custom metrics. |
+| `pve_node_exporter_extra_args` | `[]` | Extra CLI flags appended to `ExecStart`. |
+
+## Verification
+
+```bash
+systemctl is-active node_exporter
+curl -s http://<node-mgmt-ip>:9100/metrics | head
+
+# Version actually running matches the pin
+/usr/local/bin/node_exporter --version
+```
+
+## License
+
+Apache-2.0, matching the repository (node_exporter itself is Apache-2.0).

--- a/roles/pve_node_exporter/defaults/main.yml
+++ b/roles/pve_node_exporter/defaults/main.yml
@@ -19,12 +19,12 @@ pve_node_exporter_download_url: >-
 pve_node_exporter_checksum: ""
 
 # GOARCH name derived from the host fact; covers the amd64/arm64 fleet.
-pve_node_exporter_arch: "{{ {'x86_64': 'amd64', 'aarch64': 'arm64'}[ansible_architecture] | default('amd64') }}"
+pve_node_exporter_arch: "{{ {'x86_64': 'amd64', 'aarch64': 'arm64'}.get(ansible_architecture, 'amd64') }}"
 
 # Bind to the node's management IP (the default-route interface fact — derived
 # at runtime, never hardcoded) so metrics are only reachable on the management
 # VLAN. Set to 0.0.0.0 to listen on every interface.
-pve_node_exporter_listen_address: "{{ ansible_default_ipv4.address | default('0.0.0.0') }}"
+pve_node_exporter_listen_address: "{{ (ansible_default_ipv4 | default({})).address | default('0.0.0.0') }}"
 
 # Standard node_exporter port.
 pve_node_exporter_port: 9100

--- a/roles/pve_node_exporter/defaults/main.yml
+++ b/roles/pve_node_exporter/defaults/main.yml
@@ -1,0 +1,45 @@
+---
+# Prometheus node_exporter for Proxmox VE hosts: a pinned upstream release
+# installed as a native systemd service, exposing host metrics on :9100 for
+# the central Prometheus/Cribl scrape.
+
+# Pinned upstream release. Renovate-friendly single source for the version;
+# bump deliberately (the checksum below must move with it when set).
+pve_node_exporter_version: "1.9.1"
+
+# Where the release tarball comes from. Standard GitHub releases URL; override
+# to point at a local mirror (e.g. the apt-cacher / artifact LXC) if nodes
+# must not reach the internet at converge time.
+pve_node_exporter_download_url: >-
+  https://github.com/prometheus/node_exporter/releases/download/v{{ pve_node_exporter_version }}/node_exporter-{{ pve_node_exporter_version }}.linux-{{ pve_node_exporter_arch }}.tar.gz
+
+# Optional integrity pin for the tarball ("sha256:<hex>"). Empty skips the
+# check (get_url still only downloads when the versioned dest is absent).
+# Fill from the release's sha256sums.txt when bumping the version.
+pve_node_exporter_checksum: ""
+
+# GOARCH name derived from the host fact; covers the amd64/arm64 fleet.
+pve_node_exporter_arch: "{{ {'x86_64': 'amd64', 'aarch64': 'arm64'}[ansible_architecture] | default('amd64') }}"
+
+# Bind to the node's management IP (the default-route interface fact — derived
+# at runtime, never hardcoded) so metrics are only reachable on the management
+# VLAN. Set to 0.0.0.0 to listen on every interface.
+pve_node_exporter_listen_address: "{{ ansible_default_ipv4.address | default('0.0.0.0') }}"
+
+# Standard node_exporter port.
+pve_node_exporter_port: 9100
+
+# Dedicated no-login system user the service runs as.
+pve_node_exporter_user: node-exporter
+
+# Versioned install root; the active binary is /usr/local/bin/node_exporter.
+pve_node_exporter_install_dir: /opt/node_exporter
+
+# Optional textfile collector: drop *.prom files into this directory (cron
+# jobs, ZFS scripts, ...) and node_exporter exposes them as metrics.
+pve_node_exporter_textfile_collector_enabled: true
+pve_node_exporter_textfile_collector_dir: /var/lib/node_exporter/textfile_collector
+
+# Extra CLI flags appended verbatim to the service ExecStart (e.g.
+# ["--no-collector.wifi"]).
+pve_node_exporter_extra_args: []

--- a/roles/pve_node_exporter/handlers/main.yml
+++ b/roles/pve_node_exporter/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+# pve_node_exporter role handlers
+
+- name: Restart node_exporter
+  ansible.builtin.systemd:
+    name: node_exporter
+    state: restarted
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'
+  listen: Restart node_exporter

--- a/roles/pve_node_exporter/meta/main.yml
+++ b/roles/pve_node_exporter/meta/main.yml
@@ -1,0 +1,24 @@
+---
+# PVE node_exporter role metadata
+
+galaxy_info:
+  role_name: pve_node_exporter
+  author: ansible-proxmox
+  description: Install prometheus node_exporter as a pinned-version systemd service on PVE hosts
+  license: Apache-2.0
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
+  galaxy_tags:
+    - proxmox
+    - prometheus
+    - metrics
+    - monitoring
+    - observability
+
+dependencies: []

--- a/roles/pve_node_exporter/tasks/main.yml
+++ b/roles/pve_node_exporter/tasks/main.yml
@@ -5,6 +5,18 @@
 # /usr/local/bin/node_exporter is only rewritten when the pinned version
 # changes — so re-runs are no-ops and a version bump is one variable.
 
+- name: Assert critical variables are defined and valid
+  ansible.builtin.assert:
+    that:
+      - ansible_architecture in ['x86_64', 'aarch64']
+      - ansible_default_ipv4.address is defined and ansible_default_ipv4.address | length > 0
+      - pve_node_exporter_version is defined and pve_node_exporter_version | length > 0
+      - pve_node_exporter_port is defined and pve_node_exporter_port | string | length > 0
+    fail_msg: "One or more critical configuration variables (architecture, default IPv4 address, version, or port) are undefined, empty, or unsupported."
+    quiet: true
+  tags:
+    - pve_node_exporter
+
 - name: Create node_exporter system user
   ansible.builtin.user:
     name: "{{ pve_node_exporter_user }}"
@@ -80,12 +92,16 @@
   tags:
     - pve_node_exporter
 
+- name: Flush handlers to apply systemd changes
+  ansible.builtin.meta: flush_handlers
+  tags:
+    - pve_node_exporter
+
 - name: Enable and start node_exporter
   ansible.builtin.systemd:
     name: node_exporter
     state: started
     enabled: true
-    daemon_reload: true
   when: ansible_virtualization_type | default('') != 'docker'
   tags:
     - pve_node_exporter

--- a/roles/pve_node_exporter/tasks/main.yml
+++ b/roles/pve_node_exporter/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+# Install prometheus node_exporter as a pinned-version systemd service.
+# Everything is versioned: the tarball and unpacked tree live under
+# {{ pve_node_exporter_install_dir }}/node_exporter-<version>..., and
+# /usr/local/bin/node_exporter is only rewritten when the pinned version
+# changes — so re-runs are no-ops and a version bump is one variable.
+
+- name: Create node_exporter system user
+  ansible.builtin.user:
+    name: "{{ pve_node_exporter_user }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+  tags:
+    - pve_node_exporter
+
+- name: Create node_exporter install directory
+  ansible.builtin.file:
+    path: "{{ pve_node_exporter_install_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags:
+    - pve_node_exporter
+
+- name: Download the pinned node_exporter release tarball
+  ansible.builtin.get_url:
+    url: "{{ pve_node_exporter_download_url }}"
+    dest: "{{ pve_node_exporter_install_dir }}/node_exporter-{{ pve_node_exporter_version }}.linux-{{ pve_node_exporter_arch }}.tar.gz"
+    checksum: "{{ pve_node_exporter_checksum | default('', true) or omit }}"
+    owner: root
+    group: root
+    mode: "0644"
+  tags:
+    - pve_node_exporter
+
+- name: Unpack the node_exporter release
+  ansible.builtin.unarchive:
+    src: "{{ pve_node_exporter_install_dir }}/node_exporter-{{ pve_node_exporter_version }}.linux-{{ pve_node_exporter_arch }}.tar.gz"
+    dest: "{{ pve_node_exporter_install_dir }}"
+    remote_src: true
+    owner: root
+    group: root
+    creates: "{{ pve_node_exporter_install_dir }}/node_exporter-{{ pve_node_exporter_version }}.linux-{{ pve_node_exporter_arch }}/node_exporter"
+  tags:
+    - pve_node_exporter
+
+- name: Install the node_exporter binary
+  ansible.builtin.copy:
+    src: "{{ pve_node_exporter_install_dir }}/node_exporter-{{ pve_node_exporter_version }}.linux-{{ pve_node_exporter_arch }}/node_exporter"
+    dest: /usr/local/bin/node_exporter
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart node_exporter
+  tags:
+    - pve_node_exporter
+
+- name: Create the textfile collector directory
+  ansible.builtin.file:
+    path: "{{ pve_node_exporter_textfile_collector_dir }}"
+    state: directory
+    owner: "{{ pve_node_exporter_user }}"
+    group: "{{ pve_node_exporter_user }}"
+    mode: "0755"
+  when: pve_node_exporter_textfile_collector_enabled
+  tags:
+    - pve_node_exporter
+
+- name: Deploy the node_exporter systemd unit
+  ansible.builtin.template:
+    src: node_exporter.service.j2
+    dest: /etc/systemd/system/node_exporter.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart node_exporter
+  tags:
+    - pve_node_exporter
+
+- name: Enable and start node_exporter
+  ansible.builtin.systemd:
+    name: node_exporter
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - pve_node_exporter

--- a/roles/pve_node_exporter/templates/node_exporter.service.j2
+++ b/roles/pve_node_exporter/templates/node_exporter.service.j2
@@ -1,0 +1,29 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Prometheus node_exporter (v{{ pve_node_exporter_version }})
+Documentation=https://github.com/prometheus/node_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ pve_node_exporter_user }}
+Group={{ pve_node_exporter_user }}
+ExecStart=/usr/local/bin/node_exporter \
+    --web.listen-address={{ pve_node_exporter_listen_address }}:{{ pve_node_exporter_port }}{% if pve_node_exporter_textfile_collector_enabled %} \
+    --collector.textfile.directory={{ pve_node_exporter_textfile_collector_dir }}{% endif %}{% for arg in pve_node_exporter_extra_args %} \
+    {{ arg }}{% endfor %}
+
+Restart=on-failure
+RestartSec=5s
+
+# Read-only metrics daemon: lock it down.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Pinned-version release install (versioned tarball + unpack under
/opt/node_exporter, binary promoted to /usr/local/bin only on a version
bump), dedicated no-login system user, hardened systemd unit listening on
the node's management IP:9100, optional textfile collector directory, and
an optional sha256 pin / local-mirror URL override for the download.
Wired into site.yml for all proxmox hosts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> node_exporter pinned 1.9.1; sha256 must be filled from release sums before converge (Renovate will not bump the var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)