### PR TITLE
feat(dr): postgres_standby role — replicated dump archive + Tier-2 upload

### DIFF
--- a/docs/DR_RUNBOOK.md
+++ b/docs/DR_RUNBOOK.md
@@ -139,6 +139,11 @@ down (avoid split-brain — one writer, always).
      path the container bind-mounts, recreate the CT definition, repoint its bind
      mount at the cloned dataset, then `pct start <ctid>`.
 
+   - **Database data (any engine):** rebuild the guest via its role, then
+     restore the newest logical dump from `bulk/databases/<instance>` (or the
+     Tier-2 cloud copy) per [`DATABASE_DR_STANDARD.md`](./DATABASE_DR_STANDARD.md) —
+     do not clone the live DB volume; the dumps are the app-consistent artifact.
+
 5. **Repoint DNS.** Update the A record(s) for the affected service(s) to the
    standby's address. Internal traffic resolves by name
    (`<service>.${PROXMOX_SUBDOMAIN}`), so only the DNS A record changes — no

--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -79,3 +79,18 @@ sanoid_datasets:
 #     archive_path: "/bulk/databases/events/archive.db"
 #     tables:
 #       - { name: "events", key: "id" }
+
+# Postgres dump archive pull (postgres_standby role, docs/DATABASE_DR_STANDARD.md).
+# Mirrors the shared-postgres guest's pg-backup directory into the replicated
+# bulk/databases namespace above (sanoid `database` template + pve3 syncoid pull
+# cover it with no per-instance edit). The source guest is addressed by FQDN
+# derived from tofu (hostname + domain) — never a literal IP or domain. Gated on
+# domain_from_tofu so a scoped run without load_tofu.yml stays inert instead of
+# pulling from a bogus host.
+postgres_standby_jobs: >-
+  {{ [] if (domain_from_tofu | default('') | length == 0) else [
+       {'name': 'postgres',
+        'source_host': 'root@' ~ (((containers_from_tofu | default({}))['postgres'] | default({})).hostname | default('postgres')) ~ '.' ~ domain_from_tofu,
+        'source_dir': '/var/lib/postgresql/backups',
+        'archive_dir': '/bulk/databases/postgres'}
+     ] }}

--- a/playbooks/load_tofu.yml
+++ b/playbooks/load_tofu.yml
@@ -117,3 +117,12 @@
         name: "{{ item }}"
         containers_from_tofu: "{{ tofu_data.containers | default({}) }}"
       loop: "{{ groups['proxmox'] | default([]) }}"
+
+    # Estate domain, so host_vars can build guest FQDNs (e.g. the
+    # postgres_standby source_host) instead of hard-coding an IP or domain.
+    # Empty when absent (test fixture) — consumers gate on non-empty.
+    - name: Inject OpenTofu domain onto proxmox hosts
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        domain_from_tofu: "{{ tofu_data.domain | default('') }}"
+      loop: "{{ groups['proxmox'] | default([]) }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -155,6 +155,30 @@
       vars:
         sqlite_standby_healthcheck_url: "https://hc-ping.com/{{ lookup('env', 'HEALTHCHECK_PING_KEY') }}/sqlite-standby"
 
+    # Postgres dump archive pull + Tier-2 cloud upload — the Postgres consumer
+    # of docs/DATABASE_DR_STANDARD.md. Inert until postgres_standby_jobs is set
+    # (per host). Tier-2 targets are env-wired (Doppler/SOPS); an unset key
+    # drops that target, leaving Tier 1 (sanoid + syncoid) intact.
+    - role: postgres_standby
+      tags:
+        - postgres_standby
+      vars:
+        postgres_standby_healthcheck_url: "https://hc-ping.com/{{ lookup('env', 'HEALTHCHECK_PING_KEY') }}/postgres-standby"
+        postgres_standby_s3_targets: >-
+          {{ [
+               {'name': 'RUSTFS',
+                'bucket': lookup('env', 'POSTGRES_DR_RUSTFS_BUCKET'),
+                'prefix': 'postgres',
+                'endpoint_url': lookup('env', 'POSTGRES_DR_RUSTFS_ENDPOINT'),
+                'access_key': lookup('env', 'POSTGRES_DR_RUSTFS_ACCESS_KEY'),
+                'secret_key': lookup('env', 'POSTGRES_DR_RUSTFS_SECRET_KEY')},
+               {'name': 'AWS',
+                'bucket': lookup('env', 'POSTGRES_DR_AWS_BUCKET'),
+                'prefix': 'postgres',
+                'access_key': lookup('env', 'POSTGRES_DR_AWS_ACCESS_KEY'),
+                'secret_key': lookup('env', 'POSTGRES_DR_AWS_SECRET_KEY')}
+             ] | selectattr('access_key', 'ne', '') | list }}
+
     - role: idrac_kiosk
       tags:
         - idrac_kiosk

--- a/roles/postgres_standby/README.md
+++ b/roles/postgres_standby/README.md
@@ -1,0 +1,90 @@
+# postgres_standby
+
+Daily pull of **Postgres logical dumps** into the replicated database archive
+namespace, plus the optional **Tier-2 cloud upload** — the Postgres consumer of
+[`docs/DATABASE_DR_STANDARD.md`](../../docs/DATABASE_DR_STANDARD.md).
+
+The source guest's `postgres` role (in `ansible-proxmox-apps`) already produces
+app-consistent `pg_dump --format=custom` artifacts on a timer. This role, on the
+always-on standby node, mirrors that backup directory into
+`<pool>/databases/<instance>/`, where the storage layer (see
+[`zfs_pools`](../zfs_pools/README.md), `sanoid`, `syncoid`) owns snapshots and
+cross-node DR replication. It then uploads the newest dump per database to each
+configured S3-compatible target (on-prem RustFS and/or AWS S3).
+
+## Installation
+
+Ships in `ansible-proxmox`, applied via `playbooks/site.yml`. No separate install.
+
+## How it works
+
+Per job, daily (`systemd` timer, after the source's own backup window):
+
+1. **Mirror** — `rsync -a --delete` of `*.dump` from the source guest's backup
+   directory into the archive dataset. The mirror tracks the **source's**
+   retention window; pre-prune history is preserved by sanoid snapshots of the
+   archive dataset (read a point-in-time view from `<dataset>/.zfs/snapshot/`).
+2. **Tier-2 upload** — the newest dump per database (`<db>-<utc-stamp>.dump`)
+   is `aws s3 cp`'d to every configured target. Credentials live in a
+   root-only `EnvironmentFile` rendered with `no_log` — never in the script.
+
+A failed job or upload is logged to `/var/log/postgres-standby/` and does
+**not** abort the others; any failure pings `<healthcheck>/fail`.
+
+## Prerequisites (apply-time, out of band)
+
+- SSH trust from this host's `root` to each `source_host`. `cluster_ssh_trust`
+  covers PVE node↔node; a database guest is **not** a PVE node, so add that
+  trust separately (the apps `postgres` role manages the guest side).
+- The target dataset (e.g. `bulk/databases`) created by `zfs_pools` from the
+  `terraform-proxmox` declaration; `bulk/databases` recursion covers the
+  per-instance child automatically.
+- For Tier-2: the bucket exists and the supplied keys can write it.
+
+## Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `postgres_standby_enabled` | `true` | Master enable |
+| `postgres_standby_jobs` | `[]` | Jobs (see below) — inert until set |
+| `postgres_standby_s3_targets` | `[]` | Tier-2 targets (see below) |
+| `postgres_standby_on_calendar` | `*-*-* 04:00:00` | `systemd` `OnCalendar` (daily) |
+| `postgres_standby_persistent` | `true` | Run a missed schedule on next boot |
+| `postgres_standby_healthcheck_url` | `""` | healthchecks.io URL (`/fail` on error) |
+| `postgres_standby_run_now` | `false` | Opt-in: run immediately during the play |
+
+### Job shape
+
+```yaml
+postgres_standby_jobs:
+  - name: "postgres"
+    source_host: "root@<db-guest-fqdn>"
+    source_dir: "/var/lib/postgresql/backups"
+    archive_dir: "/bulk/databases/postgres"
+```
+
+### Tier-2 target shape
+
+```yaml
+postgres_standby_s3_targets:
+  - name: "RUSTFS"                 # env-var prefix in the credentials file
+    bucket: "db-dr"
+    prefix: "postgres"
+    endpoint_url: "https://..."    # omit for AWS S3
+    access_key: "..."              # wire env/SOPS-sourced, never a literal
+    secret_key: "..."
+```
+
+## Restore
+
+Owned by the source engine's role: the apps `postgres` role's `dr_restore` path
+(`pg_restore --clean --if-exists`) consumes the newest dump from this archive or
+a Tier-2 copy. The mandatory restore drill is defined in the DR standard.
+
+## Usage
+
+```bash
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags postgres_standby
+# Seed/refresh now (e.g. first run) without waiting for the timer:
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags postgres_standby -e postgres_standby_run_now=true
+```

--- a/roles/postgres_standby/defaults/main.yml
+++ b/roles/postgres_standby/defaults/main.yml
@@ -1,0 +1,58 @@
+---
+# postgres_standby role defaults — daily pull of pg_dump artifacts into the
+# replicated database archive namespace (see docs/DATABASE_DR_STANDARD.md).
+#
+# One CONSUMER of the generic <pool>/databases storage namespace (see the
+# zfs_pools role). For each configured job it mirrors the source guest's
+# pg_dump backup directory (custom-format `*.dump`, produced by the
+# ansible-proxmox-apps `postgres` role's pg-backup timer) into a local archive
+# directory. The mirror tracks the source's own retention window; pre-prune
+# history is preserved by the storage layer (sanoid snapshots + syncoid
+# replication to the DR node).
+#
+# Tier 2 (cloud/off-site): after the mirror, the newest dump per database is
+# uploaded to each configured S3-compatible target (on-prem RustFS and/or
+# AWS S3). Credentials land in a root-only EnvironmentFile — never in the
+# script, never logged.
+#
+# Inert until postgres_standby_jobs is set. Prerequisites (out of band): SSH
+# trust from this host's root to each source guest (cluster_ssh_trust covers
+# PVE node<->node trust, NOT host->guest), and the source role's backup timer.
+
+postgres_standby_enabled: true
+
+# rsync (pull) always; awscli only when S3 targets are configured.
+postgres_standby_packages:
+  - rsync
+postgres_standby_log_dir: /var/log/postgres-standby
+
+# Daily, after the source pg-backup timer (02:30 + up to 15 min splay) has
+# certainly finished — a warm archive, not a hot replica.
+postgres_standby_on_calendar: "*-*-* 04:00:00"
+# Run a missed schedule on next boot (sensible for a backup job).
+postgres_standby_persistent: true
+
+# Optional healthchecks.io URL; "<url>" pinged on success, "<url>/fail" on
+# failure. Wire from the play (env-sourced), like sqlite_standby.
+postgres_standby_healthcheck_url: ""
+
+# Opt-in: run the sync immediately during the play (seed/refresh on demand) in
+# addition to installing the timer. Mirrors sqlite_standby_run_now.
+postgres_standby_run_now: false
+
+# Pull jobs (empty -> inert). Each job:
+#   - name: "postgres"                            # log label
+#     source_host: "root@<db-guest-fqdn>"         # ssh target holding the dumps
+#     source_dir: "/var/lib/postgresql/backups"   # pg-backup output dir
+#     archive_dir: "/bulk/databases/postgres"     # replicated archive namespace
+postgres_standby_jobs: []
+
+# Tier-2 S3-compatible upload targets (empty -> Tier 1 only). Each target:
+#   - name: "RUSTFS"                    # env-var prefix in the credentials file
+#     bucket: "db-dr"
+#     prefix: "postgres"                # object key prefix inside the bucket
+#     endpoint_url: "https://..."       # omit/empty for AWS S3
+#     access_key: "..."                 # wire env/SOPS-sourced, never a literal
+#     secret_key: "..."
+postgres_standby_s3_targets: []
+postgres_standby_s3_env_file: /etc/postgres-standby-s3.env

--- a/roles/postgres_standby/handlers/main.yml
+++ b/roles/postgres_standby/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Reload systemd so it picks up the freshly written unit files. Skipped under
+# Docker (molecule), where systemd is not PID 1.
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/postgres_standby/tasks/main.yml
+++ b/roles/postgres_standby/tasks/main.yml
@@ -1,0 +1,137 @@
+---
+# postgres_standby tasks — install the pull engine and render the daily sync
+# script + systemd timer. Package install, directory creation, and the timer
+# enable are Docker-skipped (molecule); the script and unit files always render
+# so the contract is verifiable in-container.
+
+- name: Install postgres_standby packages (rsync)
+  ansible.builtin.apt:
+    name: "{{ postgres_standby_packages }}"
+    state: present
+    update_cache: true
+  when:
+    - postgres_standby_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - postgres_standby
+
+- name: Install awscli for Tier-2 S3 uploads
+  ansible.builtin.apt:
+    name: awscli
+    state: present
+  when:
+    - postgres_standby_enabled
+    - postgres_standby_s3_targets | length > 0
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - postgres_standby
+
+- name: Ensure log directory exists
+  ansible.builtin.file:
+    path: "{{ postgres_standby_log_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  when:
+    - postgres_standby_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - postgres_standby
+
+- name: Ensure archive directories exist
+  ansible.builtin.file:
+    path: "{{ item.archive_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  loop: "{{ postgres_standby_jobs }}"
+  loop_control:
+    label: "{{ item.archive_dir }}"
+  when:
+    - postgres_standby_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - postgres_standby
+
+# Root-only credentials for the Tier-2 uploads. Rendered even with no targets
+# (empty file) so the service unit's EnvironmentFile= reference always resolves.
+- name: Render the Tier-2 S3 credentials file
+  ansible.builtin.template:
+    src: postgres-standby-s3.env.j2
+    dest: "{{ postgres_standby_s3_env_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+  when: postgres_standby_enabled
+  tags:
+    - postgres_standby
+
+- name: Deploy the standby sync script
+  ansible.builtin.template:
+    src: postgres-standby-sync.sh.j2
+    dest: /usr/local/bin/postgres-standby-sync.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when: postgres_standby_enabled
+  tags:
+    - postgres_standby
+
+- name: Render the standby service unit
+  ansible.builtin.template:
+    src: postgres-standby.service.j2
+    dest: /etc/systemd/system/postgres-standby.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: postgres_standby_enabled
+  notify: Reload systemd daemon
+  tags:
+    - postgres_standby
+
+- name: Render the standby timer unit
+  ansible.builtin.template:
+    src: postgres-standby.timer.j2
+    dest: /etc/systemd/system/postgres-standby.timer
+    owner: root
+    group: root
+    mode: "0644"
+  when: postgres_standby_enabled
+  notify: Reload systemd daemon
+  tags:
+    - postgres_standby
+
+# Apply any pending daemon-reload now so the timer below enables against the
+# freshly written unit (handlers otherwise run only at end of play).
+- name: Reload systemd before enabling the timer
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start the standby timer
+  ansible.builtin.systemd:
+    name: postgres-standby.timer
+    enabled: true
+    state: started
+  when:
+    - postgres_standby_enabled
+    - postgres_standby_jobs | length > 0
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - postgres_standby
+
+# Opt-in immediate run (seed/refresh on demand) — mirrors sqlite_standby_run_now.
+# Via the service (not the script directly) so the S3 EnvironmentFile loads.
+- name: Run the standby sync now (opt-in seed/refresh)
+  ansible.builtin.systemd:
+    name: postgres-standby.service
+    state: started
+  when:
+    - postgres_standby_enabled
+    - postgres_standby_jobs | length > 0
+    - postgres_standby_run_now | bool
+    - ansible_virtualization_type != 'docker'
+  changed_when: true
+  tags:
+    - postgres_standby

--- a/roles/postgres_standby/templates/postgres-standby-s3.env.j2
+++ b/roles/postgres_standby/templates/postgres-standby-s3.env.j2
@@ -1,0 +1,5 @@
+{{ ansible_managed | comment }}
+{% for target in postgres_standby_s3_targets %}
+{{ target.name }}_ACCESS_KEY={{ target.access_key }}
+{{ target.name }}_SECRET_KEY={{ target.secret_key }}
+{% endfor %}

--- a/roles/postgres_standby/templates/postgres-standby-sync.sh.j2
+++ b/roles/postgres_standby/templates/postgres-standby-sync.sh.j2
@@ -1,0 +1,81 @@
+#!/bin/bash
+# postgres-standby-sync — daily Postgres dump archive pull + Tier-2 upload.
+# Managed by Ansible — do not edit manually.
+#
+# Per job: mirror the source guest's pg-backup directory (custom-format
+# `<db>-<utc-stamp>.dump`, already app-consistent) into the replicated archive
+# dataset. `--delete` keeps the mirror bounded by the SOURCE's own retention
+# window; pre-prune history is preserved by sanoid snapshots + syncoid
+# replication of the archive dataset (read a point-in-time view from
+# <dataset>/.zfs/snapshot/). Then upload the newest dump per database to each
+# Tier-2 S3 target. Credentials come from the systemd EnvironmentFile — never
+# echoed. A failed job/upload is logged and does NOT abort the others.
+set -uo pipefail
+
+LOG_DIR="{{ postgres_standby_log_dir }}"
+HC="{{ postgres_standby_healthcheck_url }}"
+mkdir -p "$LOG_DIR"
+log="$LOG_DIR/$(date +%Y-%m-%d).log"
+
+say()     { echo "=== $(date +%H:%M:%S) $* ===" >>"$log"; }
+ping_hc() { [ -n "$HC" ] && curl -fsS -m 10 --retry 3 -o /dev/null "$1" >/dev/null 2>&1 || true; }
+
+# Newest dump per database in a directory. Filenames are
+# `<db>-YYYYmmddTHHMMSSZ.dump` (pg-backup.sh); the UTC stamp contains no
+# hyphen, so stripping the final `-<stamp>.dump` segment yields the database
+# name (which may itself contain hyphens); first (newest-mtime) file wins.
+newest_per_db() {
+  ls -t "$1"/*.dump 2>/dev/null | awk '{
+    db = $0; sub(/-[^-]*\.dump$/, "", db)
+    if (!(db in seen)) { seen[db] = 1; print }
+  }'
+}
+
+sync_job() {
+  local name="$1" src_host="$2" src_dir="$3" archive="$4"
+  say "job $name: ${src_host}:${src_dir}/ -> ${archive}/"
+  mkdir -p "$archive"
+  if ! rsync -a --delete --include='*.dump' --exclude='*' \
+      -e 'ssh -o BatchMode=yes' \
+      "${src_host}:${src_dir}/" "${archive}/" >>"$log" 2>&1; then
+    say "  FAILED: rsync mirror"
+    return 1
+  fi
+  say "  job $name OK ($(ls "$archive"/*.dump 2>/dev/null | wc -l | tr -d ' ') dumps)"
+}
+
+{% if postgres_standby_s3_targets | length > 0 %}
+upload_job() {
+  local name="$1" archive="$2" dump rc=0
+  while IFS= read -r dump; do
+{% for target in postgres_standby_s3_targets %}
+    if AWS_ACCESS_KEY_ID="${{ target.name }}_ACCESS_KEY" \
+       AWS_SECRET_ACCESS_KEY="${{ target.name }}_SECRET_KEY" \
+       aws s3 cp {% if target.endpoint_url | default('') %}--endpoint-url "{{ target.endpoint_url }}" {% endif %}--only-show-errors \
+         "$dump" "s3://{{ target.bucket }}/{{ target.prefix | default(name) }}/$(basename "$dump")" >>"$log" 2>&1; then
+      say "  uploaded $(basename "$dump") -> {{ target.name }}"
+    else
+      say "  FAILED: upload $(basename "$dump") -> {{ target.name }}"
+      rc=1
+    fi
+{% endfor %}
+  done < <(newest_per_db "$archive")
+  return "$rc"
+}
+{% endif %}
+
+rc=0
+{% for job in postgres_standby_jobs %}
+sync_job "{{ job.name }}" "{{ job.source_host }}" "{{ job.source_dir }}" "{{ job.archive_dir }}" || rc=1
+{% if postgres_standby_s3_targets | length > 0 %}
+upload_job "{{ job.name }}" "{{ job.archive_dir }}" || rc=1
+{% endif %}
+{% endfor %}
+
+if [ "$rc" -ne 0 ]; then
+  say "one or more jobs FAILED"
+  ping_hc "${HC}/fail"
+  exit 1
+fi
+say "all jobs OK"
+ping_hc "${HC}"

--- a/roles/postgres_standby/templates/postgres-standby.service.j2
+++ b/roles/postgres_standby/templates/postgres-standby.service.j2
@@ -1,0 +1,9 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Postgres dump archive pull + Tier-2 upload
+Documentation=ansible role postgres_standby
+
+[Service]
+Type=oneshot
+EnvironmentFile=-{{ postgres_standby_s3_env_file }}
+ExecStart=/usr/local/bin/postgres-standby-sync.sh

--- a/roles/postgres_standby/templates/postgres-standby.timer.j2
+++ b/roles/postgres_standby/templates/postgres-standby.timer.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Daily Postgres dump archive pull + Tier-2 upload
+Documentation=ansible role postgres_standby
+
+[Timer]
+OnCalendar={{ postgres_standby_on_calendar }}
+Persistent={{ postgres_standby_persistent | ternary('true', 'false') }}
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Implements the Postgres consumer of the Database DR Standard (#398 follow-up).

## What

- **`roles/postgres_standby`** — on the always-on standby node, a daily systemd
  timer mirrors the source database guest's `pg_dump` backup directory
  (custom-format `*.dump`, produced by the apps `postgres` role's pg-backup
  timer) into the replicated `bulk/databases/<instance>` archive namespace.
  Sanoid snapshots + syncoid DR replication cover the archive with no
  per-instance edit (Tier 1). The newest dump per database is then uploaded to
  each configured S3-compatible target (Tier 2); credentials land only in a
  root-only `EnvironmentFile` rendered with `no_log`.
- **`playbooks/site.yml`** — wires the role after `sqlite_standby`, with an
  env-sourced healthcheck ping and env-gated Tier-2 targets (an unset key drops
  that target, leaving Tier 1 intact).
- **`playbooks/load_tofu.yml`** — injects the estate domain from the tofu
  inventory so host_vars build the source guest's FQDN from facts (never a
  literal IP or domain).
- **Standby host_vars** — the pull job, gated inert when tofu facts are absent
  so a scoped run cannot pull from a bogus host.
- **`docs/DR_RUNBOOK.md`** — database-restore pointer to the DR standard
  (restore from logical dumps, never clone the live DB volume).

## Verification

- `ansible-lint` (production profile): 0 failures on the role + touched files.
- Sync-script template rendered with and without Tier-2 targets; both pass
  `bash -n`.
- The host_vars job expression evaluated against full facts, a stale cache
  (missing container key), and no facts — correct in all three (inert in the last).

Restore path + drill land next in the apps repo (`dr_restore` in `roles/postgres`).

Refs dryvist/docs-starlight#138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF