### PR TITLE
fix(standby): accept-new host keys on pull SSH + valid Documentation URLs

### DIFF
--- a/roles/postgres_standby/templates/postgres-standby-sync.sh.j2
+++ b/roles/postgres_standby/templates/postgres-standby-sync.sh.j2
@@ -36,7 +36,7 @@ sync_job() {
   say "job $name: ${src_host}:${src_dir}/ -> ${archive}/"
   mkdir -p "$archive"
   if ! rsync -a --delete --include='*.dump' --exclude='*' \
-      -e 'ssh -o BatchMode=yes' \
+      -e 'ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new' \
       "${src_host}:${src_dir}/" "${archive}/" >>"$log" 2>&1; then
     say "  FAILED: rsync mirror"
     return 1

--- a/roles/postgres_standby/templates/postgres-standby.service.j2
+++ b/roles/postgres_standby/templates/postgres-standby.service.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 [Unit]
 Description=Postgres dump archive pull + Tier-2 upload
-Documentation=ansible role postgres_standby
+Documentation=https://github.com/dryvist/ansible-proxmox/tree/main/roles/postgres_standby
 
 [Service]
 Type=oneshot

--- a/roles/postgres_standby/templates/postgres-standby.timer.j2
+++ b/roles/postgres_standby/templates/postgres-standby.timer.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 [Unit]
 Description=Daily Postgres dump archive pull + Tier-2 upload
-Documentation=ansible role postgres_standby
+Documentation=https://github.com/dryvist/ansible-proxmox/tree/main/roles/postgres_standby
 
 [Timer]
 OnCalendar={{ postgres_standby_on_calendar }}

--- a/roles/sqlite_standby/templates/sqlite-standby-sync.sh.j2
+++ b/roles/sqlite_standby/templates/sqlite-standby-sync.sh.j2
@@ -31,13 +31,13 @@ sync_job() {
   rm -f "$snap"
 
   # 1. Consistent online backup on the source (handles a live WAL DB), pull it.
-  if ! ssh -o BatchMode=yes "$src_host" "${SQLITE} '${src_path}' \".backup '${rtmp}'\"" >>"$log" 2>&1; then
+  if ! ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$src_host" "${SQLITE} '${src_path}' \".backup '${rtmp}'\"" >>"$log" 2>&1; then
     say "  FAILED: online backup on source"
     return 1
   fi
   if ! rsync -a --remove-source-files "${src_host}:${rtmp}" "$snap" >>"$log" 2>&1; then
     say "  FAILED: rsync pull"
-    ssh -o BatchMode=yes "$src_host" "rm -f '${rtmp}'" >>"$log" 2>&1 || true
+    ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$src_host" "rm -f '${rtmp}'" >>"$log" 2>&1 || true
     return 1
   fi
 

--- a/roles/sqlite_standby/templates/sqlite-standby.service.j2
+++ b/roles/sqlite_standby/templates/sqlite-standby.service.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 [Unit]
 Description=Insert-only SQLite warm-standby sync
-Documentation=ansible role sqlite_standby
+Documentation=https://github.com/dryvist/ansible-proxmox/tree/main/roles/sqlite_standby
 
 [Service]
 Type=oneshot

--- a/roles/sqlite_standby/templates/sqlite-standby.timer.j2
+++ b/roles/sqlite_standby/templates/sqlite-standby.timer.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 [Unit]
 Description=Daily insert-only SQLite warm-standby sync
-Documentation=ansible role sqlite_standby
+Documentation=https://github.com/dryvist/ansible-proxmox/tree/main/roles/sqlite_standby
 
 [Timer]
 OnCalendar={{ sqlite_standby_on_calendar }}


### PR DESCRIPTION
Two defects surfaced by the first live postgres_standby pull:

- **Host-key trust**: the pull SSH runs with `BatchMode=yes` and no prior
  known_hosts entry for the source guest (cluster_ssh_trust covers only
  node↔node), so the first rsync failed with "Host key verification failed".
  `StrictHostKeyChecking=accept-new` trusts on first use and still pins/refuses
  on subsequent mismatch. Applied to `sqlite_standby` too (same latent defect).
- **systemd warning**: `Documentation=ansible role <name>` is rejected per word
  ("Invalid URL, ignoring"); replaced with the role's repo URL in both roles'
  service+timer units.

Verified: ansible-lint (production profile) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrBt9kMzgRZZXCxyrmkdiF