### PR TITLE
fix(media_lxc_features): add the *arr recycle bin to the /data skeleton

### DIFF
--- a/molecule/media_lxc_features/verify.yml
+++ b/molecule/media_lxc_features/verify.yml
@@ -104,6 +104,9 @@
           - "'torrents/tv' in media_lxc_features_data_directories"
           - "'media/movies' in media_lxc_features_data_directories"
           - "'media/tv' in media_lxc_features_data_directories"
+          # *arr recycle bin — the *arrs validate it exists+writable, so the
+          # skeleton must create it (servarr_wiring points them at it).
+          - "'media/.recycle' in media_lxc_features_data_directories"
         fail_msg: "shared media data-root contract regressed"
 
     # ---------------------------------------------------------------------------

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -163,6 +163,10 @@ media_lxc_features_data_directories:
   - media
   - media/movies
   - media/tv
+  # *arr recycle bin (soft-delete). MUST share the /data filesystem so
+  # deletes are atomic moves; the *arrs validate it exists and is writable
+  # by the media user before accepting it, so the skeleton owns creating it.
+  - media/.recycle
 
 # ---------------------------------------------------------------------------
 # Unprivileged-container GID passthrough for the shared data root


### PR DESCRIPTION
Found live during the media-stack verification sweep: the cross-app wiring role sets each PVR's `recycleBin` to `media/.recycle` on the shared `/data` dataset, but nothing ever created that directory. The PVRs validate the folder exists and is writable by the media user before accepting the setting, so the media-management API write failed HTTP 400 on every converge (`FolderWritableValidator`).

The `/data` skeleton (host-side, root:media, 2775 setgid) is the single owner of that tree — add `media/.recycle` there, with a molecule verify guard.

Verification: ansible-lint production profile clean; converge + live wiring re-run planned immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd