### PR TITLE
feat(pve_ha): record the data-platform tier in the default guest list

### DIFF
--- a/roles/pve_ha/defaults/main.yml
+++ b/roles/pve_ha/defaults/main.yml
@@ -72,14 +72,13 @@ pve_ha_ct_hostnames:
   - traefik
   # Data platform + shared-Postgres apps tier (live under HA since 2026-07-16;
   # this records what ha-manager already holds so a converge is idempotent).
+  # postgres-apps/nautobot/vikunja are the pvesr-replicated singletons and also
+  # appear in pve_ha_replication_ct_hostnames below.
   - postgres
   - postgres-apps
   - vikunja
   - nautobot
   - zammad
-  - postgres-apps
-  - nautobot
-  - vikunja
 # Extra HA SIDs to manage verbatim (e.g. a VM the tofu container map does not
 # cover: "vm:110130"). Merged with the resolved CT SIDs. Empty by default.
 pve_ha_extra_sids: []

--- a/roles/pve_ha/defaults/main.yml
+++ b/roles/pve_ha/defaults/main.yml
@@ -66,6 +66,13 @@ pve_ha_ct_hostnames:
   - technitium-dns
   - technitium-dns-2
   - traefik
+  # Data platform + shared-Postgres apps tier (live under HA since 2026-07-16;
+  # this records what ha-manager already holds so a converge is idempotent).
+  - postgres
+  - postgres-apps
+  - vikunja
+  - nautobot
+  - zammad
   - postgres-apps
   - nautobot
   - vikunja
@@ -93,6 +100,12 @@ pve_ha_anti_affinity_groups:
     hostnames:
       - traefik
       - traefik-2
+  # The Postgres primary/standby pair: a node loss must never take both the
+  # primary and its streaming standby.
+  - name: postgres-pair
+    hostnames:
+      - postgres
+      - postgres-apps
 
 # --- Storage replication (pvesr) for the SINGLETON app guests ----------------
 # The guests here get a pvesr job that ships their rootfs to the always-on

--- a/roles/pve_ha/defaults/main.yml
+++ b/roles/pve_ha/defaults/main.yml
@@ -60,6 +60,10 @@ pve_ha_state: started
 #     peer, so RELOCATION to a replica is their only node-loss story. They also
 #     appear in pve_ha_replication_ct_hostnames, which ships their rootfs to the
 #     always-on partner node so ha-manager can actually start them there.
+# NAMING: technitium-dns/-2 and traefik are legacy names that violate the
+# multi-instance naming law (two-digit suffix, first digit = node ID). They stay
+# here because this list must match the LIVE hostnames or the role skips them —
+# rename flows through IaC first (tofu-proxmox#679), then this list follows.
 pve_ha_ct_hostnames:
   - openbao-01
   - openbao-02


### PR DESCRIPTION
The postgres pair and the three shared-Postgres apps have been live under HA since 2026-07-16, applied via an ad-hoc `-e` payload — so the source had drifted from ha-manager's actual state and a plain converge would not reproduce it. Adds the five guests and the `postgres-pair` anti-affinity group (a node loss must never take both the primary and its standby).

Role stays inert by default (`pve_ha_enabled=false` unchanged); with the flag set, a converge is idempotent against the live HA state (the list now matches what ha-manager holds).