### PR TITLE
fix(idrac_kiosk): FQDN default instead of a hardcoded internal IP

### DIFF
--- a/roles/idrac_kiosk/README.md
+++ b/roles/idrac_kiosk/README.md
@@ -24,9 +24,9 @@ removing it from the play.
 
 The kiosk only shows content if the upstream viewers are live:
 
-- **LXC 251** (`10.0.1.251`) must be serving the two iDRAC6 noVNC viewers:
-  - `http://10.0.1.251:5410/` — Dell R410
-  - `http://10.0.1.251:5710/` — Dell R710
+- The `idrac-kvm` LXC must be serving the two iDRAC6 noVNC viewers:
+  - `http://idrac-kvm.<subdomain>:5410/` — Dell R410
+  - `http://idrac-kvm.<subdomain>:5710/` — Dell R710
 - That LXC and its ports are provisioned by the companion
   `terraform-proxmox` and `ansible-proxmox-apps` iDRAC work.
 
@@ -35,14 +35,14 @@ stays up and retries on the browser's normal schedule.
 
 ## Variables
 
-| Variable                | Default            | Description                                   |
-| ----------------------- | ------------------ | --------------------------------------------- |
-| `idrac_kiosk_enabled`   | `true`             | Master switch; `false` makes the role a no-op |
-| `idrac_kiosk_kvm_ip`    | `10.0.1.251`       | LXC serving the noVNC viewers                 |
-| `idrac_kiosk_r410_port` | `5410`             | R410 viewer port                              |
-| `idrac_kiosk_r710_port` | `5710`             | R710 viewer port                              |
-| `idrac_kiosk_data_dir`  | `/opt/idrac-kiosk` | On-host dir for the landing page              |
-| `idrac_kiosk_user`      | `kiosk`            | Unprivileged user running the session         |
+| Variable                | Default                        | Description                                   |
+| ----------------------- | ------------------------------ | --------------------------------------------- |
+| `idrac_kiosk_enabled`   | `true`                         | Master switch; `false` makes the role a no-op |
+| `idrac_kiosk_kvm_host`  | `idrac-kvm.$PROXMOX_SUBDOMAIN` | FQDN of the LXC serving the noVNC viewers     |
+| `idrac_kiosk_r410_port` | `5410`                         | R410 viewer port                              |
+| `idrac_kiosk_r710_port` | `5710`                         | R710 viewer port                              |
+| `idrac_kiosk_data_dir`  | `/opt/idrac-kiosk`             | On-host dir for the landing page              |
+| `idrac_kiosk_user`      | `kiosk`                        | Unprivileged user running the session         |
 
 ## Installation
 
@@ -62,7 +62,7 @@ Override the vars to change targets without editing the template:
   roles:
     - role: idrac_kiosk
       vars:
-        idrac_kiosk_kvm_ip: "10.0.1.99"
+        idrac_kiosk_kvm_host: "idrac-kvm.example.com"
         idrac_kiosk_r410_port: 6410
         idrac_kiosk_r710_port: 6710
 ```

--- a/roles/idrac_kiosk/defaults/main.yml
+++ b/roles/idrac_kiosk/defaults/main.yml
@@ -8,8 +8,11 @@
 # are touched.
 idrac_kiosk_enabled: true
 
-# LXC 251 serves the two iDRAC6 noVNC viewers (Dell R410 + R710).
-idrac_kiosk_kvm_ip: "10.0.1.251"
+# The LXC serving the two iDRAC6 noVNC viewers (Dell R410 + R710). FQDN, never
+# a literal IP — a hostname insulates this from the guest re-addressing (the
+# golden rule), and resolves via the managed DNS A record. PROXMOX_SUBDOMAIN
+# comes from the environment (Doppler), mirroring pve_syslog_forwarder.
+idrac_kiosk_kvm_host: "idrac-kvm.{{ lookup('env', 'PROXMOX_SUBDOMAIN') }}"
 
 # Per-server viewer ports on the LXC.
 idrac_kiosk_r410_port: 5410

--- a/roles/idrac_kiosk/templates/index.html.j2
+++ b/roles/idrac_kiosk/templates/index.html.j2
@@ -30,8 +30,8 @@
   </head>
   <body>
     <div class="console-grid">
-      <iframe src="http://{{ idrac_kiosk_kvm_ip }}:{{ idrac_kiosk_r410_port }}/" title="Dell R410 iDRAC6"></iframe>
-      <iframe src="http://{{ idrac_kiosk_kvm_ip }}:{{ idrac_kiosk_r710_port }}/" title="Dell R710 iDRAC6"></iframe>
+      <iframe src="http://{{ idrac_kiosk_kvm_host }}:{{ idrac_kiosk_r410_port }}/" title="Dell R410 iDRAC6"></iframe>
+      <iframe src="http://{{ idrac_kiosk_kvm_host }}:{{ idrac_kiosk_r710_port }}/" title="Dell R710 iDRAC6"></iframe>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Closes #378.

`roles/idrac_kiosk/defaults/main.yml` pinned a literal management-VLAN IP for the noVNC-viewer LXC — a private address committed to a public repo (against the workspace FQDN-only convention) that was also **stale** (the guest had since moved VLANs, so the literal pointed at the wrong subnet).

## Change

- Default is now an FQDN sourced from `PROXMOX_SUBDOMAIN` (env/Doppler), mirroring the sibling `idrac_power` role and `pve_syslog_forwarder`.
- Variable renamed `idrac_kiosk_kvm_ip` → `idrac_kiosk_kvm_host` for accuracy; template + README updated.
- README literals scrubbed to the FQDN/placeholder form.

## Why no history scrub

The literal is RFC1918, carries no credential, and pointed at the wrong subnet anyway. Per the public-disclosure convention (fix-forward + scrub-on-edit for a private-range octet), a normal commit is the correct handling — a force-push history rewrite on a public repo is not warranted.

## Verification

- ansible-lint (production profile): pass.
- The managed DNS A record for the viewer guest already resolves, so the kiosk iframes load unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd