### PR TITLE
feat: consume RustFS inventory with OpenBao

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ configured by `ansible-proxmox-apps` and `ansible-splunk`.
 
 ## Dependencies
 
+### External Services
+
+- **Doppler**: SSH credentials and API tokens
+
 ### Internal Services
 
 - **OpenBao**: native secret paths, including RustFS inventory credentials
@@ -60,11 +64,14 @@ doppler run -- ansible-playbook playbooks/site.yml
 ### Execution Performance & Optimization
 
 Ansible runs against the Proxmox hosts can be slow due to connection latency and fact-gathering serialization. To increase speed:
-1. **Parallel Execution (`--forks` or `ANSIBLE_FORKS`)**: Increase the concurrency from the default 5 hosts at once. Using `25` forks (e.g. `doppler run -- ansible-playbook ... --forks 25`) runs significantly faster across large fleets.
+
+1. **Parallel Execution (`--forks` or `ANSIBLE_FORKS`)**: Increase the
+   concurrency from the default 5 hosts at once. Using `25` forks (e.g.
+   `doppler run -- ansible-playbook ... --forks 25`) runs significantly
+   faster across large fleets.
 2. **Targeted Runs (`--limit`)**: Restrict play scope to the target hosts and localhost (e.g., `--limit pve-nodes,localhost`).
 3. **Scoping via Tags (`--tags`)**: Use `--tags <tag-name>` to run only a subset of roles.
 4. **Disable Fact Gathering**: Set `gather_facts: false` on ad-hoc plays where facts are not required to bypass the setup step.
-
 
 ### Common Operations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@ configured by `ansible-proxmox-apps` and `ansible-splunk`.
 
 ## Dependencies
 
-### External Services
+### Internal Services
 
-- **Doppler**: SSH credentials and API tokens
+- **OpenBao**: native secret paths, including RustFS inventory credentials
 
 ### Infrastructure
 
@@ -27,7 +27,7 @@ configured by `ansible-proxmox-apps` and `ansible-splunk`.
 
 ### Upstream inventory (read-only consumer)
 
-`terraform-proxmox` provisions the hosts and publishes the inventory this repo
+The `tofu-proxmox` Terrakube workspace provisions the hosts and publishes the inventory this repo
 consumes (`playbooks/load_tofu.yml`). This repo **never reads `deployment.json`**;
 the published inventory is the source of truth, fetched fresh with no
 authoritative local copy. The upstream desired-state's ACID single-writer

--- a/README.md
+++ b/README.md
@@ -79,17 +79,16 @@ containing OpenTofu outputs (such as `host_services`, `node_storage`, and
 order (first that resolves wins):
 
 1. `TOFU_INVENTORY_PATH` — an explicit local file (pin / override, e.g. tests).
-2. **S3 published artifact** — the inventory JSON published to an S3 bucket.
-   Any runner with scoped AWS read creds (CI via OIDC, a cloud agent, or
-   `aws-vault`) fetches it with **no checkout and no terraform toolchain**. The
-   fetch is native (`amazon.aws.aws_caller_info` + `amazon.aws.s3_object`;
-   boto3 comes from the dev shell) — no `aws` CLI required. Override the
-   location with `TOFU_INVENTORY_S3_URI` (else it is derived from the account).
-3. `inventory/tofu_inventory.json` — a local cache for development.
+2. **RustFS published artifact** — the inventory JSON published by the
+   tofu-proxmox Terrakube workspace. The shared resolver fetches it over the
+   homelab network with credentials read directly from OpenBao
+   `secret/platform/object-storage`; only `BAO_ADDR` and `BAO_TOKEN` are needed.
+   Override the object with `TOFU_INVENTORY_S3_URI` when required.
+3. `inventory/tofu_inventory.json` — a local cache for development, only when
+   `TOFU_INVENTORY_ALLOW_STALE=1` is explicitly set.
 
-So in CI or on a cloud agent you only need AWS read creds. The artifact is
-expected to already exist in S3; provisioning and publishing it is outside
-this repo's scope.
+The artifact is expected to already exist in RustFS; provisioning and
+publishing it is outside this repo's scope.
 
 Create the SOPS secrets file:
 

--- a/playbooks/load_tofu.yml
+++ b/playbooks/load_tofu.yml
@@ -6,8 +6,8 @@
   tags: always
 
   tasks:
-    # Inventory resolution (TOFU_INVENTORY_PATH -> on-prem store -> legacy AWS
-    # bucket -> opt-in local cache) is delegated to the shared inventory_resolve
+    # Inventory resolution (TOFU_INVENTORY_PATH -> RustFS via OpenBao ->
+    # opt-in local cache) is delegated to the shared inventory_resolve
     # role (dryvist/homelab-contracts), which ends with `tofu_data` loaded. The
     # repo-specific NAS assert and add_host group mapping stay below.
     - name: Resolve the published OpenTofu inventory
@@ -29,10 +29,10 @@
           tofu_data.host_services.nas is missing or incomplete in
           tofu_inventory.json.
 
-          Expected terraform-proxmox ansible_inventory output to include the
+          Expected tofu-proxmox ansible_inventory output to include the
           NAS contract under host_services.nas.
 
-          Re-run terraform-proxmox apply or export ansible_inventory again.
+          Re-run the tofu-proxmox Terrakube workspace or export ansible_inventory again.
 
     - name: Inject OpenTofu NAS config onto proxmox hosts
       ansible.builtin.add_host:

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,10 +4,11 @@ collections:
     version: ">=2.1.0"
   - name: community.general
     version: ">=12.0.0"
-  # S3 inventory resolver (playbooks/load_tofu.yml) — aws_caller_info +
-  # s3_object fetch the published inventory natively (boto3 from the dev shell).
+  # RustFS inventory resolver fetches the published inventory natively.
   - name: amazon.aws
     version: ">=9.0.0"
+  - name: community.hashi_vault
+    version: ">=6.0.0"
   # proxmox_cluster (pve_cluster role) — wraps pvecm create/join via the PVE API.
   # Ceiling at <2.0.0: validate_certs default flips to true at 2.0.0; opt in
   # deliberately rather than inherit the change silently.
@@ -21,4 +22,4 @@ roles:
   - name: inventory_resolve
     src: https://github.com/dryvist/homelab-contracts.git
     scm: git
-    version: v1.10.0
+    version: 9aba451e9de0956f9c308d72a65e86924e243f23


### PR DESCRIPTION
## Summary\n- consume the shared homelab inventory contract\n- replace AWS-backed inventory credentials with native OpenBao access to RustFS\n- retain explicit local inventory overrides and offline cache behavior\n\n## Safety\n- draft only; no live configuration or infrastructure mutation performed\n\nRefs: dryvist/iac-platform#15\nRefs: dryvist/homelab-contracts#38