### PR TITLE
feat(root_authorized_keys): manage rotatable root break-glass keys

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -74,3 +74,10 @@ jobs:
           ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
+
+      - name: Run root_authorized_keys molecule test
+        run: molecule test -s root_authorized_keys
+        env:
+          ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "1"
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"

--- a/molecule/root_authorized_keys/converge.yml
+++ b/molecule/root_authorized_keys/converge.yml
@@ -1,0 +1,34 @@
+---
+# Molecule converge for root_authorized_keys.
+#
+# Case 1: disabled (default) — must be a pure no-op (no /root/.ssh created).
+# Case 2: enabled — add the new key, retire the "old" key that prepare.yml
+#         seeded, exercising the real add + remove + lockout-guard path (the
+#         authorized_key module works as root inside the container).
+# Idempotent by design: prepare.yml (not converge) seeds the old key, so a
+# second converge run reports zero changes (idempotence phase).
+
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    # Deterministic throwaway test keys (never real).
+    rak_key_new: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINEWtestkeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA operator-new"
+    rak_key_old: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLDtestkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB operator-old"
+
+  tasks:
+    - name: Converge — disabled (expect no-op)
+      ansible.builtin.include_role:
+        name: root_authorized_keys
+
+    - name: Converge — enabled, add new key + retire old key
+      ansible.builtin.include_role:
+        name: root_authorized_keys
+      vars:
+        root_authorized_keys_enabled: true
+        root_authorized_keys_present:
+          - "{{ rak_key_new }}"
+        root_authorized_keys_absent:
+          - "{{ rak_key_old }}"

--- a/molecule/root_authorized_keys/molecule.yml
+++ b/molecule/root_authorized_keys/molecule.yml
@@ -1,0 +1,9 @@
+---
+platforms:
+  - name: proxmox-root-authorized-keys-test
+    image: "${MOLECULE_IMAGE:-debian:stable-slim}"
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp

--- a/molecule/root_authorized_keys/prepare.yml
+++ b/molecule/root_authorized_keys/prepare.yml
@@ -1,0 +1,18 @@
+---
+# Molecule prepare for root_authorized_keys — runs ONCE before converge.
+#
+# Seeds the "old" operator key so converge's removal path has something to
+# retire. Kept out of converge.yml so converge stays idempotent (the
+# idempotence phase re-runs converge and expects zero changes).
+
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Seed the "old" key so the removal path has something to remove
+      ansible.posix.authorized_key:
+        user: root
+        key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLDtestkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB operator-old"
+        state: present

--- a/molecule/root_authorized_keys/verify.yml
+++ b/molecule/root_authorized_keys/verify.yml
@@ -1,0 +1,41 @@
+---
+# Molecule verification for root_authorized_keys.
+#
+# After converge: the new key is present, the retired key is gone, /root/.ssh
+# is 0700, and root still has >=1 static key (the lockout guard's invariant).
+
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+
+  vars:
+    rak_key_new: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINEWtestkeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA operator-new"
+    rak_key_old: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLDtestkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB operator-old"
+
+  tasks:
+    - name: Read root's authorized_keys
+      ansible.builtin.slurp:
+        src: /root/.ssh/authorized_keys
+      register: rak_authorized
+
+    - name: Stat /root/.ssh
+      ansible.builtin.stat:
+        path: /root/.ssh
+      register: rak_ssh_dir
+
+    - name: Assert the new key is present and the retired key is absent
+      ansible.builtin.assert:
+        that:
+          - (rak_authorized.content | b64decode) is search(rak_key_new | regex_escape)
+          - not ((rak_authorized.content | b64decode) is search(rak_key_old | regex_escape))
+          - rak_ssh_dir.stat.mode == "0700"
+        fail_msg: "authorized_keys rotation did not converge to the expected state"
+        success_msg: "new key present, retired key removed, /root/.ssh is 0700"
+
+    - name: Assert the lockout invariant — root still has >=1 static key
+      ansible.builtin.command:
+        cmd: grep -cE '^(ssh|ecdsa)-' /root/.ssh/authorized_keys
+      register: rak_count
+      changed_when: false
+      failed_when: rak_count.stdout | int < 1

--- a/molecule/root_authorized_keys/verify.yml
+++ b/molecule/root_authorized_keys/verify.yml
@@ -38,4 +38,4 @@
         cmd: grep -cE '^(ssh|ecdsa)-' /root/.ssh/authorized_keys
       register: rak_count
       changed_when: false
-      failed_when: rak_count.stdout | int < 1
+      failed_when: rak_count.stdout | trim | int < 1

--- a/roles/root_authorized_keys/README.md
+++ b/roles/root_authorized_keys/README.md
@@ -1,0 +1,41 @@
+# root_authorized_keys
+
+Declaratively manage the **static human break-glass keys** in
+`/root/.ssh/authorized_keys` so they can be **rotated via IaC** instead of a
+manual one-off.
+
+This role governs only the operator keys that must survive an OpenBao CA
+outage. Automation does not use these — it authenticates with short-TTL
+certificates from the OpenBao SSH client CA (see the `ssh_ca_trust` role and the
+`ssh-certificate-authority` ADR). The two are complementary: `ssh_ca_trust`
+distributes CA *trust*, this role manages the static *authorized_keys*.
+
+## Design
+
+- **Deny-by-default.** No-op unless `root_authorized_keys_enabled: true` for the
+  host group AND `root_authorized_keys_present` is non-empty.
+- **Not exclusive.** It ensures the declared keys are present and the declared
+  retired keys are absent — it never rewrites the file to match a single list,
+  so a mistake cannot silently wipe root's access.
+- **Fail-closed.** Asserts at least one key is declared present before touching
+  anything, and a final lockout guard refuses to finish if root would be left
+  with zero static keys.
+
+## Variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `root_authorized_keys_enabled` | `false` | Opt in per host group. |
+| `root_authorized_keys_present` | `[]` | Full authorized-keys-format lines to ensure present. Populate from the secrets store per group_vars — never commit a real key. |
+| `root_authorized_keys_absent` | `[]` | Retired / leaked key(s) to ensure absent. |
+
+## Rotation flow (zero-downtime)
+
+1. Add the **new** key to `root_authorized_keys_present`, converge, and verify a
+   break-glass SSH with the new key succeeds.
+2. Move the **old** key from `_present` to `root_authorized_keys_absent`,
+   converge. The old key is now gone; the lockout guard confirms the new key
+   remains.
+
+Both steps are ordinary converges — the old key stays valid throughout step 1,
+so there is no window without working break-glass access.

--- a/roles/root_authorized_keys/defaults/main.yml
+++ b/roles/root_authorized_keys/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# root_authorized_keys — declaratively manage the human break-glass keys in
+# /root/.ssh/authorized_keys so they can be ROTATED via IaC instead of a manual
+# one-off. Automation authenticates with OpenBao CA certificates (ssh_ca_trust
+# role); this role governs only the STATIC operator keys that must survive a CA
+# outage. It is intentionally NOT exclusive: it ensures the declared keys are
+# present and the declared retired keys are absent — it never wipes the file to
+# match a list, so a mistake can't lock root out.
+#
+# Rotation flow (zero-downtime): add the NEW key to _present + converge + verify
+# it logs in; then move the OLD key from _present to _absent + converge. The
+# final lockout guard refuses to finish if root would be left with zero static
+# keys.
+
+# Deny-by-default: no-op unless a host group opts in AND supplies keys.
+root_authorized_keys_enabled: false
+
+# Public keys to ENSURE PRESENT (full authorized-keys-format lines, one per
+# list item). Populate per host group from the secrets store — never commit a
+# real key here.
+root_authorized_keys_present: []
+
+# Public keys to ENSURE ABSENT — the rotated-out / leaked key(s) to retire.
+root_authorized_keys_absent: []

--- a/roles/root_authorized_keys/tasks/main.yml
+++ b/roles/root_authorized_keys/tasks/main.yml
@@ -53,7 +53,7 @@
     cmd: grep -cE '^(ssh|ecdsa)-' /root/.ssh/authorized_keys
   register: root_authorized_keys_count
   changed_when: false
-  failed_when: root_authorized_keys_count.stdout | int < 1
+  failed_when: root_authorized_keys_count.stdout | trim | int < 1
   when: root_authorized_keys_enabled | bool
   tags:
     - root_authorized_keys

--- a/roles/root_authorized_keys/tasks/main.yml
+++ b/roles/root_authorized_keys/tasks/main.yml
@@ -1,0 +1,59 @@
+---
+# Manage the static break-glass keys in /root/.ssh/authorized_keys. See
+# defaults/main.yml for the deny-by-default gate and the rotation flow.
+
+- name: Assert at least one break-glass key is declared present
+  ansible.builtin.assert:
+    that:
+      - root_authorized_keys_present | length > 0
+    fail_msg: >-
+      root_authorized_keys_enabled is true but root_authorized_keys_present is
+      empty. Refusing to manage root's authorized_keys with no key to keep —
+      that would risk locking root out. Supply the operator break-glass key(s).
+  when: root_authorized_keys_enabled | bool
+  tags:
+    - root_authorized_keys
+
+- name: Ensure root .ssh directory exists
+  ansible.builtin.file:
+    path: /root/.ssh
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  when: root_authorized_keys_enabled | bool
+  tags:
+    - root_authorized_keys
+
+- name: Ensure declared break-glass keys are present
+  ansible.posix.authorized_key:
+    user: root
+    key: "{{ item }}"
+    state: present
+  loop: "{{ root_authorized_keys_present }}"
+  when: root_authorized_keys_enabled | bool
+  tags:
+    - root_authorized_keys
+
+- name: Ensure retired keys are absent
+  ansible.posix.authorized_key:
+    user: root
+    key: "{{ item }}"
+    state: absent
+  loop: "{{ root_authorized_keys_absent }}"
+  when: root_authorized_keys_enabled | bool
+  tags:
+    - root_authorized_keys
+
+# Lockout guard: after add+remove, refuse to finish unless root still has at
+# least one static key. A rotation that emptied the file would be caught here
+# before the play completes (the same fail-closed stance as ssh_ca_trust).
+- name: Assert root still has a static authorized_key (lockout guard)
+  ansible.builtin.command:
+    cmd: grep -cE '^(ssh|ecdsa)-' /root/.ssh/authorized_keys
+  register: root_authorized_keys_count
+  changed_when: false
+  failed_when: root_authorized_keys_count.stdout | int < 1
+  when: root_authorized_keys_enabled | bool
+  tags:
+    - root_authorized_keys


### PR DESCRIPTION
## What

A new `root_authorized_keys` role that declaratively manages the static human break-glass keys in `/root/.ssh/authorized_keys` so they can be **rotated via IaC** instead of a manual one-off — the "rotatable, inventory-stored key management" the `cluster_ssh_trust` README explicitly defers.

This is the managed mechanism for the PVE static-key rotation (SSH-CA Phase D / tofu-proxmox#637): the key distribution belongs in a role here, not an ad-hoc converge. Automation authenticates with OpenBao CA certs (`ssh_ca_trust`); this governs only the static operator keys that must survive a CA outage.

## Design (safe by construction)

- **Deny-by-default**: no-op unless `root_authorized_keys_enabled: true` for the host group AND `root_authorized_keys_present` is non-empty.
- **Present/absent lists, not exclusive management**: it ensures declared keys are present and declared retired keys are absent — it never rewrites the file to match a single list, so a mistake can't silently wipe root's access.
- **Fail-closed**: asserts ≥1 key is declared present before touching anything, and a final lockout guard refuses to finish if root would be left with zero static keys (same stance as `ssh_ca_trust`).

## Rotation flow (zero-downtime)

1. Add the new key to `_present`, converge, verify the new key logs in.
2. Move the old key from `_present` to `_absent`, converge — old key gone, guard confirms the new key remains. The old key stays valid through step 1, so there's no window without break-glass.

## Verification

- **Molecule scenario** (add + retire + lockout guard) wired into `molecule.yml` CI; `prepare.yml` seeds the retired key so converge stays idempotent.
- **Proven end-to-end in a container** (local molecule needs the docker SDK the dev shell lacks, so validated via direct `ansible-playbook` per the documented workaround): converge `changed=2`, **idempotence `changed=0`**, verify confirms new key present / retired key absent / `/root/.ssh` 0700 / lockout guard held.
- `ansible-lint` clean (production profile).

No host is converged by this PR — the role is deny-by-default and ships with empty key lists. Enabling + supplying keys per group_vars is the (gated) rotation step.