### PR TITLE
feat(ssh): fail-loud cert fallback + strict pinned host-key verification

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,10 @@
 [defaults]
 inventory = inventory/hosts.yml
 roles_path = roles
-host_key_checking = False
+# Host identities are verified against the reviewed pinned known_hosts that
+# scripts/run-ansible.sh materializes from SSH_KNOWN_HOSTS (Doppler). A rebuilt
+# node/guest fails closed until re-harvested. LXC pushes use pct, not SSH.
+host_key_checking = True
 retry_files_enabled = False
 gathering = smart
 fact_caching = jsonfile

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,9 +1,11 @@
 [defaults]
 inventory = inventory/hosts.yml
 roles_path = roles
-# Host identities are verified against the reviewed pinned known_hosts that
-# scripts/run-ansible.sh materializes from SSH_KNOWN_HOSTS (Doppler). A rebuilt
-# node/guest fails closed until re-harvested. LXC pushes use pct, not SSH.
+# Refuse unverified host keys. Pinned verification (the reviewed known_hosts
+# from Doppler SSH_KNOWN_HOSTS) applies when running via scripts/run-ansible.sh;
+# direct ansible-playbook runs verify against the operator's own known_hosts
+# and fail closed for unknown hosts. A rebuilt node/guest fails closed until
+# re-harvested. LXC pushes use pct, not SSH.
 host_key_checking = True
 retry_files_enabled = False
 gathering = smart

--- a/scripts/run-ansible.sh
+++ b/scripts/run-ansible.sh
@@ -31,7 +31,7 @@ trap cleanup EXIT
 # ssh-client-ca/sign/automation-ansible (principal `ansible`, cert TTL <=1h),
 # and point the inventory at the key (OpenSSH pairs id + id-cert.pub
 # automatically). Requires BAO_ADDR + the ansible-converge AppRole in the
-# ambient env (Doppler). Any failure falls back to the static key path below.
+# ambient env (Doppler). With that env present, a mint failure is fatal.
 mint_ssh_cert() {
   local mount=${SSH_CA_MOUNT:-ssh-client-ca} login token signed
   CERT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ansible-sshcert.XXXXXX") || return 1
@@ -95,7 +95,7 @@ if [[ -n ${SSH_KNOWN_HOSTS:-} ]]; then
   fi
   printf '%s\n' "$SSH_KNOWN_HOSTS" > "$CERT_DIR/known_hosts"
   chmod 600 "$CERT_DIR/known_hosts"
-  export ANSIBLE_SSH_COMMON_ARGS="-o UserKnownHostsFile=$CERT_DIR/known_hosts -o StrictHostKeyChecking=yes${ANSIBLE_SSH_COMMON_ARGS:+ $ANSIBLE_SSH_COMMON_ARGS}"
+  export ANSIBLE_SSH_COMMON_ARGS="-o UserKnownHostsFile=$CERT_DIR/known_hosts -o GlobalKnownHostsFile=/dev/null -o StrictHostKeyChecking=yes${ANSIBLE_SSH_COMMON_ARGS:+ $ANSIBLE_SSH_COMMON_ARGS}"
 fi
 
 # Run ansible-playbook - prefer NIX_SHELL if set, otherwise use PATH

--- a/scripts/run-ansible.sh
+++ b/scripts/run-ansible.sh
@@ -53,8 +53,16 @@ mint_ssh_cert() {
   export PROXMOX_SSH_KEY_PATH="$CERT_DIR/id"
 }
 
-if [[ -n ${BAO_ADDR:-} && -n ${OPENBAO_APPROLE_ANSIBLE_ROLE_ID:-} && -n ${OPENBAO_APPROLE_ANSIBLE_SECRET_ID:-} ]] \
-  && mint_ssh_cert; then
+if [[ -n ${BAO_ADDR:-} && -n ${OPENBAO_APPROLE_ANSIBLE_ROLE_ID:-} && -n ${OPENBAO_APPROLE_ANSIBLE_SECRET_ID:-} ]]; then
+  # FAIL-LOUD: when the cert env is present, a mint failure is an error — never
+  # silently ride the static key (that masked a dead cert path once already).
+  # Break-glass = run WITHOUT the BAO env, with the static key vars set.
+  if ! mint_ssh_cert; then
+    echo "ERROR: OpenBao SSH cert mint FAILED and the cert env is present — refusing" >&2
+    echo "the silent static-key fallback. Fix the cert path, or unset the" >&2
+    echo "OPENBAO_APPROLE_ANSIBLE_* env to deliberately use the static break-glass key." >&2
+    exit 1
+  fi
   echo "Using a short-lived SSH certificate from the OpenBao CA (automation-ansible)."
 # If key file exists at PROXMOX_SSH_KEY_PATH, export expanded path for inventory.
 # Otherwise load key content into ssh-agent and unset PROXMOX_SSH_KEY_PATH so
@@ -75,6 +83,19 @@ else
   echo "ERROR: No SSH key available."
   echo "Set PROXMOX_SSH_KEY_PATH (file path) or PROXMOX_SSH_PRIVATE_KEY (key content) via Doppler."
   exit 1
+fi
+
+# Pin host identities: materialize the reviewed known_hosts (Doppler
+# SSH_KNOWN_HOSTS, harvested over authenticated channels) and verify strictly.
+# A rebuilt guest gets a new host key and fails closed until re-harvested.
+if [[ -n ${SSH_KNOWN_HOSTS:-} ]]; then
+  if [[ -z $CERT_DIR ]]; then
+    CERT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ansible-sshkh.XXXXXX")
+    chmod 700 "$CERT_DIR"
+  fi
+  printf '%s\n' "$SSH_KNOWN_HOSTS" > "$CERT_DIR/known_hosts"
+  chmod 600 "$CERT_DIR/known_hosts"
+  export ANSIBLE_SSH_COMMON_ARGS="-o UserKnownHostsFile=$CERT_DIR/known_hosts -o StrictHostKeyChecking=yes${ANSIBLE_SSH_COMMON_ARGS:+ $ANSIBLE_SSH_COMMON_ARGS}"
 fi
 
 # Run ansible-playbook - prefer NIX_SHELL if set, otherwise use PATH

--- a/scripts/run-ansible.sh
+++ b/scripts/run-ansible.sh
@@ -56,7 +56,8 @@ mint_ssh_cert() {
 if [[ -n ${BAO_ADDR:-} && -n ${OPENBAO_APPROLE_ANSIBLE_ROLE_ID:-} && -n ${OPENBAO_APPROLE_ANSIBLE_SECRET_ID:-} ]]; then
   # FAIL-LOUD: when the cert env is present, a mint failure is an error — never
   # silently ride the static key (that masked a dead cert path once already).
-  # Break-glass = run WITHOUT the BAO env, with the static key vars set.
+  # Break-glass = unset any of BAO_ADDR / OPENBAO_APPROLE_ANSIBLE_* (this branch
+  # only triggers when all three are present) and set the static key vars.
   if ! mint_ssh_cert; then
     echo "ERROR: OpenBao SSH cert mint FAILED and the cert env is present — refusing" >&2
     echo "the silent static-key fallback. Fix the cert path, or unset the" >&2


### PR DESCRIPTION
## What (SSH-CA Phase D prep — retirement hardening)

1. **Fail-loud cert fallback**: when the OpenBao cert env is present, a mint failure now errors instead of silently riding the static key. The silent fallback masked a completely dead cert path once already (the AppRole misroute) — converges looked green on the static key. Break-glass is explicit: run without the `OPENBAO_APPROLE_ANSIBLE_*` env.
2. **Strict pinned host-key verification**: `run-ansible.sh` materializes the reviewed known_hosts (Doppler `SSH_KNOWN_HOSTS` — all 6 automation SSH targets, harvested over already-authenticated channels, cross-verified) and connects with `StrictHostKeyChecking=yes`; `ansible.cfg` `host_key_checking` flips to `True`. A rebuilt node/guest fails closed until re-harvested — intended (ChaosMonkey rebuilds get a one-line re-harvest, not silent TOFU).

## Verified live

- All 4 PVE nodes converge over an **automation-ansible certificate** with the **pinned known_hosts under strict checking**: `failed=0, unreachable=0`, fresh handshakes (control sockets cleared first).
- Negative proof: a host whose offered key mismatches its known_hosts entry is refused (`Host key verification failed` → UNREACHABLE).
- `shellcheck` clean.

Twin PR in ansible-proxmox-apps. Precedes static-key rotation (tofu-proxmox#637). CA DR restore drill passed tonight (snapshot → local restore → same CA fingerprint → mints valid certs).