### PR TITLE
fix(docker_lxc_features): cover the hindsight memory-plane replicas

### DIFF
--- a/roles/docker_lxc_features/defaults/main.yml
+++ b/roles/docker_lxc_features/defaults/main.yml
@@ -6,9 +6,10 @@
 # so this role applies the host-side `pct set --features` step after create.
 #
 # The role targets containers whose tofu inventory tags include `docker` plus
-# either `ai-orchestration` or `agentgateway`. `n8n` and `langgraph` remain
-# explicit fallbacks so they stay covered even if the tags have not landed in
-# inventory yet.
+# `ai-orchestration`, `agentgateway`, or `hindsight` (the memory-plane API
+# replicas — same Docker-in-LXC fuse-overlayfs need as the orchestration tier).
+# `n8n` and `langgraph` remain explicit fallbacks so they stay covered even if
+# the tags have not landed in inventory yet.
 
 docker_lxc_features_desired_tokens:
   - nesting=1

--- a/roles/docker_lxc_features/tasks/main.yml
+++ b/roles/docker_lxc_features/tasks/main.yml
@@ -22,7 +22,7 @@
   when:
     - item.value.vmid is defined
     - "'docker' in (item.value.tags | default([]))"
-    - "(item.value.tags | default([])) | intersect(['ai-orchestration', 'agentgateway']) | length > 0"
+    - "(item.value.tags | default([])) | intersect(['ai-orchestration', 'agentgateway', 'hindsight']) | length > 0"
   tags:
     - docker_lxc_features
 


### PR DESCRIPTION
## Problem

The role selects docker-tagged guests that *also* carry `ai-orchestration` or `agentgateway`. The Hindsight API replicas are Docker-in-LXC on the same ai VLAN with the same fuse-overlayfs storage driver, but carry the `hindsight` tag — so they were never selected and came up with `nesting=1` only.

Docker then failed to pull any image:

```
failed to register layer: using mount program fuse-overlayfs:
fuse: device not found, try 'modprobe fuse' first
fuse-overlayfs: cannot mount: No such file or directory
```

`keyctl`/`fuse` are root@pam-only, so tofu deliberately cannot set them (documented in `modules/proxmox-container/locals.tf` — deriving them from the docker tag 403s every new guest at create time). This role is the only thing that can apply them.

## Fix

Add `hindsight` to the accepted tag set, alongside `ai-orchestration` and `agentgateway`.

Scoped deliberately: `containers_from_tofu` currently holds 20 docker-tagged LXCs, but broadening selection to the bare `docker` tag would sweep 15 unrelated guests (mssql, prometheus, ntfy, …) into a feature-set + restart on the next converge. That is a separate decision, not a side effect of adding one service.

## Verification

Converged live. Both replicas selected and changed, restart handler fired, 0 failed:

```
included: configure_container.yml for pve1 => (item=hindsight-1 -> 518000)
included: configure_container.yml for pve2 => (item=hindsight-2 -> 518010)
```

Confirmed on both guests afterward:

```
features: nesting=1,keyctl=1,fuse=1
/dev/fuse            # present inside the container
```