### PR TITLE
refactor(molecule): dedup shared scenario config into a base config

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -1,0 +1,29 @@
+---
+# Shared base config, auto-discovered by molecule via find_vcs_root() at
+# .config/molecule/config.yml (see `molecule --help` / molecule/shell.py).
+# Deep-merged under every scenario's molecule.yml, so each scenario file only
+# needs to carry the keys that make it unique (platforms + any test fixtures).
+# `platforms:` is a list and molecule replaces lists wholesale on merge, so it
+# must stay out of this base and be defined in every scenario file.
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
+
+driver:
+  name: docker
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      gathering: smart
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
+  inventory:
+    group_vars:
+      all:
+        ansible_connection: docker
+
+verifier:
+  name: ansible

--- a/molecule/cluster_ssh_trust/molecule.yml
+++ b/molecule/cluster_ssh_trust/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-cluster-ssh-trust-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -17,20 +9,10 @@ platforms:
       - /tmp
 
 provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
   inventory:
     group_vars:
       all:
-        ansible_connection: docker
         # Override defaults for testing environment
         zfs_swap_size: "1G"
         common_packages:
           - htop
-
-verifier:
-  name: ansible

--- a/molecule/docker_lxc_features/molecule.yml
+++ b/molecule/docker_lxc_features/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-docker-lxc-features-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -17,16 +9,9 @@ platforms:
       - /tmp
 
 provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
   inventory:
     group_vars:
       all:
-        ansible_connection: docker
         docker_lxc_features_test_containers:
           n8n:
             vmid: 90001
@@ -56,6 +41,3 @@ provisioner:
               - container
               - docker
               - analytics
-
-verifier:
-  name: ansible

--- a/molecule/idrac_power/molecule.yml
+++ b/molecule/idrac_power/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-idrac-power-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/media_lxc_features/molecule.yml
+++ b/molecule/media_lxc_features/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-media-lxc-features-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -17,16 +9,9 @@ platforms:
       - /tmp
 
 provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
   inventory:
     group_vars:
       all:
-        ansible_connection: docker
         # SINGLE source for the test's service -> vmid fixture, inherited by both
         # converge and verify (a vmid is therefore defined in exactly one place).
         # These are ARBITRARY test ids — NEVER the real production VMIDs, which
@@ -39,6 +24,3 @@ provisioner:
           radarr: 90004
           download-vpn: 90005
           sortarr: 90006
-
-verifier:
-  name: ansible

--- a/molecule/nas_storage/molecule.yml
+++ b/molecule/nas_storage/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-nas-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -17,18 +9,5 @@ platforms:
       - /tmp
 
 provisioner:
-  name: ansible
   env:
     NAS_HOMEASSISTANT_SMB_PASSWORD: molecule-pass
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/node_auto_poweroff/molecule.yml
+++ b/molecule/node_auto_poweroff/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-node-auto-poweroff-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/node_scheduled_wake/molecule.yml
+++ b/molecule/node_scheduled_wake/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-node-scheduled-wake-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/pve_cluster/molecule.yml
+++ b/molecule/pve_cluster/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-cluster-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/sanoid/molecule.yml
+++ b/molecule/sanoid/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-sanoid-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/sqlite_standby/molecule.yml
+++ b/molecule/sqlite_standby/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-sqlite-standby-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/syncoid/molecule.yml
+++ b/molecule/syncoid/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-syncoid-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/zfs_pools/molecule.yml
+++ b/molecule/zfs_pools/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-zfs-pools-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible

--- a/molecule/zfs_replication/molecule.yml
+++ b/molecule/zfs_replication/molecule.yml
@@ -1,12 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/requirements.yml
-
-driver:
-  name: docker
-
 platforms:
   - name: proxmox-zfs-replication-test
     image: "${MOLECULE_IMAGE:-debian:stable-slim}"
@@ -15,18 +7,3 @@ platforms:
     tmpfs:
       - /run
       - /tmp
-
-provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-      gathering: smart
-      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles
-  inventory:
-    group_vars:
-      all:
-        ansible_connection: docker
-
-verifier:
-  name: ansible


### PR DESCRIPTION
## Summary

All 13 `molecule/*/molecule.yml` scenario files repeated the identical `dependency`, `driver`, `provisioner.name`/`config_options`/`inventory.group_vars.all.ansible_connection`, and `verifier` blocks verbatim — differing only in each scenario's `platforms` block and, for 4 scenarios, a handful of test-fixture overrides. This adds `.config/molecule/config.yml`, which molecule auto-discovers at the git root (`find_vcs_root` walk, confirmed against the installed `molecule` 25.11.1 source — `molecule/shell.py`'s `LOCAL_CONFIG_SEARCH = ".config/molecule/config.yml"`) and deep-merges under every scenario's `molecule.yml`. No CI, env var, or `.envrc` changes needed — a missing base config file is silently skipped, so no other repo is affected.

Each scenario file now carries only what makes it unique:
- 10 scenarios (`cluster_ssh_trust`, `idrac_power`, `node_auto_poweroff`, `node_scheduled_wake`, `pve_cluster`, `sanoid`, `sqlite_standby`, `syncoid`, `zfs_pools`, `zfs_replication`) → `platforms:` only.
- `nas_storage` → `platforms:` + `provisioner.env.NAS_HOMEASSISTANT_SMB_PASSWORD`.
- `default` → `platforms:` + `provisioner.inventory.group_vars.all.{zfs_swap_size,common_packages}`.
- `media_lxc_features` / `docker_lxc_features` → `platforms:` + their respective test-fixture maps under `group_vars.all`.

`platforms:` is a list, and molecule replaces lists wholesale on merge (never deep-merges them), so it must stay out of the base config and live in every scenario file — this is called out in a comment in `.config/molecule/config.yml`.

Net: **-276 LOC** (29 insertions, 305 deletions across 15 files).

## Verification

- `molecule list -s <scenario>` resolves cleanly for all 13 scenarios (correct instance/driver/provisioner/scenario names, no config errors) — confirms the base-config merge is structurally valid everywhere.
- Programmatic config-dump comparison for all 13 scenarios, using molecule's own `Config` class (mirroring exactly how the CLI loads `base_config`) to diff the **old monolithic file's resolved config** against the **new base+scenario merged config**: `dependency.options`, `driver.name`, `provisioner.name`, `provisioner.env` (the `nas_storage` password), `provisioner.config_options` (`interpreter_python`/`gathering`/`roles_path`), `provisioner.inventory.group_vars.all` (every fixture override), `verifier.name`, and `platforms` — **all 13 scenarios match byte-for-byte** on every semantically relevant field.
- `ansible-lint` (profile production): 0 failures, 0 warnings, 277 files.
- `yamllint`: clean, exit 0.
- **Real `molecule test -s cluster_ssh_trust` / `molecule converge` could not complete locally**: the nix devShell's Python is missing the `docker` SDK package that `molecule_plugins.docker.driver` imports directly for container create/destroy/reset (`ModuleNotFoundError: No module named 'docker'`, confirmed via `python3 -c "import docker"` in this repo's dev shell). Confirmed this is a **pre-existing environment gap, not caused by this change** — reproduces identically against unmodified `origin/main` (same `molecule reset` `ModuleNotFoundError`, same `molecule test` destroy-phase `UnboundLocalError`). CI is unaffected since `requirements-ci.txt` pip-installs `molecule-docker`, which pulls the `docker` SDK as a normal transitive dependency. Filed dryvist/nix-devenv#65 to add the missing package to the shared ansible devShell profile.

Given the mandatory real-test path was blocked by that pre-existing gap, this PR relies on the config-dump comparison (which exercises the actual merge algorithm, not just my by-hand reading of the YAML) as the verification of record, per the fallback path. CI's `ci / Merge Gate` will run the `default` scenario for real; the post-merge `molecule.yml` workflow will additionally run `nas_storage` and `media_lxc_features` for real against the new base config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj9ZFKDR2iCis44dC2y8Hu