### PR TITLE
feat(common): enforce UTC timezone on every node

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -4,3 +4,13 @@
 - name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: true
+
+# glibc caches /etc/localtime per process: after a timezone change rsyslog
+# keeps stamping outgoing syslog headers in the old zone until restarted.
+# failed_when: false — rsyslog may not be installed yet on a node whose first
+# converge runs common before pve_syslog_forwarder.
+- name: Restart rsyslog for the timezone change
+  ansible.builtin.systemd:
+    name: rsyslog
+    state: restarted
+  failed_when: false

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -8,6 +8,18 @@
 # no-subscription channel automatically, before any apt operation here. This role
 # only refreshes the cache and installs the baseline packages.
 
+# Estate timezone doctrine: every host logs UTC so no consumer ever needs a
+# per-source timezone override (which the Cribl pipeline provably strips).
+# Nodes installed interactively defaulted to a local zone and stamped every
+# RFC3164 syslog line hours off; enforce UTC here so a rebuilt or newly
+# commissioned node can never reintroduce the skew.
+- name: Set the system timezone to UTC
+  community.general.timezone:
+    name: Etc/UTC
+  notify: Restart rsyslog for the timezone change
+  tags:
+    - common
+
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: true


### PR DESCRIPTION
## Why

Three of the four nodes were installed with a local timezone and stamp every outgoing RFC3164 syslog line ~4h off — invisible at event-time (`earliest=-Nm` just misses the events), provable with `eval skew=_indextime-_time` (avg 14401s from those hosts vs 9s from the UTC node). The estate doctrine is **UTC at the source, everywhere except the workstation Mac**, because the Cribl pipeline provably strips per-source timezone overrides.

## What

- `common` role: `community.general.timezone` → `Etc/UTC` (idempotent; first task so it runs before anything else stamps logs).
- Handler: restart rsyslog on change — glibc caches `/etc/localtime` per process, so rsyslog keeps stamping the old zone until restarted. `failed_when: false` for first-converge nodes where rsyslog isn't installed yet.

## Verification

- `ansible-lint` (production profile) green.
- Post-merge converge flips the local-time nodes; Splunk REST skew check on `index=os process=pve-firewall` should drop from ~14401s to <10s per host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)