### PR TITLE
feat(media_lxc_features): NFS library mount + staged relocation prereqs (#395)

### DIFF
--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -62,7 +62,7 @@ kernel_tuning_disable_zen_c6: true
 # media_lxc_features_nfs_mounts:
 #   - src: "{{ proxmox_node_prefix }}2:/bulk/data"
 #     path: /bulk/data
-#     opts: ro,soft,timeo=150
+#     opts: ro,soft,timeo=150,nofail,_netdev
 #
 # syncoid_jobs:
 #   # Appdata seed/refresh for the relocation: pull Plex's identity +

--- a/inventory/host_vars/pve1.yml
+++ b/inventory/host_vars/pve1.yml
@@ -50,3 +50,25 @@ node_scheduled_wake_targets: []
 # Clear the CPU C6-state enable MSR bits at boot (kernel_tuning role);
 # the cmdline max_cstate limit alone does not cover this idle state.
 kernel_tuning_disable_zen_c6: true
+
+# --- STAGED-ONLY: Plex relocation prereqs (issue #395, terraform-proxmox#615) ---
+# Uncomment BOTH blocks only after the staged node_storage entries are applied
+# upstream (fast/appdata parent dataset exists here + the library dataset on the
+# storage node carries its nfs_export) — GATE-A in terraform-proxmox#615.
+# Until then the syncoid cron would fail nightly (no recv parent) and the NFS
+# mount would error (no export), so they stay commented, same staged convention
+# as the upstream deployment manifest.
+#
+# media_lxc_features_nfs_mounts:
+#   - src: "{{ proxmox_node_prefix }}2:/bulk/data"
+#     path: /bulk/data
+#     opts: ro,soft,timeo=150
+#
+# syncoid_jobs:
+#   # Appdata seed/refresh for the relocation: pull Plex's identity +
+#   # watch-history dataset from the storage node into the local fast pool.
+#   # Repeated runs keep it fresh until the cutover flip; after the flip this
+#   # job is REMOVED (the dataset becomes live here, direction would invert).
+#   - name: "plex-appdata-relocation"
+#     source: "root@{{ proxmox_node_prefix }}2:bulk/appdata/plex"
+#     target: "fast/appdata/plex"

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -208,5 +208,5 @@ media_lxc_features_unpriv_base: 100000
 # at the SAME host path the `mounts` map expects, so the per-container
 # bind-mounts need zero changes. Empty by default — realized only on hosts
 # whose host_vars declare entries. Shape:
-#   - { src: "<host>:/bulk/data", path: /bulk/data, opts: "ro,soft,timeo=150" }
+#   - { src: "<host>:/bulk/data", path: /bulk/data, opts: "ro,soft,timeo=150,nofail,_netdev" }
 media_lxc_features_nfs_mounts: []

--- a/roles/media_lxc_features/defaults/main.yml
+++ b/roles/media_lxc_features/defaults/main.yml
@@ -201,3 +201,12 @@ media_lxc_features_data_idmap_lines:
 # mapped uid/gid (resolved LIVE per container — the ids are package-assigned,
 # never hardcoded) so the dir appears as <user>:<user> and stays writable inside.
 media_lxc_features_unpriv_base: 100000
+
+# NFS client mounts (media relocation prereq — issue #395, terraform-proxmox#615).
+# Lets a relocation target node reach the media library that stays on the
+# storage node (exported ro via the tofu node_storage `nfs_export` contract)
+# at the SAME host path the `mounts` map expects, so the per-container
+# bind-mounts need zero changes. Empty by default — realized only on hosts
+# whose host_vars declare entries. Shape:
+#   - { src: "<host>:/bulk/data", path: /bulk/data, opts: "ro,soft,timeo=150" }
+media_lxc_features_nfs_mounts: []

--- a/roles/media_lxc_features/tasks/main.yml
+++ b/roles/media_lxc_features/tasks/main.yml
@@ -175,7 +175,7 @@
     state: present
   when:
     - ansible_virtualization_type | default('') != 'docker'
-    - media_lxc_features_nfs_mounts | length > 0
+    - (media_lxc_features_nfs_mounts | default([])) | length > 0
   tags:
     - media_lxc_features
 
@@ -184,9 +184,12 @@
     src: "{{ item.src }}"
     path: "{{ item.path }}"
     fstype: nfs
-    opts: "{{ item.opts | default('ro,soft,timeo=150') }}"
+    # nofail + _netdev keep a host reboot from hanging when the storage node
+    # is offline: _netdev defers the mount until networking is up, nofail lets
+    # boot proceed if the export is still unreachable.
+    opts: "{{ item.opts | default('ro,soft,timeo=150,nofail,_netdev') }}"
     state: mounted
-  loop: "{{ media_lxc_features_nfs_mounts }}"
+  loop: "{{ media_lxc_features_nfs_mounts | default([]) }}"
   loop_control:
     label: "{{ item.path }}"
   when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/media_lxc_features/tasks/main.yml
+++ b/roles/media_lxc_features/tasks/main.yml
@@ -161,3 +161,34 @@
     - media_ct.key in media_lxc_features_present | default([])
   tags:
     - media_lxc_features
+
+# ---------------------------------------------------------------------------
+# NFS client mounts (media relocation prereq — issue #395)
+# ---------------------------------------------------------------------------
+# Mounts the storage node's ro library export at the same path the bind-mount
+# map uses, so a relocated container's `mounts` entries work unchanged. No-op
+# wherever media_lxc_features_nfs_mounts is empty (the default).
+
+- name: Install the NFS client for library mounts
+  ansible.builtin.apt:
+    name: nfs-common
+    state: present
+  when:
+    - ansible_virtualization_type | default('') != 'docker'
+    - media_lxc_features_nfs_mounts | length > 0
+  tags:
+    - media_lxc_features
+
+- name: Mount the media library over NFS
+  ansible.posix.mount:
+    src: "{{ item.src }}"
+    path: "{{ item.path }}"
+    fstype: nfs
+    opts: "{{ item.opts | default('ro,soft,timeo=150') }}"
+    state: mounted
+  loop: "{{ media_lxc_features_nfs_mounts }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - media_lxc_features


### PR DESCRIPTION
## What
Prereq capability for the Plex relocation (dryvist/terraform-proxmox#615, closes half of #395):

- New `media_lxc_features_nfs_mounts` (default `[]`): installs `nfs-common` and mounts the storage node's ro library export at the same host path the bind-mount map uses — relocated containers' `mounts` entries need zero changes. No-op on every host until host_vars declare entries.
- Staged (commented) host_vars on the relocation target: the NFS mount + a `syncoid_jobs` appdata pull (reusing the existing syncoid role/pattern — repeated runs keep the seed fresh until cutover). Commented because the syncoid cron would fail nightly until the upstream staged `node_storage` entries apply (GATE-A in tf#615); same staged convention as the upstream manifest.

## Impact
Zero behavior change on merge or converge — the var is empty everywhere and the host_vars blocks are commented. Activation is a 2-block uncomment gated on tf#615 GATE-A.

## Testing
`ansible-lint` (production profile): 0 failures on all changed files.

Refs #395.