### PR TITLE
feat(pve_ha): pvesr replication + HA enrollment for singleton app guests

### DIFF
--- a/roles/pve_ha/README.md
+++ b/roles/pve_ha/README.md
@@ -71,7 +71,10 @@ the only node-loss story**:
   exists to relocate onto.
 - On a **node loss**, ha-manager relocates the guest to the partner and starts
   it from the replica. `max_relocate=1` is enough: one hop to the partner.
-- `pve3` sleeps for DR and holds no replica, so it is never a relocation target.
+- A **strict `node-affinity` rule** (`pve_ha_replication_affinity_rule`) pins
+  these guests to `pve_ha_replication_pair`, so ha-manager can never relocate one
+  onto a node without a replica (e.g. `pve3` when it is awake) and then
+  start-fail/flap. `strict` = run only on the listed nodes.
 - The replica is a **relocation enabler, not the durability layer**: the app
   guests' real data-loss window is covered separately (`postgres-apps` by
   streaming replication + WAL archiving; `nautobot`/`vikunja` are near-stateless
@@ -118,3 +121,4 @@ No real service is touched.
 | `pve_ha_replication_schedule` | `*/15` | `pvesr` schedule (systemd-calendar subset). |
 | `pve_ha_replication_rate` | `""` | `pvesr` rate limit in MB/s; empty = unlimited. |
 | `pve_ha_replication_jobnum` | `0` | Job-number suffix in the `<vmid>-<jobnum>` job id. |
+| `pve_ha_replication_affinity_rule` | `apps-replication-nodes` | Name of the strict node-affinity rule pinning replication guests to the pair. |

--- a/roles/pve_ha/README.md
+++ b/roles/pve_ha/README.md
@@ -30,35 +30,64 @@ doppler run -- ansible-playbook -i inventory playbooks/ha.yml -e pve_ha_enabled=
 
 When enabled it:
 
-1. Places each tier-0 LXC under HA (`ha-manager add ct:VMID --state started
+1. Places each managed LXC under HA (`ha-manager add ct:VMID --state started
    --max_restart 3 --max_relocate 1`). VMIDs resolve from the tofu inventory by
    hostname, so a renumber flows through with no edit.
 2. Adds `resource-affinity` **negative** rules so the two halves of each
    redundant pair never share a node.
+3. For the **singleton app guests** (`pve_ha_replication_ct_hostnames`), creates
+   a `pvesr` job shipping each one's rootfs to the always-on partner node, so
+   ha-manager has a replica to relocate onto.
 
 Guests (default `pve_ha_ct_hostnames`): `openbao-01`, `openbao-02`,
-`technitium-dns`, `technitium-dns-2`, `traefik`. Anti-affinity pairs
+`technitium-dns`, `technitium-dns-2`, `traefik`, plus the singleton app guests
+`postgres-apps`, `nautobot`, `vikunja`. Anti-affinity pairs
 (`pve_ha_anti_affinity_groups`): the two OpenBao Raft voters, the two Technitium
 DNS instances, and the Traefik ingress pair (the last auto-activates once
 `traefik-2` exists). A pair whose members do not all resolve is skipped.
 
-## Why anti-affinity is the real payload (and relocation is not)
+## Two guest classes: peer-redundant vs singleton
 
-These tier-0 guests sit on **local ZFS**, not shared storage, and each already
-has a redundant PEER on another node (OpenBao Raft quorum, the second Technitium
-instance, the keepalived VRRP VIP). So:
+Every guest here sits on **local ZFS**, not shared storage, so ha-manager can
+only start a guest on another node if its rootfs already exists there (`pvesr`).
+The guests split on how they survive a node loss:
+
+**Peer-redundant** (`openbao-*`, `technitium-dns*`, `traefik`) — each has a
+redundant PEER on another node (OpenBao Raft quorum, the second Technitium
+instance, the keepalived VRRP VIP):
 
 - On a **crash**, HA auto-restarts the guest in place (`max_restart`).
 - On a **node loss**, the surviving PEER carries the service; the failed guest
-  returns when its node heals. HA cannot start it on another node without the
-  rootfs being there (PVE storage replication / `pvesr`), which is a tracked
-  follow-up — deliberately **not** required for the node-loss story. Hence
-  `max_relocate` is intentionally low.
-- **Anti-affinity** is what keeps the redundancy real: it stops HA (or a manual
-  migrate) from ever collapsing both peers onto one node.
+  returns when its node heals. No replicated storage needed.
+- **Anti-affinity** keeps the redundancy real: it stops HA (or a manual migrate)
+  from ever collapsing both peers onto one node.
+
+**Singleton app guests** (`postgres-apps`, `nautobot`, `vikunja` —
+`pve_ha_replication_ct_hostnames`) — one instance, no peer, so **relocation is
+the only node-loss story**:
+
+- `pvesr` ships each guest's rootfs to the always-on PARTNER node on a schedule
+  (`pve_ha_replication_schedule`, default `*/15`), so a current-enough replica
+  exists to relocate onto.
+- On a **node loss**, ha-manager relocates the guest to the partner and starts
+  it from the replica. `max_relocate=1` is enough: one hop to the partner.
+- `pve3` sleeps for DR and holds no replica, so it is never a relocation target.
+- The replica is a **relocation enabler, not the durability layer**: the app
+  guests' real data-loss window is covered separately (`postgres-apps` by
+  streaming replication + WAL archiving; `nautobot`/`vikunja` are near-stateless
+  — their state lives in `postgres-apps`).
+
+Membership in `pve_ha_replication_ct_hostnames` is the per-guest "relocation is
+viable" knob. A guest in `pve_ha_ct_hostnames` but not in the replication list
+is treated as peer-redundant and gets no `pvesr` job.
 
 With 4 quorate nodes, HA fencing is safe — losing one node keeps quorum, so no
 surviving node self-fences.
+
+Because a `pvesr` job is node-local (`pvesr create-local-job` runs on the guest's
+source node), the replication tasks run on **every** node and each creates jobs
+only for the guests homed on it; the cluster-wide HA config still runs once on
+`pve_ha_config_host`.
 
 ## Safety
 
@@ -84,3 +113,8 @@ No real service is touched.
 | `pve_ha_extra_sids` | `[]` | Verbatim extra SIDs (e.g. `vm:NNN`). |
 | `pve_ha_anti_affinity_groups` | pairs | Redundant pairs to keep apart. |
 | `pve_ha_max_restart` / `pve_ha_max_relocate` | `3` / `1` | Per-guest bounds. |
+| `pve_ha_replication_ct_hostnames` | app list | Singleton guests that get a `pvesr` replica (relocation-enabled). |
+| `pve_ha_replication_pair` | `[pve1, pve2]` | Always-on nodes; `pvesr` target is the member that is not the guest's home node. |
+| `pve_ha_replication_schedule` | `*/15` | `pvesr` schedule (systemd-calendar subset). |
+| `pve_ha_replication_rate` | `""` | `pvesr` rate limit in MB/s; empty = unlimited. |
+| `pve_ha_replication_jobnum` | `0` | Job-number suffix in the `<vmid>-<jobnum>` job id. |

--- a/roles/pve_ha/defaults/main.yml
+++ b/roles/pve_ha/defaults/main.yml
@@ -124,3 +124,10 @@ pve_ha_replication_rate: ""
 
 # Job-number suffix for the pvesr job id (<vmid>-<jobnum>). One job per guest.
 pve_ha_replication_jobnum: 0
+
+# STRICT node-affinity rule pinning the replication guests to pve_ha_replication_pair.
+# This is correctness, not preference: a pvesr replica exists ONLY on the pair, so
+# ha-manager must never start one of these guests on any other node (e.g. pve3,
+# which holds no replica). A strict rule = run ONLY on the listed nodes, so a
+# relocation onto a replica-less node can't happen and then start-fail/flap.
+pve_ha_replication_affinity_rule: apps-replication-nodes

--- a/roles/pve_ha/defaults/main.yml
+++ b/roles/pve_ha/defaults/main.yml
@@ -14,16 +14,21 @@
 # per-node. All CLI work is skipped under Docker so the role is molecule-testable
 # in containers without a live cluster.
 #
-# STORAGE NOTE (why max_relocate is deliberately low): these tier-0 guests live
-# on LOCAL ZFS, not shared storage. On a node FAILURE ha-manager can only start
-# a guest on another node if that guest's rootfs already exists there (PVE
-# storage replication, pvesr). Today it does not — and that is fine: every
-# tier-0 guest has a redundant PEER on another node (OpenBao Raft quorum after
-# the third voter lands / the second Technitium instance / the keepalived VRRP
-# VIP), so the surviving peer covers the outage and the failed guest returns
-# when its node heals. Real cross-node relocation via pvesr is a tracked
-# follow-up, NOT required for the node-loss story. So the payload here is
-# anti-affinity + in-place auto-restart + orderly return-home, not migration.
+# STORAGE NOTE: these guests live on LOCAL ZFS, not shared storage. On a node
+# FAILURE ha-manager can only START a guest on another node if that guest's
+# rootfs already exists there (PVE storage replication, pvesr). Two classes of
+# guest split on this:
+#   * REDUNDANT-PEER guests (openbao/technitium/traefik): each has a peer on
+#     another node (OpenBao Raft quorum / the second Technitium instance / the
+#     keepalived VRRP VIP), so the surviving peer covers the outage and the
+#     failed guest returns when its node heals. They need NO replicated storage;
+#     the payload is anti-affinity + in-place auto-restart + orderly return-home.
+#   * SINGLETON app guests (pve_ha_replication_ct_hostnames): one instance, no
+#     peer, so RELOCATION is the only node-loss story. The replication block
+#     below runs pvesr to ship each one's rootfs to the always-on PARTNER node,
+#     so ha-manager can start it there. max_relocate=1 is enough — one hop to
+#     the partner that holds the replica (pve3 sleeps and holds no replica, so
+#     it is never a relocation target).
 pve_ha_enabled: false
 
 # Inventory hostname of the SINGLE node the ha-manager commands run on. HA state
@@ -40,17 +45,30 @@ pve_ha_max_restart: 3
 pve_ha_max_relocate: 1
 pve_ha_state: started
 
-# Tier-0 LXC guests to place under HA, identified by HOSTNAME (stable across a
-# VMID renumber). The VMID + "ct:" SID are resolved in tasks/main.yml from the
-# tofu inventory (containers_from_tofu, injected by load_tofu.yml), so a
-# renumber flows through with no edit here. A hostname absent from the inventory
-# is skipped with a warning rather than failing the run.
+# LXC guests to place under HA, identified by HOSTNAME (stable across a VMID
+# renumber). The VMID + "ct:" SID are resolved in tasks/main.yml from the tofu
+# inventory (containers_from_tofu, injected by load_tofu.yml), so a renumber
+# flows through with no edit here. A hostname absent from the inventory is
+# skipped with a warning rather than failing the run.
+#
+# Two classes of guest live here (see the STORAGE NOTE above and the replication
+# block below):
+#   * REDUNDANT-PEER guests (openbao/technitium/traefik) — a peer on another node
+#     carries the service on node loss, so they need no replicated storage; HA
+#     gives them in-place restart + anti-affinity.
+#   * SINGLETON app guests (postgres-apps/nautobot/vikunja) — one instance, no
+#     peer, so RELOCATION to a replica is their only node-loss story. They also
+#     appear in pve_ha_replication_ct_hostnames, which ships their rootfs to the
+#     always-on partner node so ha-manager can actually start them there.
 pve_ha_ct_hostnames:
   - openbao-01
   - openbao-02
   - technitium-dns
   - technitium-dns-2
   - traefik
+  - postgres-apps
+  - nautobot
+  - vikunja
 # Extra HA SIDs to manage verbatim (e.g. a VM the tofu container map does not
 # cover: "vm:110130"). Merged with the resolved CT SIDs. Empty by default.
 pve_ha_extra_sids: []
@@ -75,3 +93,34 @@ pve_ha_anti_affinity_groups:
     hostnames:
       - traefik
       - traefik-2
+
+# --- Storage replication (pvesr) for the SINGLETON app guests ----------------
+# The guests here get a pvesr job that ships their rootfs to the always-on
+# PARTNER node, so ha-manager can relocate them on node loss (see STORAGE NOTE).
+# Membership in THIS list is the per-guest "relocation is viable" knob — a guest
+# in pve_ha_ct_hostnames but NOT here is a redundant-peer guest and gets no
+# replica. Hostname-keyed like pve_ha_ct_hostnames; a guest absent from the tofu
+# inventory (e.g. not provisioned yet) is skipped with a warning, not a failure.
+pve_ha_replication_ct_hostnames:
+  - postgres-apps
+  - nautobot
+  - vikunja
+
+# The two ALWAYS-ON nodes that form the replication pair. A guest's pvesr target
+# is the pair member that is NOT its current home node. pve3 is deliberately
+# absent: it sleeps for DR and cannot be a live pvesr peer (pvesr needs the
+# target up). A guest whose home node is outside this pair is skipped.
+pve_ha_replication_pair:
+  - "{{ proxmox_node_prefix }}1"
+  - "{{ proxmox_node_prefix }}2"
+
+# pvesr schedule (systemd-calendar subset) and optional rate limit (MB/s; empty
+# = unlimited). */15 matches Proxmox's default; the app guests' real data-loss
+# window is covered separately (postgres-apps by streaming replication + WAL
+# archiving, the others are near-stateless), so this is a relocation-enabler,
+# not the primary durability layer.
+pve_ha_replication_schedule: "*/15"
+pve_ha_replication_rate: ""
+
+# Job-number suffix for the pvesr job id (<vmid>-<jobnum>). One job per guest.
+pve_ha_replication_jobnum: 0

--- a/roles/pve_ha/tasks/main.yml
+++ b/roles/pve_ha/tasks/main.yml
@@ -144,3 +144,91 @@
         - item.name in pve_ha_existing_rules
       # ponytail: idempotent enforce, same rationale as the resource set above.
       changed_when: false
+
+# Storage replication (pvesr) for the SINGLETON app guests, so ha-manager can
+# relocate them to the always-on partner node on node loss (see STORAGE NOTE in
+# defaults). Unlike the cluster-wide HA config above (run_once on the config
+# host), a pvesr job is NODE-LOCAL: `pvesr create-local-job` must run on the node
+# that currently hosts the guest (its SOURCE). So this block runs on EVERY node
+# and each node creates jobs only for the guests homed on it. The existing-job
+# read is cluster-wide, so a job already present anywhere is skipped — idempotent
+# across converges and across a later relocation (Proxmox reverses the job's
+# direction itself when a replicated guest migrates). Docker-skipped like above.
+- name: Configure pvesr storage replication for singleton app guests
+  when:
+    - pve_ha_enabled | bool
+    - pve_ha_replication_ct_hostnames | length > 0
+    - ansible_virtualization_type | default('') != 'docker'
+  tags:
+    - pve_ha
+  block:
+    - name: Map container hostname -> {vmid, node} from the tofu inventory
+      ansible.builtin.set_fact:
+        pve_ha_ct_by_host: >-
+          {{
+            dict(
+              (containers_from_tofu | default({})) | dict2items
+              | selectattr('value.vmid', 'defined')
+              | selectattr('value.node', 'defined')
+              | map(attribute='key') | list
+              | zip(
+                  (containers_from_tofu | default({})) | dict2items
+                  | selectattr('value.vmid', 'defined')
+                  | selectattr('value.node', 'defined')
+                  | map(attribute='value') | list
+                )
+            )
+          }}
+
+    # target = the pair member that is NOT the guest's home node. Guests absent
+    # from the inventory, or homed outside the always-on pair, resolve to no job.
+    - name: Resolve replication jobs (present guests homed in the always-on pair)
+      ansible.builtin.set_fact:
+        pve_ha_replication_jobs: >-
+          {{ pve_ha_replication_jobs | default([]) + [ {
+               'hostname': item,
+               'id': (pve_ha_ct_by_host[item].vmid | string) ~ '-'
+                     ~ (pve_ha_replication_jobnum | string),
+               'source': pve_ha_ct_by_host[item].node,
+               'target': (pve_ha_replication_pair
+                          | difference([pve_ha_ct_by_host[item].node]) | first)
+             } ] }}
+      loop: "{{ pve_ha_replication_ct_hostnames }}"
+      when:
+        - item in pve_ha_ct_by_host
+        - pve_ha_ct_by_host[item].node in pve_ha_replication_pair
+
+    - name: Warn about app guests with no replication job (skipped)
+      ansible.builtin.debug:
+        msg: >-
+          pve_ha replication: no job for {{ item }} — absent from the tofu
+          inventory, or its home node is outside the always-on pair
+          {{ pve_ha_replication_pair }}.
+      loop: "{{ pve_ha_replication_ct_hostnames }}"
+      when: item not in (pve_ha_replication_jobs | default([])
+                         | map(attribute='hostname') | list)
+
+    - name: Read current replication jobs (cluster-wide)
+      ansible.builtin.command: pvesh get /cluster/replication --output-format json
+      register: pve_ha_replication_raw
+      changed_when: false
+
+    - name: Parse existing replication job ids
+      ansible.builtin.set_fact:
+        pve_ha_existing_replication_ids: >-
+          {{ (pve_ha_replication_raw.stdout | from_json)
+             | map(attribute='id') | list }}
+
+    - name: Create a pvesr job on each guest's source node (only if absent)
+      ansible.builtin.command: >-
+        pvesr create-local-job {{ item.id }} {{ item.target }}
+        --schedule '{{ pve_ha_replication_schedule }}'
+        {% if pve_ha_replication_rate | string | length > 0 %}--rate {{ pve_ha_replication_rate }}{% endif %}
+        --comment 'pve_ha: relocation replica for {{ item.hostname }} -> {{ item.target }}'
+      loop: "{{ pve_ha_replication_jobs | default([]) }}"
+      loop_control:
+        label: "{{ item.id }} ({{ item.source }} -> {{ item.target }})"
+      when:
+        - inventory_hostname == item.source
+        - item.id not in pve_ha_existing_replication_ids
+      changed_when: true

--- a/roles/pve_ha/tasks/main.yml
+++ b/roles/pve_ha/tasks/main.yml
@@ -145,6 +145,43 @@
       # ponytail: idempotent enforce, same rationale as the resource set above.
       changed_when: false
 
+    # SIDs of replication guests that actually have a replica: present in the
+    # inventory AND homed in the pair (same scope as the pvesr jobs). A guest
+    # outside the pair has no replica, so it must NOT go in the strict rule (a
+    # strict rule with no available node would STOP it).
+    - name: Resolve replication guest SIDs (present, homed in the always-on pair)
+      ansible.builtin.set_fact:
+        pve_ha_replication_sids: >-
+          {{ pve_ha_replication_ct_hostnames | select('in', pve_ha_vmid_by_host)
+             | map('extract', containers_from_tofu | default({}))
+             | selectattr('node', 'in', pve_ha_replication_pair)
+             | map(attribute='vmid') | map('string')
+             | map('regex_replace', '^(.+)$', 'ct:\1') | list }}
+
+    - name: Pin replication guests to the always-on pair (strict; add if absent)
+      ansible.builtin.command: >-
+        ha-manager rules add node-affinity {{ pve_ha_replication_affinity_rule }}
+        --resources {{ pve_ha_replication_sids | join(',') }}
+        --nodes {{ pve_ha_replication_pair | join(',') }}
+        --strict 1
+        --comment 'pve_ha: keep singleton app guests on nodes holding their pvesr replica'
+      when:
+        - pve_ha_replication_sids | length > 0
+        - pve_ha_replication_affinity_rule not in pve_ha_existing_rules
+      changed_when: true
+
+    - name: Enforce the replication node-affinity rule (nodes + strict)
+      ansible.builtin.command: >-
+        ha-manager rules set node-affinity {{ pve_ha_replication_affinity_rule }}
+        --resources {{ pve_ha_replication_sids | join(',') }}
+        --nodes {{ pve_ha_replication_pair | join(',') }}
+        --strict 1
+      when:
+        - pve_ha_replication_sids | length > 0
+        - pve_ha_replication_affinity_rule in pve_ha_existing_rules
+      # ponytail: idempotent enforce, same rationale as the resource-affinity set.
+      changed_when: false
+
 # Storage replication (pvesr) for the SINGLETON app guests, so ha-manager can
 # relocate them to the always-on partner node on node loss (see STORAGE NOTE in
 # defaults). Unlike the cluster-wide HA config above (run_once on the config

--- a/tests/pve_ha_replication/verify_targets.yml
+++ b/tests/pve_ha_replication/verify_targets.yml
@@ -1,0 +1,77 @@
+---
+# Pin the pve_ha replication target-derivation logic without the live cluster or
+# the S3 inventory pipeline: feed a fake containers_from_tofu and run the SAME
+# resolution expression tasks/main.yml uses, then assert each guest resolves to
+# the correct partner node (or is skipped). Run: ansible-playbook tests/pve_ha_replication/verify_targets.yml
+- name: Verify pve_ha replication target resolution
+  hosts: localhost
+  become: false
+  gather_facts: false
+  vars:
+    proxmox_node_prefix: pve
+    pve_ha_replication_jobnum: 0
+    pve_ha_replication_pair:
+      - "{{ proxmox_node_prefix }}1"
+      - "{{ proxmox_node_prefix }}2"
+    pve_ha_replication_ct_hostnames:
+      - postgres-apps   # homed on pve1 -> target pve2
+      - nautobot        # homed on pve2 -> target pve1
+      - stray-on-pve3   # homed on pve3 (outside pair) -> skipped
+      - not-provisioned # absent from inventory -> skipped
+    containers_from_tofu:
+      postgres-apps: {vmid: 602000, node: pve1}
+      nautobot: {vmid: 605000, node: pve2}
+      stray-on-pve3: {vmid: 605010, node: pve3}
+
+  tasks:
+    - name: Map container hostname -> {vmid, node}
+      ansible.builtin.set_fact:
+        pve_ha_ct_by_host: >-
+          {{
+            dict(
+              (containers_from_tofu | default({})) | dict2items
+              | selectattr('value.vmid', 'defined')
+              | selectattr('value.node', 'defined')
+              | map(attribute='key') | list
+              | zip(
+                  (containers_from_tofu | default({})) | dict2items
+                  | selectattr('value.vmid', 'defined')
+                  | selectattr('value.node', 'defined')
+                  | map(attribute='value') | list
+                )
+            )
+          }}
+
+    - name: Resolve replication jobs (present guests homed in the always-on pair)
+      ansible.builtin.set_fact:
+        pve_ha_replication_jobs: >-
+          {{ pve_ha_replication_jobs | default([]) + [ {
+               'hostname': item,
+               'id': (pve_ha_ct_by_host[item].vmid | string) ~ '-'
+                     ~ (pve_ha_replication_jobnum | string),
+               'source': pve_ha_ct_by_host[item].node,
+               'target': (pve_ha_replication_pair
+                          | difference([pve_ha_ct_by_host[item].node]) | first)
+             } ] }}
+      loop: "{{ pve_ha_replication_ct_hostnames }}"
+      when:
+        - item in pve_ha_ct_by_host
+        - pve_ha_ct_by_host[item].node in pve_ha_replication_pair
+
+    - name: Assert exactly the two in-pair guests resolved, to the right partners
+      ansible.builtin.assert:
+        that:
+          - (pve_ha_replication_jobs | map(attribute='hostname') | sort)
+            == ['nautobot', 'postgres-apps']
+          - (pve_ha_replication_jobs
+             | selectattr('hostname', 'eq', 'postgres-apps') | first).target == 'pve2'
+          - (pve_ha_replication_jobs
+             | selectattr('hostname', 'eq', 'postgres-apps') | first).id == '602000-0'
+          - (pve_ha_replication_jobs
+             | selectattr('hostname', 'eq', 'nautobot') | first).target == 'pve1'
+        fail_msg: >-
+          pve_ha replication target derivation is wrong:
+          {{ pve_ha_replication_jobs }}
+        success_msg: >-
+          pve_ha replication targets resolve correctly (pve1-homed -> pve2,
+          pve2-homed -> pve1, pve3 + absent guests skipped).

--- a/tests/pve_ha_replication/verify_targets.yml
+++ b/tests/pve_ha_replication/verify_targets.yml
@@ -1,9 +1,15 @@
 ---
-# Pin the pve_ha replication target-derivation logic without the live cluster or
-# the S3 inventory pipeline: feed a fake containers_from_tofu and run the SAME
-# resolution expression tasks/main.yml uses, then assert each guest resolves to
-# the correct partner node (or is skipped). Run: ansible-playbook tests/pve_ha_replication/verify_targets.yml
-- name: Verify pve_ha replication target resolution
+# Pin the pve_ha replication derivation without a live cluster or the S3
+# inventory pipeline: feed a SYNTHETIC containers_from_tofu and run the SAME
+# expressions tasks/main.yml uses, then assert targets + the strict-pin SID set.
+# Run: ansible-playbook tests/pve_ha_replication/verify_targets.yml -i localhost,
+#
+# The fixture is a code-path model, NOT a snapshot of live inventory, but it
+# tracks reality where it matters: postgres-apps (602000) is ABSENT (not yet
+# provisioned) so it exercises the absent-guest exclusion; nautobot (605000) and
+# vikunja (605010) are PRESENT and in-pair so both must resolve; a made-up
+# out-of-pair-pve3 guest (fake vmid) exercises the node-not-in-pair exclusion.
+- name: Verify pve_ha replication target + node-affinity resolution
   hosts: localhost
   become: false
   gather_facts: false
@@ -14,14 +20,15 @@
       - "{{ proxmox_node_prefix }}1"
       - "{{ proxmox_node_prefix }}2"
     pve_ha_replication_ct_hostnames:
-      - postgres-apps   # homed on pve1 -> target pve2
-      - nautobot        # homed on pve2 -> target pve1
-      - stray-on-pve3   # homed on pve3 (outside pair) -> skipped
-      - not-provisioned # absent from inventory -> skipped
+      - postgres-apps      # ABSENT from the fixture (not provisioned) -> skipped
+      - nautobot           # present, pve2 -> target pve1, in the strict pin
+      - vikunja            # present, pve1 -> target pve2, in the strict pin
+      - out-of-pair-pve3   # present but homed on pve3 (outside pair) -> skipped
     containers_from_tofu:
-      postgres-apps: {vmid: 602000, node: pve1}
       nautobot: {vmid: 605000, node: pve2}
-      stray-on-pve3: {vmid: 605010, node: pve3}
+      vikunja: {vmid: 605010, node: pve1}
+      out-of-pair-pve3: {vmid: 699000, node: pve3}
+      # postgres-apps (602000) deliberately absent — models #662 unapplied.
 
   tasks:
     - name: Map container hostname -> {vmid, node}
@@ -58,23 +65,25 @@
         - item in pve_ha_ct_by_host
         - pve_ha_ct_by_host[item].node in pve_ha_replication_pair
 
-    - name: Assert exactly the two in-pair guests resolved, to the right partners
+    - name: Assert both present in-pair guests resolved, to the right partners
       ansible.builtin.assert:
         that:
           - (pve_ha_replication_jobs | map(attribute='hostname') | sort)
-            == ['nautobot', 'postgres-apps']
+            == ['nautobot', 'vikunja']
           - (pve_ha_replication_jobs
-             | selectattr('hostname', 'eq', 'postgres-apps') | first).target == 'pve2'
+             | selectattr('hostname', 'eq', 'vikunja') | first).target == 'pve2'
           - (pve_ha_replication_jobs
-             | selectattr('hostname', 'eq', 'postgres-apps') | first).id == '602000-0'
+             | selectattr('hostname', 'eq', 'vikunja') | first).id == '605010-0'
           - (pve_ha_replication_jobs
              | selectattr('hostname', 'eq', 'nautobot') | first).target == 'pve1'
+          - (pve_ha_replication_jobs
+             | selectattr('hostname', 'eq', 'nautobot') | first).id == '605000-0'
         fail_msg: >-
           pve_ha replication target derivation is wrong:
           {{ pve_ha_replication_jobs }}
         success_msg: >-
-          pve_ha replication targets resolve correctly (pve1-homed -> pve2,
-          pve2-homed -> pve1, pve3 + absent guests skipped).
+          pve_ha replication targets resolve correctly (vikunja pve1 -> pve2,
+          nautobot pve2 -> pve1; absent postgres-apps + pve3-homed guest skipped).
 
     # Node-affinity scope: the STRICT pin must cover only guests that have a
     # replica (present + in-pair), so pve3-homed / absent guests are excluded —
@@ -96,14 +105,14 @@
              | map(attribute='vmid') | map('string')
              | map('regex_replace', '^(.+)$', 'ct:\1') | list }}
 
-    - name: Assert the strict pin covers only the in-pair guests (pve3 excluded)
+    - name: Assert the strict pin covers exactly the present in-pair guests
       ansible.builtin.assert:
         that:
-          - (pve_ha_replication_sids | sort) == ['ct:602000', 'ct:605000']
+          - (pve_ha_replication_sids | sort) == ['ct:605000', 'ct:605010']
           - "'pve3' not in pve_ha_replication_pair"
         fail_msg: >-
-          node-affinity SID scope is wrong (must exclude pve3-homed/absent):
-          {{ pve_ha_replication_sids }}
+          node-affinity SID scope is wrong (must be every present in-pair guest,
+          excluding pve3-homed/absent): {{ pve_ha_replication_sids }}
         success_msg: >-
-          node-affinity strict pin covers only ct:602000 + ct:605000 over
-          {{ pve_ha_replication_pair }} (pve3-homed + absent guests excluded).
+          node-affinity strict pin covers exactly ct:605000 + ct:605010 over
+          {{ pve_ha_replication_pair }} (absent + pve3-homed guests excluded).

--- a/tests/pve_ha_replication/verify_targets.yml
+++ b/tests/pve_ha_replication/verify_targets.yml
@@ -75,3 +75,35 @@
         success_msg: >-
           pve_ha replication targets resolve correctly (pve1-homed -> pve2,
           pve2-homed -> pve1, pve3 + absent guests skipped).
+
+    # Node-affinity scope: the STRICT pin must cover only guests that have a
+    # replica (present + in-pair), so pve3-homed / absent guests are excluded —
+    # a strict rule over a replica-less guest would stop it, and the pin's node
+    # set (the pair, no pve3) is what keeps ha-manager off the awake pve3.
+    - name: Map container hostname -> vmid (node-affinity resolution input)
+      ansible.builtin.set_fact:
+        pve_ha_vmid_by_host: >-
+          {{ dict(containers_from_tofu | dict2items | map(attribute='key') | list
+             | zip(containers_from_tofu | dict2items
+                   | map(attribute='value.vmid') | list)) }}
+
+    - name: Resolve the strict node-affinity SID set
+      ansible.builtin.set_fact:
+        pve_ha_replication_sids: >-
+          {{ pve_ha_replication_ct_hostnames | select('in', pve_ha_vmid_by_host)
+             | map('extract', containers_from_tofu)
+             | selectattr('node', 'in', pve_ha_replication_pair)
+             | map(attribute='vmid') | map('string')
+             | map('regex_replace', '^(.+)$', 'ct:\1') | list }}
+
+    - name: Assert the strict pin covers only the in-pair guests (pve3 excluded)
+      ansible.builtin.assert:
+        that:
+          - (pve_ha_replication_sids | sort) == ['ct:602000', 'ct:605000']
+          - "'pve3' not in pve_ha_replication_pair"
+        fail_msg: >-
+          node-affinity SID scope is wrong (must exclude pve3-homed/absent):
+          {{ pve_ha_replication_sids }}
+        success_msg: >-
+          node-affinity strict pin covers only ct:602000 + ct:605000 over
+          {{ pve_ha_replication_pair }} (pve3-homed + absent guests excluded).


### PR DESCRIPTION
## What

Extends the `pve_ha` role so the singleton application guests survive a node
loss by **relocation**, not just in-place restart. A guest with no redundant
peer can only be started on another node if its rootfs already exists there, so
this adds Proxmox-native storage replication (`pvesr`) to put a current replica
on the always-on partner node.

## Why

The role already handles two things well for **peer-redundant** guests
(anti-affinity + in-place auto-restart): losing a node is covered by the
surviving peer. The application guests are **singletons** with no peer, so their
only node-loss story is relocation — which needs a replica to relocate onto.

## Changes

- Add the three application guests to `pve_ha_ct_hostnames` (HA enrollment).
  Hostnames absent from the inventory are skipped with a warning, so a guest not
  yet provisioned does not break a run.
- New `pve_ha_replication_ct_hostnames`: the subset that also gets a `pvesr` job
  shipping its rootfs to the always-on partner node. The target is derived as
  the replication-pair member that is not the guest's home node. Membership in
  this list is the per-guest "relocation is viable" knob.
- A **strict `node-affinity` rule** pins these guests to the replication pair, so
  ha-manager can only start them on a node that holds a replica. This is
  correctness, not preference: a relocation onto a replica-less node (e.g. the DR
  node while it is awake) would start-fail and flap. The rule is scoped to the
  same present-and-in-pair set as the `pvesr` jobs, so a replica-less guest is
  never placed under a strict rule that would stop it.
- The replication tasks run per source node (a `pvesr` job is node-local), while
  the cluster-wide HA config and rules run once on the config host. The
  existing-job read is cluster-wide, so it stays idempotent across converges and
  across a later relocation.

## Safety and durability

- Fully **inert** behind `pve_ha_enabled=false` (unchanged default) and skipped
  under Docker, so molecule and a preview run are no-ops. Enabling live cluster
  behaviour stays a deliberate, gated step for the operator.
- The replica is a **relocation enabler, not the durability layer**: the
  application guests' real data-loss window is covered separately (streaming
  replication + WAL archiving for the database primary; the others are
  near-stateless).

## Testing

- `ansible-lint` (profile `production`): clean.
- `tests/pve_ha_replication/verify_targets.yml` pins the target-derivation logic
  (home-node → partner, out-of-pair and absent guests skipped) without a live
  cluster or the S3 inventory pipeline.

## Live-enable sequence (operator, out of band)

1. Enable with replication and confirm the first `pvesr` sync completes for each
   guest (a replica exists on the partner).
2. Confirm the HA resources are registered and healthy.
3. Run the non-destructive failover drill against a disposable test guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ
