### PR TITLE
fix(pve_node_exporter): pin the 1.9.1 tarball checksums from the release sums

### DIFF
--- a/roles/pve_node_exporter/defaults/main.yml
+++ b/roles/pve_node_exporter/defaults/main.yml
@@ -13,10 +13,15 @@ pve_node_exporter_version: "1.9.1"
 pve_node_exporter_download_url: >-
   https://github.com/prometheus/node_exporter/releases/download/v{{ pve_node_exporter_version }}/node_exporter-{{ pve_node_exporter_version }}.linux-{{ pve_node_exporter_arch }}.tar.gz
 
-# Optional integrity pin for the tarball ("sha256:<hex>"). Empty skips the
-# check (get_url still only downloads when the versioned dest is absent).
-# Fill from the release's sha256sums.txt when bumping the version.
-pve_node_exporter_checksum: ""
+# Integrity pin for the tarball ("sha256:<hex>"), per-arch from the release's
+# sha256sums.txt. Refresh both hashes when bumping the version; an empty
+# string skips the check (get_url still only downloads when the versioned
+# dest is absent).
+pve_node_exporter_checksum: >-
+  sha256:{{ {
+    'amd64': 'becb950ee80daa8ae7331d77966d94a611af79ad0d3307380907e0ec08f5b4e8',
+    'arm64': '848f139986f63232ced83babe3cad1679efdbb26c694737edc1f4fbd27b96203',
+  }[pve_node_exporter_arch] }}
 
 # GOARCH name derived from the host fact; covers the amd64/arm64 fleet.
 pve_node_exporter_arch: "{{ {'x86_64': 'amd64', 'aarch64': 'arm64'}.get(ansible_architecture, 'amd64') }}"


### PR DESCRIPTION
Fills the integrity pin that #369 introduced empty: per-arch sha256 values taken from the upstream v1.9.1 release `sha256sums.txt`, keyed off the derived GOARCH map so both amd64 and arm64 nodes verify the download. Prerequisite for the first `pve_node_exporter` converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TS3gHC9B5sR5WxvLt9gRE