### PR TITLE
feat(docker_lxc_features): select agentgateway-tagged docker guests

### DIFF
--- a/roles/docker_lxc_features/README.md
+++ b/roles/docker_lxc_features/README.md
@@ -11,7 +11,8 @@ host with `pct set`.
 
 The role resolves candidate containers from `containers_from_tofu`:
 
-- any container tagged `docker` and `ai-orchestration` is selected
+- any container tagged `docker` plus either `ai-orchestration` or
+  `agentgateway` is selected
 - `n8n` and `langgraph` remain explicit fallbacks until those tags are present
 
 That keeps the role VMID-agnostic and lets a renumber flow through from tofu

--- a/roles/docker_lxc_features/defaults/main.yml
+++ b/roles/docker_lxc_features/defaults/main.yml
@@ -5,9 +5,10 @@
 # Proxmox provider's API token cannot set `keyctl` or `fuse` on these shells,
 # so this role applies the host-side `pct set --features` step after create.
 #
-# The role targets containers whose tofu inventory tags include both `docker`
-# and `ai-orchestration`. `n8n` and `langgraph` remain explicit fallbacks so
-# they stay covered even if the tags have not landed in inventory yet.
+# The role targets containers whose tofu inventory tags include `docker` plus
+# either `ai-orchestration` or `agentgateway`. `n8n` and `langgraph` remain
+# explicit fallbacks so they stay covered even if the tags have not landed in
+# inventory yet.
 
 docker_lxc_features_desired_tokens:
   - nesting=1

--- a/roles/docker_lxc_features/tasks/main.yml
+++ b/roles/docker_lxc_features/tasks/main.yml
@@ -2,9 +2,10 @@
 # docker_lxc_features role tasks
 #
 # Applies root-only Docker-in-LXC features on the Proxmox host. Selection is
-# driven by the tofu inventory: containers tagged `docker` + `ai-orchestration`
-# are targeted automatically, with `n8n` and `langgraph` kept as fallbacks for
-# the live guests already called out in the problem report.
+# driven by the tofu inventory: containers tagged `docker` plus either
+# `ai-orchestration` or `agentgateway` are targeted automatically, with `n8n`
+# and `langgraph` kept as fallbacks for the live guests already called out in
+# the problem report.
 
 - name: Reset the AI Docker service accumulator
   ansible.builtin.set_fact:
@@ -21,7 +22,7 @@
   when:
     - item.value.vmid is defined
     - "'docker' in (item.value.tags | default([]))"
-    - "'ai-orchestration' in (item.value.tags | default([]))"
+    - "(item.value.tags | default([])) | intersect(['ai-orchestration', 'agentgateway']) | length > 0"
   tags:
     - docker_lxc_features
 


### PR DESCRIPTION
## What

Extend the `docker_lxc_features` role so its tofu-inventory-driven selection
targets containers tagged `docker` plus **either** `ai-orchestration` **or**
`agentgateway`. Previously the second tag had to be `ai-orchestration`.

## Why

The agentgateway MCP/LLM/A2A data-plane LXC is tagged `docker`+`agentgateway`
(deliberately **not** `ai-orchestration` — that tag would double-attach its
firewall options upstream in Terraform). Docker-in-LXC on that guest still
needs the root-only `nesting`/`keyctl`/`fuse` features this role applies via
the host-side `pct set --features` step, which the BPG provider's API token
cannot set at create time.

## Change

- `tasks/main.yml` — the selection `when` now accepts `ai-orchestration` OR
  `agentgateway` as the second tag (via `intersect`).
- Comment blocks in `tasks/main.yml`, `defaults/main.yml`, and the role
  `README.md` updated to describe the widened rule.

Tag-driven selection remains the mechanism; the tag already rides on the tofu
inventory entry, so `docker_lxc_features_fallback_services` is unchanged. No
variables renamed, no role restructuring.

`ansible-lint` (profile: production) passes: 0 failures, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MktvVScwVZZZj84gH7bknt