### PR TITLE
feat(ssh_ca_trust): roll out CA trust to PVE nodes + LXCs; fix pct sshd -t

### DIFF
--- a/inventory/group_vars/proxmox.yml
+++ b/inventory/group_vars/proxmox.yml
@@ -1,6 +1,14 @@
 ---
 # Group variables for Proxmox VE servers
 
+# Trust the OpenBao SSH client CA on the PVE nodes and (via pct) their LXC
+# containers (ssh-certificate-authority ADR). Additive + lockout-guarded (a
+# static break-glass key must still authenticate before the role finishes) and
+# the pinned SSH_CA_FINGERPRINT is verified fail-closed. Principals are
+# deny-by-default: PVE root:[ansible], LXC root:[ansible] — ai-agent is never a
+# hypervisor root. Stopped containers are reported as blockers, not failures.
+ssh_ca_trust_rollout_enabled: true
+
 # Node naming: every Proxmox node is addressed as <proxmox_node_prefix><N> — a node
 # is just its number with this prefix prepended. Parameterized so node references in
 # roles and host_vars never hard-code the real prefix. The REAL prefix is injected at

--- a/roles/ssh_ca_trust/tasks/lxc.yml
+++ b/roles/ssh_ca_trust/tasks/lxc.yml
@@ -53,6 +53,11 @@
         | pct exec {{ item }} -- tee {{ ssh_ca_trust_dropin }} > /dev/null
       pct exec {{ item }} -- chmod 0644 {{ ssh_ca_trust_ca_file }} {{ ssh_ca_trust_dropin }}
       if pct exec {{ item }} -- sh -c 'command -v sshd' > /dev/null 2>&1; then
+        # sshd -t needs the privilege-separation dir, which a bare `pct exec`
+        # shell lacks (systemd normally creates it at sshd start) — create it
+        # so the config test doesn't abort with "Missing privilege separation
+        # directory: /run/sshd".
+        pct exec {{ item }} -- mkdir -p /run/sshd
         pct exec {{ item }} -- sshd -t
         pct exec {{ item }} -- sh -c 'systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true'
         echo "CONFIGURED-SSHD"


### PR DESCRIPTION
## What

1. Flip `ssh_ca_trust_rollout_enabled: true` for the `proxmox` group — the PVE nodes and (via `pct`) their LXC containers now trust the OpenBao SSH client CA (ssh-certificate-authority ADR). This is the bulk of the estate's SSH surface (~all guests are LXC via `proxmox_pct_remote`).
2. **Bug fix in `lxc.yml`**: `pct exec <id> -- sshd -t` aborted with `Missing privilege separation directory: /run/sshd` — a bare `pct exec` shell lacks the runtime dir systemd creates at sshd start, so every running container's trust push failed rc=255. Create `/run/sshd` before the config test.

## Why now

The client CA is live and its fingerprint pinned (`SSH_CA_FINGERPRINT` in Doppler). Phase 1's activation gate means this flag is what turns trust on for the host class. Principals stay deny-by-default (`root: [ansible]`; `ai-agent` is never a hypervisor root).

## Verified live

Converged `--tags ssh_ca_trust --limit proxmox`:
- pve1–4: pin verified fail-closed, CA keys + principals written, effective-sshd assert + **static break-glass lockout guard passed**, `failed=0` on all nodes.
- **59 running LXC containers** received CA trust (`failed=0`) after the `/run/sshd` fix — before the fix, all failed on `sshd -t`.
- 1 stopped container (990) reported as a non-fatal blocker (can't push to a stopped guest).
- `ansible-lint` clean (profile production).

The `sshd -t` bug is exactly the class of defect the missing molecule scenario (#418) would catch — a scenario is tracked there.

Part of the SSH-CA fabric rollout (Vikunja #636).