### PR TITLE
feat(postgres_standby): pull the ai-VLAN memory cluster's dump archive

### DIFF
--- a/inventory/host_vars/pve2.yml
+++ b/inventory/host_vars/pve2.yml
@@ -92,5 +92,9 @@ postgres_standby_jobs: >-
        {'name': 'postgres',
         'source_host': 'root@' ~ (((containers_from_tofu | default({}))['postgres'] | default({})).hostname | default('postgres')) ~ '.' ~ domain_from_tofu,
         'source_dir': '/var/lib/postgresql/backups',
-        'archive_dir': '/bulk/databases/postgres'}
+        'archive_dir': '/bulk/databases/postgres'},
+       {'name': 'postgres-ai',
+        'source_host': 'root@' ~ (((containers_from_tofu | default({}))['postgres-ai-1'] | default({})).hostname | default('postgres-ai-1')) ~ '.' ~ domain_from_tofu,
+        'source_dir': '/var/lib/postgresql/backups',
+        'archive_dir': '/bulk/databases/postgres-ai'}
      ] }}


### PR DESCRIPTION
## Summary
One new `postgres_standby_jobs` entry: mirror the Hindsight memory cluster primary's (`postgres-ai-1`, FQDN derived from tofu) `pg-backup` directory into `/bulk/databases/postgres-ai`. Snapshots, offline-DR replication, and the Tier-2 cloud upload cover the new archive dir with no further edits (docs/DATABASE_DR_STANDARD.md "Adding a new database").

Companion to dryvist/ansible-proxmox-apps#1035 (the ai-VLAN Postgres cluster itself). Standby pull-key trust on the new guest lands via that cluster's converge (`postgres_standby_pull_pubkeys`).

## Test plan
- ansible-lint via pre-commit/pre-push (clean).
- Post-converge: standby timer run mirrors the new dump dir; restore drill for the `hindsight` DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgTn2CxMJmyY9yKXndsNaq