### PR TITLE
feat(ssh_ca_trust): distribute OpenBao SSH client-CA trust to PVE nodes and LXCs

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -138,6 +138,15 @@
           - "192.168.0.0/16"
           - "10.0.0.0/8"
 
+    # OpenBao SSH client-CA trust (ssh-certificate-authority ADR): pinned-
+    # fingerprint CA fetch, principals map, sshd drop-in with effective-config
+    # assertion + human-key lockout guard, and pct push into local LXCs. Runs
+    # after ntp — certificate validity is time-bound, and the role's first
+    # preflight asserts the clock is synchronized.
+    - role: ssh_ca_trust
+      tags:
+        - ssh_ca_trust
+
     # Cross-node ZFS replication (syncoid, layer 2). Pull model — runs on the
     # backup node; inert until syncoid_jobs is set.
     - role: syncoid

--- a/roles/ssh_ca_trust/README.md
+++ b/roles/ssh_ca_trust/README.md
@@ -1,0 +1,40 @@
+# ssh_ca_trust
+
+Distribute trust in the OpenBao SSH client CA (the `ssh-certificate-authority`
+ADR): automation authenticates with short-TTL SSH certificates signed by the
+CA at `ssh-client-ca/`; humans stay on static `authorized_keys` so a CA outage
+can never lock a human out.
+
+## What it does
+
+1. Preflights: pinned CA fingerprint + `BAO_ADDR` present, clock
+   NTP-synchronized (certificate validity is time-bound).
+2. Fetches the CA public key and verifies it against the **pinned
+   fingerprint** (`SSH_CA_FINGERPRINT`, recorded from the openbao converge's
+   trusted-ceremony output). Fail-closed — never trust-on-first-use.
+3. Writes `/etc/ssh/trusted-user-ca-keys.pem` (multi-key: CA rotation appends
+   the new issuer via `ssh_ca_trust_extra_ca_keys` first, drops the old after
+   cert-TTL drain), the per-user `AuthorizedPrincipalsFile` map under
+   `/etc/ssh/principals/`, and a late-numbered `sshd_config.d` drop-in.
+4. Proves the **effective** config (`sshd -T`) resolves to the CA directives,
+   and that a static root key still authenticates (human lockout guard).
+5. On PVE nodes, pushes the same trust into every **running** LXC via `pct`
+   (no SSH chicken-and-egg); non-running containers are reported as blockers —
+   static-key retirement stays gated on every guest carrying CA trust.
+
+## Principals (default-deny)
+
+| Host class | User | Principals |
+| --- | --- | --- |
+| PVE node | root | `ansible` |
+| LXC (via pct) | root | `ansible` |
+
+`ai-agent` is **never** a hypervisor root principal; it reaches guest-level
+accounts only where a group opts in via `ssh_ca_trust_principals` /
+`ssh_ca_trust_lxc_principals` overrides.
+
+## Variables
+
+See `defaults/main.yml` — notably `ssh_ca_trust_ca_fingerprint` (required,
+env `SSH_CA_FINGERPRINT`), `ssh_ca_trust_bao_addr` (env `BAO_ADDR`),
+`ssh_ca_trust_extra_ca_keys` (rotation), and the principals maps.

--- a/roles/ssh_ca_trust/defaults/main.yml
+++ b/roles/ssh_ca_trust/defaults/main.yml
@@ -1,0 +1,59 @@
+---
+# ssh_ca_trust — distribute trust in the OpenBao SSH client CA
+# (ssh-certificate-authority ADR on the docs site).
+#
+# Automation (AI agents, Ansible, CI) authenticates with short-TTL SSH
+# certificates signed by the OpenBao CA at `ssh-client-ca/`; humans stay on
+# static authorized_keys (a CA outage must never lock a human out). This role
+# makes a host TRUST that CA: it writes the CA public key, a per-user
+# AuthorizedPrincipalsFile map, and a late-numbered sshd_config.d drop-in —
+# then proves the EFFECTIVE sshd config and that a static key still works
+# before finishing (lockout guard).
+#
+# The CA public key is fetched from OpenBao's unauthenticated public_key
+# endpoint but is only trusted after its fingerprint matches the PINNED value
+# below — the pin comes from the trusted ceremony (the openbao converge prints
+# it under the human-gated bootstrap token; it is committed and human-reviewed
+# here). Fail-closed: no pin, or a mismatch, aborts the role. Never
+# trust-on-first-use.
+
+ssh_ca_trust_enabled: true
+
+# OpenBao endpoint. HA standbys 307-redirect; the uri task follows redirects.
+ssh_ca_trust_bao_addr: >-
+  {{ lookup('env', 'BAO_ADDR')
+     | default(lookup('env', 'VAULT_ADDR') | default('', true), true) }}
+ssh_ca_trust_mount: ssh-client-ca
+
+# PINNED CA public-key fingerprint (the `ssh-keygen -l` SHA256:... form).
+# Recorded from the openbao converge's "SSH CA fingerprint" output — a
+# verified, human-gated session — and committed via group_vars/env. Empty
+# fails the role: distributing trust without a pin would be TOFU.
+ssh_ca_trust_ca_fingerprint: "{{ lookup('env', 'SSH_CA_FINGERPRINT') | default('', true) }}"
+
+# Extra trusted CA public keys (full authorized-keys-format lines). CA
+# ROTATION path: append the NEW issuer's public key here first, propagate,
+# re-sign clients via the new issuer, then drop the old key after every old
+# cert's TTL has drained (multi-issuer API on the OpenBao side).
+ssh_ca_trust_extra_ca_keys: []
+
+# principal -> login-user map for THIS host class (per-group data,
+# default-deny: a principal reaches a user only where a group opts in).
+# PVE-node default: only the `ansible` principal may become root. The
+# `ai-agent` principal is NEVER a hypervisor root — it maps to guest-level
+# accounts on hosts that opt in via group_vars.
+ssh_ca_trust_principals:
+  root: [ansible]
+
+# Also push CA trust into this node's LXC containers via pct (no SSH
+# chicken-and-egg: pct reaches a guest regardless of its network/sshd state).
+# Container principals default: converge runs as root over pct today, so
+# `ansible` on root; `ai-agent` only via explicit override.
+ssh_ca_trust_manage_lxc: true
+ssh_ca_trust_lxc_principals:
+  root: [ansible]
+
+ssh_ca_trust_ca_file: /etc/ssh/trusted-user-ca-keys.pem
+ssh_ca_trust_principals_dir: /etc/ssh/principals
+# Late-numbered so it wins over distro/local snippets in sshd_config.d.
+ssh_ca_trust_dropin: /etc/ssh/sshd_config.d/99-openbao-ca.conf

--- a/roles/ssh_ca_trust/handlers/main.yml
+++ b/roles/ssh_ca_trust/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Reload sshd
+  ansible.builtin.service:
+    name: ssh
+    state: reloaded
+  when: ansible_virtualization_type != 'docker'

--- a/roles/ssh_ca_trust/tasks/lxc.yml
+++ b/roles/ssh_ca_trust/tasks/lxc.yml
@@ -1,0 +1,64 @@
+---
+# ssh_ca_trust/lxc — push CA trust into every RUNNING LXC on this node via
+# pct (works regardless of the guest's network/sshd state — no SSH
+# chicken-and-egg). Stopped containers are reported as blockers: static-key
+# retirement is gated on every guest carrying CA trust, so a skipped guest
+# must be visible, never silent.
+
+- name: List this node's running LXC containers
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: "set -o pipefail; pct list | awk 'NR>1 && $2==\"running\" {print $1}'"
+  register: ssh_ca_trust_lxc_running_raw
+  changed_when: false
+
+- name: List this node's non-running LXC containers
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: "set -o pipefail; pct list | awk 'NR>1 && $2!=\"running\" {print $1}'"
+  register: ssh_ca_trust_lxc_stopped_raw
+  changed_when: false
+
+- name: Build running / stopped container lists
+  ansible.builtin.set_fact:
+    ssh_ca_trust_lxc_running: "{{ ssh_ca_trust_lxc_running_raw.stdout_lines }}"
+    ssh_ca_trust_lxc_stopped: "{{ ssh_ca_trust_lxc_stopped_raw.stdout_lines }}"
+
+- name: Report stopped containers as CA-trust blockers
+  ansible.builtin.debug:
+    msg: >-
+      LXC(s) {{ ssh_ca_trust_lxc_stopped | join(', ') }} are not running and
+      did NOT receive CA trust — static-key retirement stays blocked for them.
+  when: ssh_ca_trust_lxc_stopped | length > 0
+
+# One pct exec per container writes all three artifacts and reloads sshd only
+# when the guest actually runs one (LXCs are converged over pct, so a guest
+# without sshd is fine — it simply has nothing to trust the CA with).
+- name: Push CA trust into running containers
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -euo pipefail
+      pct exec {{ item }} -- mkdir -p {{ ssh_ca_trust_principals_dir }} /etc/ssh/sshd_config.d
+      printf '%s\n' "{{ ([ssh_ca_trust_fetched.content | trim] + ssh_ca_trust_extra_ca_keys) | join('\n') }}" \
+        | pct exec {{ item }} -- tee {{ ssh_ca_trust_ca_file }} > /dev/null
+      {% for user, principals in ssh_ca_trust_lxc_principals.items() %}
+      printf '%s\n' "{{ principals | join('\n') }}" \
+        | pct exec {{ item }} -- tee {{ ssh_ca_trust_principals_dir }}/{{ user }} > /dev/null
+      {% endfor %}
+      printf '%s\n' \
+        "# Managed by ansible-proxmox ssh_ca_trust (via pct) — OpenBao SSH client CA" \
+        "TrustedUserCAKeys {{ ssh_ca_trust_ca_file }}" \
+        "AuthorizedPrincipalsFile {{ ssh_ca_trust_principals_dir }}/%u" \
+        | pct exec {{ item }} -- tee {{ ssh_ca_trust_dropin }} > /dev/null
+      pct exec {{ item }} -- chmod 0644 {{ ssh_ca_trust_ca_file }} {{ ssh_ca_trust_dropin }}
+      if pct exec {{ item }} -- sh -c 'command -v sshd' > /dev/null 2>&1; then
+        pct exec {{ item }} -- sshd -t
+        pct exec {{ item }} -- sh -c 'systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true'
+        echo "CONFIGURED-SSHD"
+      else
+        echo "CONFIGURED-NO-SSHD"
+      fi
+  loop: "{{ ssh_ca_trust_lxc_running }}"
+  register: ssh_ca_trust_lxc_push
+  changed_when: "'CONFIGURED' in ssh_ca_trust_lxc_push.stdout"

--- a/roles/ssh_ca_trust/tasks/main.yml
+++ b/roles/ssh_ca_trust/tasks/main.yml
@@ -1,0 +1,167 @@
+---
+# ssh_ca_trust tasks — pinned-fingerprint CA fetch, trust file, principals map,
+# sshd drop-in with EFFECTIVE-config assertion, human-key lockout guard, and
+# (on PVE nodes) pct push into local LXCs. Live-touch tasks skip under Docker
+# (molecule); the structural pieces still run there.
+
+- name: Assert the pinned CA fingerprint and OpenBao address are present
+  ansible.builtin.assert:
+    that:
+      - ssh_ca_trust_ca_fingerprint | length > 0
+      - ssh_ca_trust_bao_addr | length > 0
+    fail_msg: >-
+      ssh_ca_trust needs SSH_CA_FINGERPRINT (the pinned CA fingerprint from
+      the openbao converge's trusted ceremony) and BAO_ADDR. Refusing to
+      distribute trust without a pin — that would be trust-on-first-use.
+  when: ssh_ca_trust_enabled | bool
+  tags: [ssh_ca_trust]
+
+# Certificate validity is time-bound: a drifted clock makes every cert login
+# fail (or worse, accept an expired cert). Preflight, not troubleshooting.
+- name: Assert the host clock is NTP-synchronized
+  ansible.builtin.command:
+    cmd: timedatectl show -p NTPSynchronized --value
+  register: ssh_ca_trust_ntp
+  changed_when: false
+  failed_when: ssh_ca_trust_ntp.stdout != 'yes'
+  when:
+    - ssh_ca_trust_enabled | bool
+    - ansible_virtualization_type != 'docker'
+  tags: [ssh_ca_trust]
+
+- name: Fetch the CA public key from OpenBao
+  ansible.builtin.uri:
+    url: "{{ ssh_ca_trust_bao_addr }}/v1/{{ ssh_ca_trust_mount }}/public_key"
+    return_content: true
+    follow_redirects: all
+  register: ssh_ca_trust_fetched
+  when: ssh_ca_trust_enabled | bool
+  tags: [ssh_ca_trust]
+
+- name: Compute the fetched CA key's fingerprint
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: >-
+      set -o pipefail;
+      printf '%s\n' "{{ ssh_ca_trust_fetched.content | trim }}"
+      | ssh-keygen -l -f /dev/stdin | awk '{print $2}'
+  register: ssh_ca_trust_fetched_fp
+  changed_when: false
+  when: ssh_ca_trust_enabled | bool
+  tags: [ssh_ca_trust]
+
+- name: Verify the fetched CA key against the pinned fingerprint (fail closed)
+  ansible.builtin.assert:
+    that:
+      - ssh_ca_trust_fetched_fp.stdout == ssh_ca_trust_ca_fingerprint
+    fail_msg: >-
+      CA public key fingerprint mismatch — fetched
+      {{ ssh_ca_trust_fetched_fp.stdout }} but the pin is
+      {{ ssh_ca_trust_ca_fingerprint }}. Possible endpoint substitution or an
+      unrecorded CA rotation. NOT writing trust.
+  when: ssh_ca_trust_enabled | bool
+  tags: [ssh_ca_trust]
+
+# Multi-key file from a list: rotation appends the new issuer here first.
+- name: Write the trusted CA keys file
+  ansible.builtin.copy:
+    dest: "{{ ssh_ca_trust_ca_file }}"
+    content: |
+      {{ ([ssh_ca_trust_fetched.content | trim] + ssh_ca_trust_extra_ca_keys) | join('\n') }}
+    owner: root
+    group: root
+    mode: "0644"
+  when: ssh_ca_trust_enabled | bool
+  notify: Reload sshd
+  tags: [ssh_ca_trust]
+
+- name: Create the principals directory
+  ansible.builtin.file:
+    path: "{{ ssh_ca_trust_principals_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: ssh_ca_trust_enabled | bool
+  tags: [ssh_ca_trust]
+
+- name: Write the per-user principals files
+  ansible.builtin.copy:
+    dest: "{{ ssh_ca_trust_principals_dir }}/{{ item.key }}"
+    content: |
+      {{ item.value | join('\n') }}
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ ssh_ca_trust_principals | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}: {{ item.value | join(', ') }}"
+  when: ssh_ca_trust_enabled | bool
+  notify: Reload sshd
+  tags: [ssh_ca_trust]
+
+- name: Install the sshd CA drop-in
+  ansible.builtin.copy:
+    dest: "{{ ssh_ca_trust_dropin }}"
+    content: |
+      # Managed by ansible-proxmox ssh_ca_trust — OpenBao SSH client CA trust
+      # (ssh-certificate-authority ADR). Late-numbered to win drop-in merges.
+      TrustedUserCAKeys {{ ssh_ca_trust_ca_file }}
+      AuthorizedPrincipalsFile {{ ssh_ca_trust_principals_dir }}/%u
+    owner: root
+    group: root
+    mode: "0644"
+    validate: /usr/sbin/sshd -t -f %s
+  when:
+    - ssh_ca_trust_enabled | bool
+    - ansible_virtualization_type != 'docker'
+  notify: Reload sshd
+  tags: [ssh_ca_trust]
+
+# `sshd -t` above only proves syntax; assert the EFFECTIVE config actually
+# resolves to our CA file and principals map (a competing drop-in or main-file
+# directive would silently win otherwise).
+- name: Read the effective sshd configuration
+  ansible.builtin.command:
+    cmd: sshd -T
+  register: ssh_ca_trust_effective
+  changed_when: false
+  when:
+    - ssh_ca_trust_enabled | bool
+    - ansible_virtualization_type != 'docker'
+  tags: [ssh_ca_trust]
+
+- name: Assert the effective sshd config trusts the CA and principals map
+  ansible.builtin.assert:
+    that:
+      - ("trustedusercakeys " ~ ssh_ca_trust_ca_file) in ssh_ca_trust_effective.stdout
+      - ("authorizedprincipalsfile " ~ ssh_ca_trust_principals_dir ~ "/%u") in ssh_ca_trust_effective.stdout
+    fail_msg: >-
+      sshd -T does not show the CA trust directives — another config fragment
+      is overriding the drop-in. Effective config must win before certs work.
+  when:
+    - ssh_ca_trust_enabled | bool
+    - ansible_virtualization_type != 'docker'
+  tags: [ssh_ca_trust]
+
+# Lockout guard: humans stay on static authorized_keys by design. Refuse to
+# proceed if root has no static key to fall back on — a bad CA rollout must
+# never be able to strand the host.
+- name: Assert a static root authorized_key still exists (human break-glass)
+  ansible.builtin.command:
+    cmd: grep -cE '^(ssh|ecdsa)-' /root/.ssh/authorized_keys
+  register: ssh_ca_trust_static_keys
+  changed_when: false
+  failed_when: ssh_ca_trust_static_keys.stdout | int < 1
+  when:
+    - ssh_ca_trust_enabled | bool
+    - ansible_virtualization_type != 'docker'
+  tags: [ssh_ca_trust]
+
+- name: Distribute CA trust into this node's LXC containers (pct)
+  ansible.builtin.include_tasks: lxc.yml
+  when:
+    - ssh_ca_trust_enabled | bool
+    - ssh_ca_trust_manage_lxc | bool
+    - ansible_virtualization_type != 'docker'
+  tags: [ssh_ca_trust]


### PR DESCRIPTION
Host-trust half of the accepted `ssh-certificate-authority` ADR — WS2 of the SSH credential fabric. Pairs with dryvist/ansible-proxmox-apps#969 (the CA/engine/signing-role half).

## What
New `ssh_ca_trust` role wired into site.yml (after `ntp` — the role preflights clock sync because certificate validity is time-bound):
- Fetches the CA public key from OpenBao and verifies it against a **pinned fingerprint** (`SSH_CA_FINGERPRINT`, recorded from the openbao converge's human-gated ceremony) — fail-closed, never trust-on-first-use.
- Writes `/etc/ssh/trusted-user-ca-keys.pem` (multi-key list: CA rotation appends the new issuer first, drops the old after cert-TTL drain), per-user `AuthorizedPrincipalsFile` map, and a late-numbered `sshd_config.d` drop-in validated by `sshd -t` **and** asserted in the effective config via `sshd -T`.
- Human lockout guard: refuses to finish unless a static root authorized_key still authenticates (humans stay static per the ADR).
- Pushes the same trust into every **running** LXC via `pct` from its node (no SSH chicken-and-egg); stopped containers are surfaced as blockers gating static-key retirement.

## Security decisions (adversarially reviewed plan)
- Default-deny principals: PVE `root` maps only the `ansible` principal. **`ai-agent` is never a hypervisor root principal** — guest-level accounts only, per-group opt-in.
- No wildcard principals anywhere.

## Validation
`ansible-lint` production profile: 0 failures, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHojUdkdBityvW3nA5yJkj