### PR TITLE
fix(media_lxc_features): honor idmap punch-through in config-owner chown

### DIFF
--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -177,6 +177,36 @@
           - (['keyctl=1', 'nesting=1'] | sort) == media_lxc_features_verify_converged
         fail_msg: "keyctl feature-merge logic regressed (drop, order, or idempotency)"
 
+    # Guards the config-owner host-gid mapping (the load-bearing expression
+    # reconcile_config_owner.yml feeds its chown). On a container carrying the
+    # shared-data idmap, the punch-through maps the shared media gid to ITSELF
+    # on the host and carves it out of the offset range — so an owner whose
+    # primary group is that gid must map to the gid itself. base+gid there is
+    # a host gid with no in-container mapping: the dir shows group `nogroup`
+    # and container root loses DAC_OVERRIDE, breaking delegated config writes
+    # (the Prowlarr config.xml permission-denied regression).
+    - name: Assert the config-owner host-gid map honors the punch-through carve-out
+      ansible.builtin.assert:
+        that:
+          - >-
+            ((item.in_gid | int)
+             if ((item.data_idmap | bool)
+                 and (item.in_gid | int) == (media_lxc_features_data_gid | int))
+             else (media_lxc_features_unpriv_base + (item.in_gid | int)))
+            == (item.expect | int)
+        fail_msg: >-
+          host-gid mapping regressed for in_gid={{ item.in_gid }}
+          (data_idmap={{ item.data_idmap }}): expected {{ item.expect }}
+      loop:
+        # shared media gid on a /data container -> punched straight through
+        - { data_idmap: true, in_gid: "{{ media_lxc_features_data_gid }}", expect: "{{ media_lxc_features_data_gid | int }}" }
+        # app-private gid on a /data container -> normal offset
+        - { data_idmap: true, in_gid: 991, expect: 100991 }
+        # any gid on a container without the shared-data idmap -> normal offset
+        - { data_idmap: false, in_gid: 1000, expect: 101000 }
+      loop_control:
+        label: "data_idmap={{ item.data_idmap }} in_gid={{ item.in_gid }}"
+
     # Guards the orphaned-slot pruning logic (the load-bearing expression the role
     # uses to `pct set --delete mpN` after a mounts list shrinks). Bind-mounts are
     # position-indexed, so a shorter desired list leaves higher mpN slots stale.

--- a/roles/media_lxc_features/README.md
+++ b/roles/media_lxc_features/README.md
@@ -170,8 +170,11 @@ Every change is gated on a config diff read from `pct config` / the live
 - **keyctl**: current `features` tokens are parsed, any `keyctl=*` dropped,
   `keyctl=1` appended, sorted; `pct set --features` runs only when the token set
   differs. OpenTofu-set `nesting=1` is preserved.
-- **/dev/net/tun**: a marker-guarded `blockinfile` writes the two raw LXC lines
-  to `/etc/pve/lxc/<vmid>.conf`; reports changed only on an actual edit.
+- **/dev/net/tun**: the two raw LXC lines are reconciled the same
+  drop-all/re-add way as the idmap lines (read the live line-set, rewrite only
+  on a diff) — a marker-guarded `blockinfile` is NOT usable here because pmxcfs
+  relocates raw `lxc.*` keys and strips comment markers, which would re-append
+  duplicates on every run; reports changed only on an actual edit.
 
 A container is **restarted only if its config changed** (handler `pct reboot`,
 notified by the mutating tasks). A fully converged host performs **zero**

--- a/roles/media_lxc_features/tasks/configure_container.yml
+++ b/roles/media_lxc_features/tasks/configure_container.yml
@@ -182,8 +182,10 @@
 # ---------------------------------------------------------------------------
 # A mount whose host dataset must be owned by an in-container app owner (e.g. the
 # plex user on bulk/appdata/plex, or seerr's raw uid 1000 on bulk/appdata/seerr)
-# gets chowned to that owner's MAPPED host uid/gid (unpriv_base + the in-container
-# id). Looped over every owner-bearing mount, so a container with more than one
+# gets chowned to that owner's MAPPED host uid/gid (unpriv_base + the
+# in-container id — except a punched-through shared-data gid, which maps to
+# itself; see reconcile_config_owner.yml). Looped over every owner-bearing
+# mount, so a container with more than one
 # app-config mount (download-vpn: qbittorrent + prowlarr) reconciles each. A mount
 # carries EITHER owner_user (named, resolved live) OR owner_uid/owner_gid
 # (explicit) — the union below selects both; no mount carries both keys.

--- a/roles/media_lxc_features/tasks/reconcile_config_owner.yml
+++ b/roles/media_lxc_features/tasks/reconcile_config_owner.yml
@@ -7,7 +7,11 @@
 #
 # An unprivileged LXC maps in-container uid/gid N -> host (unpriv_base + N) on the
 # default offset, so the host dataset must be owned by that mapped pair for the
-# app user to read+write its config. With `owner_user` the in-container ids are
+# app user to read+write its config. EXCEPTION: on a container carrying the
+# shared-data idmap, the punch-through lines map the shared media gid straight
+# through (container gid == host gid) and carve it OUT of the offset range — an
+# owner whose primary group is that gid maps to the gid itself, never base+gid
+# (see the host-gid computation below). With `owner_user` the in-container ids are
 # package-assigned, so resolve them LIVE (never hardcode). With `owner_uid` the
 # owner is a raw numeric id with no named user inside the LXC (e.g. seerr's
 # Docker `node` = 1000) and is used directly. Idempotent (stat then chown only on
@@ -78,8 +82,24 @@
       ansible.builtin.set_fact:
         media_lxc_features_cfg_host_uid: >-
           {{ media_lxc_features_unpriv_base + (media_lxc_features_cfg_in_uid | int) }}
+        # The gid map is NOT a pure offset on containers carrying the shared-data
+        # idmap: those lxc.idmap lines punch the shared media gid straight through
+        # (container gid -> the SAME host gid) and carve it out of the offset
+        # range. For an owner whose primary group IS that punched-through gid, the
+        # mapped host gid is the gid itself. base+gid there lands on a host gid
+        # with NO in-container mapping — the dir shows group `nogroup` and
+        # container root loses DAC_OVERRIDE over it (the kernel grants
+        # capabilities only on files whose uid AND gid both map into the
+        # namespace), which breaks delegated Ansible writes into the mount.
         media_lxc_features_cfg_host_gid: >-
-          {{ media_lxc_features_unpriv_base + (media_lxc_features_cfg_in_gid | int) }}
+          {{
+            (media_lxc_features_cfg_in_gid | int)
+            if (
+              (media_ct.value.data_idmap | default(false) | bool)
+              and (media_lxc_features_cfg_in_gid | int) == (media_lxc_features_data_gid | int)
+            )
+            else (media_lxc_features_unpriv_base + (media_lxc_features_cfg_in_gid | int))
+          }}
 
     - name: "Chown the host config dataset to its mapped owner on {{ media_ct.key }}"
       ansible.builtin.command:


### PR DESCRIPTION
## Problem

The per-app config-dataset ownership reconcile computed the mapped host gid as `unpriv_base + gid` unconditionally. On containers that carry the shared-data idmap, the punch-through lines map the shared media gid straight through (container gid == host gid) and carve it **out** of the offset range. `base+gid` there is a host gid with **no in-container mapping**: the dataset directory shows group `nogroup` inside the guest, and container root loses `DAC_OVERRIDE` over it — the kernel grants capabilities only on files whose uid AND gid both map into the namespace.

Live impact (verified on the media host before the fix): the indexer app's config dataset directory sat at mode 750 with the unmappable group, so delegated Ansible config writes into that mount failed with permission-denied — the exact failure tracked in dryvist/ansible-proxmox-apps#609. Two sibling app datasets carried the same wrong group but escaped symptoms only because their directory mode includes other-execute.

## Fix

- Map a punched-through shared-data gid to itself; keep the offset for every other gid (and for all uids — the uid map has no punch-through).
- Molecule verify guard over the mapping expression (punched, offset-on-data-container, and no-idmap cases).

The next `media_lxc_features` converge reconciles the three affected datasets' top-level group via the existing stat-then-chown drift gate.

## Verification

- `ansible-lint` production profile: 0 failures.
- The new verify assertions pass standalone (all three cases).
- Root cause confirmed live: dataset dir group = offset-mapped id while children = punched-through id; in-guest view `nogroup`; container-root write test EPERM.

Fixes dryvist/ansible-proxmox-apps#609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd