### PR TITLE
feat(zfs_replication): mirror vzdump guest backups to S3

### DIFF
--- a/roles/zfs_replication/defaults/main.yml
+++ b/roles/zfs_replication/defaults/main.yml
@@ -80,8 +80,9 @@ zfs_replication_randomized_delay_sec: 120
 zfs_replication_timer_persistent: false
 
 # --- Optional vzdump backup leg (separate, also off by default) -----------
-# Schedules `vzdump` of named guests to a backup storage. Independent of the
-# syncoid replication above. Disabled until explicitly enabled AND given guests.
+# Schedules `vzdump` of named guests to a backup storage, then mirrors each
+# fresh archive to an S3 bucket. Independent of the syncoid replication above.
+# Disabled until explicitly enabled AND given guests.
 zfs_replication_vzdump_enabled: false
 # Proxmox storage id that vzdump writes to (must already exist on the node and
 # be backed by a dataset such as bulk/backups). No real id committed.
@@ -89,6 +90,35 @@ zfs_replication_vzdump_storage: "<backup-storage-id>"
 zfs_replication_vzdump_mode: snapshot
 zfs_replication_vzdump_compress: zstd
 # vmid list of guests to back up (CT or VM ids). Empty → the vzdump leg no-ops.
+# The apps data-platform target set (enable per host_vars, never hard-wired on):
+#   zfs_replication_vzdump_guests: [602000, 605000, 605010, 605020]
+#   # 602000 postgres-apps · 605000 nautobot · 605010 vikunja · 605020 zammad
 zfs_replication_vzdump_guests: []
 zfs_replication_vzdump_on_calendar: "*-*-* 01:30:00"
 zfs_replication_vzdump_extra_options: ""
+
+# Prune-by-count: keep this many backups per guest. Applied identically to the
+# local storage (vzdump --prune-backups keep-last) and the S3 copy below, so the
+# two tiers stay in step. Object lock on the off-site B2 mirror makes ITS deletes
+# non-destructive (a delete just adds a marker; the locked version is retained).
+zfs_replication_vzdump_keep_last: 4
+
+# --- S3 mirror of the vzdump archives (second tier) -----------------------
+# After each guest's vzdump completes to the local storage, the archive + its
+# sidecars (.log/.notes) are copied to s3://<bucket>/<prefix>/<vmid>/ with the
+# vzdump filenames preserved VERBATIM — the same bucket + keys mirror 1:1 to
+# off-site immutable object storage out of band. Inert until an endpoint is set;
+# a run whose endpoint is unreachable SKIPS the S3 leg cleanly (the local vzdump
+# still happened), mirroring the syncoid reachability gate.
+zfs_replication_vzdump_s3_bucket: dryvist-homelab-backups
+zfs_replication_vzdump_s3_prefix: guests
+# Injection-agnostic: read GUEST_BACKUP_S3_* from the environment at render time
+# (parallels the postgres role's POSTGRES_BACKUP_S3_* grain). Empty endpoint =>
+# the S3 leg stays off. RustFS/MinIO ignore the region but the aws CLI requires a
+# non-empty value.
+zfs_replication_vzdump_s3_endpoint: "{{ lookup('env', 'GUEST_BACKUP_S3_ENDPOINT') | default('', true) }}"
+zfs_replication_vzdump_s3_region: "{{ lookup('env', 'GUEST_BACKUP_S3_REGION') | default('us-east-1', true) }}"
+zfs_replication_vzdump_s3_access_key_id: "{{ lookup('env', 'GUEST_BACKUP_S3_ACCESS_KEY_ID') | default('', true) }}"
+zfs_replication_vzdump_s3_secret_access_key: "{{ lookup('env', 'GUEST_BACKUP_S3_SECRET_ACCESS_KEY') | default('', true) }}"
+# Connection probe timeout (seconds) before the S3 leg for a run.
+zfs_replication_vzdump_s3_probe_timeout: 10

--- a/roles/zfs_replication/tasks/vzdump.yml
+++ b/roles/zfs_replication/tasks/vzdump.yml
@@ -4,6 +4,33 @@
 # zfs_replication_vzdump_enabled is true AND guests are listed; the timer below
 # only enables when there is at least one guest to back up.
 
+# The S3 mirror leg needs the aws CLI and a root-only credentials file. Both are
+# gated on an endpoint being set, so the plain-vzdump case installs nothing extra
+# and stays inert. The env file is absent when S3 is off; the wrapper sources it
+# only if present, so the local vzdump is unaffected either way.
+- name: Install awscli for the vzdump S3 mirror leg
+  ansible.builtin.apt:
+    name: awscli
+    state: present
+    update_cache: true
+  when:
+    - zfs_replication_vzdump_s3_endpoint | length > 0
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - zfs_replication_vzdump
+
+- name: Deploy the vzdump S3 credentials env file
+  ansible.builtin.template:
+    src: zfs-replication-vzdump-s3.env.j2
+    dest: /etc/default/zfs-replication-vzdump-s3
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+  when: zfs_replication_vzdump_s3_endpoint | length > 0
+  tags:
+    - zfs_replication_vzdump
+
 - name: Render the vzdump backup wrapper
   ansible.builtin.template:
     src: zfs-replication-vzdump.sh.j2

--- a/roles/zfs_replication/templates/zfs-replication-vzdump-s3.env.j2
+++ b/roles/zfs_replication/templates/zfs-replication-vzdump-s3.env.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+# Endpoint + credentials for the vzdump S3 mirror leg. Sourced by
+# zfs-replication-vzdump.sh. Root-only (0600) — never world-readable.
+# Config the wrapper reads:
+GUEST_BACKUP_S3_ENDPOINT='{{ zfs_replication_vzdump_s3_endpoint }}'
+GUEST_BACKUP_S3_BUCKET='{{ zfs_replication_vzdump_s3_bucket }}'
+GUEST_BACKUP_S3_PREFIX='{{ zfs_replication_vzdump_s3_prefix }}'
+# Credentials the aws CLI picks up from the environment:
+AWS_ACCESS_KEY_ID='{{ zfs_replication_vzdump_s3_access_key_id }}'
+AWS_SECRET_ACCESS_KEY='{{ zfs_replication_vzdump_s3_secret_access_key }}'
+AWS_DEFAULT_REGION='{{ zfs_replication_vzdump_s3_region }}'

--- a/roles/zfs_replication/templates/zfs-replication-vzdump.sh.j2
+++ b/roles/zfs_replication/templates/zfs-replication-vzdump.sh.j2
@@ -1,14 +1,79 @@
 #!/bin/bash
 {{ ansible_managed | comment }}
-# Optional vzdump backup of named guests to a backup storage. Per-guest logging;
-# a single failed guest does NOT abort the rest.
+# Optional vzdump backup of named guests to a backup storage, then an S3 mirror
+# of each fresh archive. Per-guest logging; a single failed guest does NOT abort
+# the rest. The S3 leg is reachability-gated: if the endpoint is unset or
+# unreachable, the local vzdump still runs and only the S3 copy is skipped.
 set -uo pipefail
 
 LOG_DIR="{{ zfs_replication_log_dir }}"
 STORAGE="{{ zfs_replication_vzdump_storage }}"
+KEEP_LAST="{{ zfs_replication_vzdump_keep_last }}"
 mkdir -p "$LOG_DIR"
 log="$LOG_DIR/vzdump-$(date +%Y-%m-%d).log"
 say() { echo "$(date +%H:%M:%S) $*" >>"$log"; }
+
+# S3 config + credentials live in a root-only env file (0600). Sourcing here
+# means a manual run works exactly like the systemd run. Absent file => S3 off.
+S3_ENV="/etc/default/zfs-replication-vzdump-s3"
+# shellcheck disable=SC1090
+[ -r "$S3_ENV" ] && . "$S3_ENV"
+S3_ENDPOINT="${GUEST_BACKUP_S3_ENDPOINT:-}"
+S3_BUCKET="${GUEST_BACKUP_S3_BUCKET:-}"
+S3_PREFIX="${GUEST_BACKUP_S3_PREFIX:-guests}"
+# aws reads AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_DEFAULT_REGION from
+# the sourced env; only the endpoint is a per-command flag.
+AWS_ARGS="--endpoint-url ${S3_ENDPOINT}"
+
+# Probe the endpoint ONCE per run. curl exits 0 on any HTTP response (RustFS
+# answers 403 unauthenticated — still "up"); non-zero on connect/timeout.
+s3_ready() {
+  [ -n "$S3_ENDPOINT" ] || return 1
+  curl -sS -o /dev/null -m "{{ zfs_replication_vzdump_s3_probe_timeout }}" "$S3_ENDPOINT" 2>/dev/null
+}
+if s3_ready; then S3_UP=1; else S3_UP=0; [ -n "$S3_ENDPOINT" ] && say "S3 endpoint unreachable — skipping S3 mirror this run"; fi
+
+# Copy this run's fresh archive + sidecars to s3://bucket/prefix/<vmid>/, keys
+# preserved verbatim. The vmid's newest archive path is read back from the log.
+s3_sync() {
+  local vmid="$1"
+  local archive adir ts dest f
+  archive=$(grep -oE "/[^']*vzdump-[a-z]+-${vmid}-[0-9_-]+\.(tar|vma)\.(zst|gz|lzo)" "$log" | tail -1)
+  [ -n "$archive" ] || { say "  no archive path in log — skipping S3 for $vmid"; return 0; }
+  adir=$(dirname "$archive")
+  ts=$(echo "$archive" | grep -oE '[0-9]{4}_[0-9]{2}_[0-9]{2}-[0-9]{2}_[0-9]{2}_[0-9]{2}')
+  dest="s3://${S3_BUCKET}/${S3_PREFIX}/${vmid}/"
+  for f in "$adir"/*"$ts"*; do
+    [ -e "$f" ] || continue
+    if aws $AWS_ARGS s3 cp "$f" "${dest}$(basename "$f")" >>"$log" 2>&1; then
+      say "  synced $(basename "$f") -> $dest"
+    else
+      say "  S3 cp FAILED for $(basename "$f")"
+    fi
+  done
+}
+
+# Prune S3 to KEEP_LAST backups per guest — same count as the local storage, so
+# the two tiers stay in step. Delete by timestamp token, which uniquely names one
+# backup's whole file set (archive + sidecars).
+s3_prune() {
+  local vmid="$1"
+  local dest count excess old old_ts
+  dest="s3://${S3_BUCKET}/${S3_PREFIX}/${vmid}/"
+  mapfile -t archives < <(aws $AWS_ARGS s3 ls "$dest" 2>>"$log" | awk '{print $NF}' \
+    | grep -E "vzdump-[a-z]+-${vmid}-.*\.(tar|vma)\.(zst|gz|lzo)$" | sort)
+  # Count via printf/grep, not bash array-length syntax: the latter's brace-hash
+  # byte pair would open a Jinja comment while this template renders.
+  count=$(printf '%s\n' "${archives[@]}" | grep -c .)
+  excess=$(( count - KEEP_LAST ))
+  [ "$excess" -le 0 ] && return 0
+  for old in "${archives[@]:0:$excess}"; do
+    old_ts=$(echo "$old" | grep -oE '[0-9]{4}_[0-9]{2}_[0-9]{2}-[0-9]{2}_[0-9]{2}_[0-9]{2}')
+    if aws $AWS_ARGS s3 rm "$dest" --recursive --exclude '*' --include "*${old_ts}*" >>"$log" 2>&1; then
+      say "  pruned S3 backup $old_ts (archive + sidecars)"
+    fi
+  done
+}
 
 backup() {
   local vmid="$1"
@@ -18,8 +83,16 @@ backup() {
     --storage "$STORAGE" \
     --mode {{ zfs_replication_vzdump_mode }} \
     --compress {{ zfs_replication_vzdump_compress }} \
+    --prune-backups keep-last="$KEEP_LAST" \
     {{ zfs_replication_vzdump_extra_options }} >>"$log" 2>&1 || rc=$?
-  [ "$rc" -ne 0 ] && say "  FAILED (rc=$rc)"
+  if [ "$rc" -ne 0 ]; then
+    say "  FAILED (rc=$rc)"
+    return 0
+  fi
+  if [ "$S3_UP" -eq 1 ]; then
+    s3_sync "$vmid"
+    s3_prune "$vmid"
+  fi
   return 0
 }
 


### PR DESCRIPTION
## What

Extends the `zfs_replication` role's existing (inert) vzdump leg with a second backup tier: after each guest's `vzdump` writes to the local PVE storage, the fresh archive is mirrored to an S3 bucket. This is the guest-level half of the apps data-platform backup design (companion to the pgBackRest data-tier and the private `dryvist-homelab-backups` bucket).

## Behaviour

- **Keys preserved verbatim.** Each archive and its sidecars (`.log`/`.notes`) copy to `s3://<bucket>/guests/<vmid>/<filename>` unchanged, so the same bucket and keys mirror 1:1 to off-site immutable object storage (object lock) out of band.
- **Reachability-gated.** One pre-flight probe per run. An unset or unreachable endpoint skips only the S3 copy — the local vzdump still runs — matching the syncoid leg's existing gate philosophy.
- **Prune-by-count, both tiers.** A single `keep-last` drives both the local `vzdump --prune-backups keep-last` and the S3 prune, so the two tiers stay in step. (Object lock on the off-site mirror makes its deletes non-destructive — the locked prior version is retained.)
- **Credentials, not prompts.** `GUEST_BACKUP_S3_*` are read from the environment at render time (parallel to the postgres role's `POSTGRES_BACKUP_S3_*` grain) and land in a root-only `0600` env file the wrapper sources — never in the world-readable script (`no_log` on the template task). `awscli` and that file install only when an endpoint is set.

## Inert by default

vzdump leg off, empty guest list, no endpoint → nothing installs, nothing runs. **Not wired into `site.yml`** — the live enable is a separate step. The four apps VMIDs (postgres-apps, nautobot, vikunja, zammad) are documented as the intended guest set, default-empty per the role grain.

## Scope + validation

Touches only `roles/zfs_replication` (defaults, `tasks/vzdump.yml`, the wrapper template, and a new creds env-file template). `ansible-lint` passes (production profile, 0 failures). The rendered wrapper passes `bash -n` in both the S3-enabled and empty-guest cases — this caught a `${#array}`-vs-Jinja-comment collision that would have failed `ansible.builtin.template` at runtime. The default molecule scenario (vzdump off) is unaffected.