### PR TITLE
fix(ntp,lint): converge container guard drift + fix stale lint glob

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -27,7 +27,7 @@ enable_list:
   - no-changed-when
 
 kinds:
-  - playbook: "**/load_terraform.yml"
+  - playbook: "**/load_tofu.yml"
 
 use_default_rules: true
 offline: false

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -47,11 +47,23 @@
   tags:
     - ntp
 
+- name: Detect if running inside a system container
+  # systemd-detect-virt --container: exit 0 = inside a container, exit 1 = not.
+  # More reliable than ansible_virtualization_type, which LXC containers with
+  # extra capabilities (e.g. nftables/WireGuard) often mis-report.
+  # Proxmox host syncs the clock for LXC guests, so chrony needn't start there.
+  ansible.builtin.command: systemd-detect-virt --container
+  register: _ntp_virt_container
+  changed_when: false
+  failed_when: false
+  tags:
+    - ntp
+
 - name: Enable and start chrony service
   ansible.builtin.systemd:
     name: chrony
     state: "{{ ntp_service_state }}"
     enabled: "{{ ntp_service_enabled }}"
-  when: ansible_virtualization_type | default('') != 'docker'
+  when: _ntp_virt_container.rc != 0
   tags:
     - ntp

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -64,6 +64,6 @@
     name: chrony
     state: "{{ ntp_service_state }}"
     enabled: "{{ ntp_service_enabled }}"
-  when: _ntp_virt_container.rc != 0
+  when: (_ntp_virt_container.rc | default(1)) != 0
   tags:
     - ntp


### PR DESCRIPTION
## Summary

Two small drift fixes surfaced by a cross-repo Ansible survey:

1. **roles/ntp**: backport the `systemd-detect-virt --container` guest guard from `ansible-proxmox-apps`' copy of this role. `ansible_virtualization_type` can mis-report on LXC containers with extra capabilities (e.g. nftables/WireGuard), which the sibling repo's role already accounts for. This role only applies to `hosts: proxmox` (bare-metal nodes) via `playbooks/site.yml`, so the guard is inert on this repo's current usage — this is drift reduction toward the better-guarded sibling implementation, not a fix for an observed failure here.
2. **.ansible-lint**: the `kinds:` override still globbed `**/load_terraform.yml`, a path that no longer exists after the terraform-to-tofu rename (the real file is `playbooks/load_tofu.yml`). `ansible-proxmox-apps` and `ansible-splunk` already carry the corrected glob.

## Evidence

- `ansible-proxmox-apps/roles/ntp/tasks/main.yml` has the container-detection task this PR ports.
- `ansible-proxmox-apps/.ansible-lint` and `ansible-splunk/.ansible-lint` both already glob `**/load_tofu.yml`.

## Test plan

- [x] `ansible-lint` (profile production) passes clean: 0 failures, 0 warnings on 276 files.
- [x] Diffed against sibling repos to confirm convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj9ZFKDR2iCis44dC2y8Hu