### PR TITLE
feat(pve_syslog_forwarder): ship pve-firewall drop logs to the os index

### DIFF
--- a/roles/pve_syslog_forwarder/defaults/main.yml
+++ b/roles/pve_syslog_forwarder/defaults/main.yml
@@ -29,3 +29,8 @@ pve_syslog_forwarder_config_path: /etc/rsyslog.d/10-forward-cribl.conf
 # Disk-assisted action queue: buffer through a HAProxy/Cribl outage instead of
 # dropping logs (capped so a long outage can't fill the root filesystem).
 pve_syslog_forwarder_queue_max_disk_space: 256m
+
+# PVE firewall log written by pvefw-logger (guest-layer DROP lines with the
+# terraform firewall module's log_level_in/out=warning). File-only — never in
+# the journal — so it needs its own imfile tail (see the template).
+pve_syslog_forwarder_firewall_log: /var/log/pve-firewall.log

--- a/roles/pve_syslog_forwarder/templates/10-forward-cribl.conf.j2
+++ b/roles/pve_syslog_forwarder/templates/10-forward-cribl.conf.j2
@@ -15,3 +15,30 @@
            queue.maxDiskSpace="{{ pve_syslog_forwarder_queue_max_disk_space }}"
            queue.saveOnShutdown="on"
            action.resumeRetryCount="-1")
+
+# PVE firewall drops: pvefw-logger writes {{ pve_syslog_forwarder_firewall_log }}
+# directly (a file, NOT the journal), so the journal-fed *.* rule above never
+# sees a single DROP line. Tail the file and forward it through a dedicated
+# ruleset so the lines are ONLY forwarded — never re-written into local log
+# files by the default ruleset. Lands in the same os index, searchable as
+# process=pve-firewall "policy DROP". If drop volume ever warrants its own
+# index, promote it to a dedicated syslog family in terraform-proxmox
+# syslog_port_map instead of filtering here.
+module(load="imfile")
+ruleset(name="pve_firewall_fwd") {
+  action(type="omfwd"
+         target="{{ pve_syslog_forwarder_target_host }}"
+         port="{{ pve_syslog_forwarder_target_port }}"
+         protocol="{{ pve_syslog_forwarder_protocol }}"
+         queue.type="LinkedList"
+         queue.filename="cribl_fwd_pvefw"
+         queue.maxDiskSpace="{{ pve_syslog_forwarder_queue_max_disk_space }}"
+         queue.saveOnShutdown="on"
+         action.resumeRetryCount="-1")
+}
+input(type="imfile"
+      file="{{ pve_syslog_forwarder_firewall_log }}"
+      tag="pve-firewall:"
+      severity="warning"
+      facility="local0"
+      ruleset="pve_firewall_fwd")


### PR DESCRIPTION
## Why

Guest-layer firewall drops are already being logged on every node (`log_level_in/out = warning` from the terraform firewall module — `/var/log/pve-firewall.log` is 35MB+ of `policy DROP` lines on the first node), but **zero of them reach Splunk**: `pvefw-logger` writes that file directly, never the journal, and this role's `*.*` forward only sees what rsyslog ingests from the journal.

## What

- `imfile` tail of `/var/log/pve-firewall.log` bound to a **dedicated ruleset** whose only action is the same omfwd target (linux syslog family port → `os` index). Dedicated ruleset = lines are only forwarded, never duplicated into local log files by the default ruleset, with an independent disk-assisted queue (`cribl_fwd_pvefw`).
- Tagged `pve-firewall:` so the Cribl syslog pipeline extracts `process=pve-firewall`; searchable as `index=os process=pve-firewall "policy DROP"` per node.
- New default `pve_syslog_forwarder_firewall_log` (path only; no behavior toggle — the file exists on every PVE node).

No new ports, no firewall changes — rides the already-allowed linux family frontend. pvefw-logger stamps UTC (`+0000`), so event-time is skew-safe.

Upgrade path if drop volume warrants its own index: a dedicated syslog family in terraform-proxmox `syslog_port_map`, not node-side filtering.

## Verification

- `ansible-lint` (production profile) green.
- Template deploys with `validate: rsyslogd -N1`.
- Post-merge: converge `pve_syslog_forwarder`, then Splunk REST proof of `policy DROP` lines per host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)