### PR TITLE
fix(ssh_ca_trust): gate role activation behind a two-condition switch

### DIFF
--- a/roles/ssh_ca_trust/defaults/main.yml
+++ b/roles/ssh_ca_trust/defaults/main.yml
@@ -17,7 +17,14 @@
 # here). Fail-closed: no pin, or a mismatch, aborts the role. Never
 # trust-on-first-use.
 
-ssh_ca_trust_enabled: true
+# Two-condition activation gate. The role is a NO-OP unless BOTH a pinned CA
+# fingerprint exists AND rollout is explicitly enabled for this host group.
+# Separating "a pin exists" from "roll out today" keeps a stray/stale
+# SSH_CA_FINGERPRINT from distributing trust estate-wide, and enables staged,
+# host-class-by-host-class activation (flip rollout per group_vars once proven).
+# When active it is still fail-closed on a fingerprint MISMATCH.
+ssh_ca_trust_rollout_enabled: false
+ssh_ca_trust_enabled: "{{ (ssh_ca_trust_ca_fingerprint | length > 0) and (ssh_ca_trust_rollout_enabled | bool) }}"
 
 # OpenBao endpoint. HA standbys 307-redirect; the uri task follows redirects.
 ssh_ca_trust_bao_addr: >-
@@ -28,7 +35,8 @@ ssh_ca_trust_mount: ssh-client-ca
 # PINNED CA public-key fingerprint (the `ssh-keygen -l` SHA256:... form).
 # Recorded from the openbao converge's "SSH CA fingerprint" output — a
 # verified, human-gated session — and committed via group_vars/env. Empty
-# fails the role: distributing trust without a pin would be TOFU.
+# leaves the role a no-op (see the activation gate): distributing trust
+# without a pin would be TOFU.
 ssh_ca_trust_ca_fingerprint: "{{ lookup('env', 'SSH_CA_FINGERPRINT') | default('', true) }}"
 
 # Extra trusted CA public keys (full authorized-keys-format lines). CA


### PR DESCRIPTION
## Problem (P0)

The `ssh_ca_trust` role (merged in #410) shipped hardwired `ssh_ca_trust_enabled: true` and its first task asserts a non-empty pinned CA fingerprint. It is wired into `site.yml` with no play-level guard, and `SSH_CA_FINGERPRINT` is populated nowhere yet. **Any full/baseline converge without that env var set hard-fails for every targeted host** until the CA is stood up (Phase 2). This is a live estate-breaking gate.

## Fix

Replace the unconditional `enabled: true` with a **two-condition activation gate**: the role is a no-op unless BOTH a pinned CA fingerprint exists AND `ssh_ca_trust_rollout_enabled` is explicitly flipped for that host group. This:

- Restores safe baseline converges immediately (role skips cleanly, every task already carries `when: ssh_ca_trust_enabled | bool`).
- Enables **staged, host-class-by-host-class rollout** (flip `ssh_ca_trust_rollout_enabled: true` per group_vars once that class is proven).
- Keeps a stray/stale `SSH_CA_FINGERPRINT` from silently distributing trust estate-wide — separating "a pin exists" from "roll out today".
- Stays **fail-closed on a fingerprint mismatch** when active.

Design hardening adopted from an adversarial (Codex) review of the rollout plan; supersedes a simpler single-env-var trigger.

## Verification

- `ansible-lint roles/ssh_ca_trust` — passes clean (profile: production, 0 failures).
- Reasoning: unset pin OR rollout-disabled ⇒ `enabled` renders `false` ⇒ every task (incl. the fingerprint assert) skips; pin present AND rollout enabled ⇒ `enabled` true ⇒ all asserts run.

The twin change for the VM half lands in `ansible-proxmox-apps` #976.