### PR TITLE
feat(zfs_pools): register individual datasets as Proxmox zfspool storage

### DIFF
--- a/molecule/zfs_pools/converge.yml
+++ b/molecule/zfs_pools/converge.yml
@@ -8,7 +8,8 @@
     # Mirrors terraform-proxmox ansible_inventory.node_storage["pve2"], the
     # live pve2 contract (tank raidz1 + tank/backups). ZFS/pvesm tasks are
     # skipped under Docker; this proves the role converges and the contract
-    # plumbing resolves.
+    # plumbing resolves. The `splunk` dataset additionally carries `pvesm_id`
+    # to exercise the per-dataset zfspool-registration include gate.
     zfs_pools_from_tofu:
       pools:
         tank:
@@ -25,6 +26,9 @@
               properties:
                 recordsize: "1M"
                 compression: "zstd"
+            splunk:
+              quota: "500G"
+              pvesm_id: tank-splunk
 
   roles:
     - role: zfs_pools

--- a/molecule/zfs_pools/verify.yml
+++ b/molecule/zfs_pools/verify.yml
@@ -14,6 +14,9 @@
               properties:
                 recordsize: "1M"
                 compression: "zstd"
+            splunk:
+              quota: "500G"
+              pvesm_id: tank-splunk
 
   tasks:
     - name: Re-derive pools from the injected node_storage contract
@@ -31,6 +34,15 @@
           - zfs_pools_check.tank.datasets.backups.properties.recordsize == '1M'
           - zfs_pools_check.tank.datasets.backups.properties.compression == 'zstd'
         fail_msg: "node_storage contract did not resolve as expected"
+
+    - name: Assert the per-dataset pvesm_id registration field resolves
+      ansible.builtin.assert:
+        that:
+          # Confirms `pvesm_id` plumbs through the contract, so the
+          # dataset_pvesm_register include gate would fire on a real host.
+          - zfs_pools_check.tank.datasets.splunk.pvesm_id == 'tank-splunk'
+          - zfs_pools_check.tank.datasets.splunk.pvesm_id | length > 0
+        fail_msg: "pvesm_id did not resolve through the node_storage contract"
 
     - name: Probe for ZFS pools (should be absent in the molecule container)
       ansible.builtin.command:

--- a/roles/zfs_pools/README.md
+++ b/roles/zfs_pools/README.md
@@ -119,8 +119,10 @@ which give Splunk a volume-level cap so indexed data can no longer fill a pool.
 
 Registration is gated with `pvesm status --storage <pvesm_id>` and only added
 when absent, so re-runs report no change. It is registered with `-content
-images` on the current node (`proxmox_node_name`, defaulting to the inventory
-hostname). Leave `pvesm_id` unset (the default) to skip registration.
+{{ content | default(['images', 'rootdir']) }}` (both VM and LXC disks by
+default; override per-dataset with `content`) on the current node
+(`proxmox_node_name`, defaulting to the inventory hostname). Leave `pvesm_id`
+unset (the default) to skip registration.
 
 Unlike pool creation, this capability is **not** gated by
 `zfs_pools_allow_create` — it is non-destructive against an already-existing

--- a/roles/zfs_pools/README.md
+++ b/roles/zfs_pools/README.md
@@ -96,6 +96,39 @@ without per-child config; a child can opt out with `sharenfs: "off"` under
 `nfs-kernel-server` is installed and running. Leave it `null` (the default) for
 no export.
 
+### Per-dataset Proxmox storage registration (`pvesm_id`)
+
+`datasets.<name>.pvesm_id` (optional) registers **the dataset itself** as its
+own distinct Proxmox `zfspool` storage ID, so a VM/LXC disk can target the
+dataset directly via `datastore_id`:
+
+```yaml
+datasets:
+  fast-splunk:
+    quota: "500G"
+    pvesm_id: fast-splunk  # register this dataset as its own zfspool storage
+```
+
+**Why a quota is not enough.** A `zfspool`-backed VM disk lands at the pool
+**root** by default (a sibling of any child dataset), so a plain `quota` on a
+child dataset does *not* confine a disk to it. Registering the dataset itself
+(`pvesm add zfspool <pvesm_id> -pool <pool>/<dataset>`) is what makes it a real,
+isolated storage target — the disk lives inside the dataset and is capped by its
+quota. This is the mechanism behind the `fast-splunk` and `bulk-splunk` tiers,
+which give Splunk a volume-level cap so indexed data can no longer fill a pool.
+
+Registration is gated with `pvesm status --storage <pvesm_id>` and only added
+when absent, so re-runs report no change. It is registered with `-content
+images` on the current node (`proxmox_node_name`, defaulting to the inventory
+hostname). Leave `pvesm_id` unset (the default) to skip registration.
+
+Unlike pool creation, this capability is **not** gated by
+`zfs_pools_allow_create` — it is non-destructive against an already-existing
+pool. Creating a *new* pool for a new tier (e.g. `bulk-splunk` on a fresh pool)
+still requires the existing `zfs_pools_allow_create: true` + `zfs_pools_devices`
+opt-in in untracked `host_vars`; only the dataset registration itself runs
+unconditionally on a present pool.
+
 ## Database storage namespace (engine- and tier-agnostic)
 
 A reserved `<pool>/databases/<instance>` namespace standardizes where database
@@ -153,7 +186,8 @@ doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags zfs_pools
   `1T` and `1024G` do not cause spurious changes.
 - Properties: each `properties` entry compared as a string (`zfs get -H -o
   value`) and only `zfs set` when it differs.
-- Registration: `pvesm status --storage <pool>` gates `pvesm add`.
+- Registration: `pvesm status --storage <pool>` gates `pvesm add`; the same
+  check gates per-dataset `pvesm_id` registration.
 
 All ZFS / `pvesm` tasks are skipped under Docker (`ansible_virtualization_type
 == 'docker'`) for molecule testing.

--- a/roles/zfs_pools/defaults/main.yml
+++ b/roles/zfs_pools/defaults/main.yml
@@ -13,7 +13,9 @@ zfs_pools_config: >-
 
 # Map of pools for this node, keyed by pool name. Shape per pool:
 #   { type, raid, protected, register, content,
-#     datasets: { <name>: { quota, mountpoint, nfs_export, properties } } }
+#     datasets: { <name>: { quota, mountpoint, nfs_export, pvesm_id, properties } } }
+# pvesm_id (optional) registers THIS dataset as its own Proxmox zfspool storage
+# ID, so a VM/LXC disk can target the dataset directly (see README).
 # nfs_export (optional) is the exact zfs `sharenfs` value, e.g.
 # "ro=@10.0.0.0/8 ro=@192.168.0.0/16"; children inherit a parent's sharenfs.
 zfs_pools_map: "{{ zfs_pools_config.pools | default({}) }}"

--- a/roles/zfs_pools/tasks/dataset_pvesm_register.yml
+++ b/roles/zfs_pools/tasks/dataset_pvesm_register.yml
@@ -25,7 +25,7 @@
     cmd: >-
       pvesm add zfspool {{ zfs_dataset.value.pvesm_id }}
       -pool {{ zfs_pool.key }}/{{ zfs_dataset.key }}
-      -content images
+      -content {{ zfs_dataset.value.content | default(['images', 'rootdir']) | join(',') }}
       -nodes {{ proxmox_node_name | default(inventory_hostname) }}
   when: zfs_pools_dataset_pvesm_check.rc != 0
   changed_when: true

--- a/roles/zfs_pools/tasks/dataset_pvesm_register.yml
+++ b/roles/zfs_pools/tasks/dataset_pvesm_register.yml
@@ -1,0 +1,33 @@
+---
+# Register a single dataset as its own Proxmox `zfspool` storage ID.
+# Included per-dataset from datasets.yml when `pvesm_id` is set; `zfs_pool` and
+# `zfs_dataset` (dict2items entries) are in scope. A plain ZFS `quota` does NOT
+# make a VM/LXC disk land inside a child dataset — zfspool-backed disks default
+# to the pool root, siblings of any child. Registering the dataset itself as a
+# distinct storage ID (`pvesm add zfspool <pvesm_id> -pool <pool>/<dataset>`)
+# makes it a real, isolated `datastore_id` target that tofu-proxmox can point a
+# disk at, so indexed data is actually capped by the dataset quota. This whole
+# path is already Docker-skipped via the datasets.yml include gate in main.yml,
+# so no per-task docker guard is needed. Non-destructive against an existing
+# pool, so it is NOT gated by zfs_pools_allow_create (that guards zpool create).
+
+- name: "Check Proxmox storage registration for {{ zfs_dataset.value.pvesm_id }}"
+  ansible.builtin.command:
+    cmd: "pvesm status --storage {{ zfs_dataset.value.pvesm_id }}"
+  register: zfs_pools_dataset_pvesm_check
+  changed_when: false
+  failed_when: false
+  tags:
+    - zfs_pools
+
+- name: "Register Proxmox ZFS storage for dataset {{ zfs_pool.key ~ '/' ~ zfs_dataset.key }}"
+  ansible.builtin.command:
+    cmd: >-
+      pvesm add zfspool {{ zfs_dataset.value.pvesm_id }}
+      -pool {{ zfs_pool.key }}/{{ zfs_dataset.key }}
+      -content images
+      -nodes {{ proxmox_node_name | default(inventory_hostname) }}
+  when: zfs_pools_dataset_pvesm_check.rc != 0
+  changed_when: true
+  tags:
+    - zfs_pools

--- a/roles/zfs_pools/tasks/datasets.yml
+++ b/roles/zfs_pools/tasks/datasets.yml
@@ -81,3 +81,19 @@
     - zfs_dataset.value.nfs_export | default('') | length > 0
   tags:
     - zfs_pools
+
+# Optional: register an individual dataset as its own Proxmox `zfspool` storage
+# ID so a VM/LXC disk can target the dataset directly (a plain quota alone does
+# not confine a disk to a child dataset). Only runs for datasets that set
+# `pvesm_id`.
+- name: "Register datasets as Proxmox zfspool storage in pool {{ zfs_pool.key }}"
+  ansible.builtin.include_tasks: dataset_pvesm_register.yml
+  loop: "{{ zfs_pool.value.datasets | default({}) | dict2items }}"
+  loop_control:
+    loop_var: zfs_dataset
+    label: "{{ zfs_pool.key }}/{{ zfs_dataset.key }}"
+  when:
+    - zfs_dataset.value.pvesm_id | default(None) is not none
+    - zfs_dataset.value.pvesm_id | default('') | length > 0
+  tags:
+    - zfs_pools


### PR DESCRIPTION
## What

Adds an optional per-dataset `pvesm_id` field to the `zfs_pools` role. When a dataset in `node_storage` sets `pvesm_id`, the role registers **that dataset** as its own distinct Proxmox `zfspool` storage ID (`pvesm add zfspool <pvesm_id> -pool <pool>/<dataset> -content images -nodes <node>`), so a VM/LXC disk can target the dataset directly via `datastore_id`.

**Why registration, not just a quota:** a `zfspool`-backed VM disk lands at the pool **root** by default (a sibling of any child dataset), so a plain ZFS `quota` on a child dataset does not confine a disk to it. Registering the dataset itself is what makes it a real, isolated storage target — the disk lives inside the dataset and is actually capped by its quota. This is the mechanism behind the upcoming `fast-splunk` and `bulk-splunk` storage tiers in the Splunk storage redesign (fixing the incident where Splunk filled a pool because indexed data had no volume-level cap).

## Changes

- `roles/zfs_pools/tasks/dataset_pvesm_register.yml` (new) — per-dataset `pvesm status` check + conditional `pvesm add`, mirroring the existing pool-level registration and the `nfs_export.yml` / `dataset_properties.yml` conditional-include pattern.
- `roles/zfs_pools/tasks/datasets.yml` — include the new file per dataset, gated on a non-empty `pvesm_id` (same gate shape as the `nfs_export` include).
- `roles/zfs_pools/defaults/main.yml` — document `pvesm_id` in the per-pool shape comment.
- `roles/zfs_pools/README.md` — new "Per-dataset Proxmox storage registration (`pvesm_id`)" section + idempotency note.
- `molecule/zfs_pools/{converge,verify}.yml` — add a `splunk` dataset carrying `pvesm_id` and assert it resolves through the `node_storage` contract (the actual `pvesm` command stays Docker-skipped, matching the existing test approach).

## Compatibility

Purely **additive and backward-compatible** — datasets without `pvesm_id` behave exactly as before; no existing dataset behavior changes. Registration is gated with `pvesm status --storage`, so re-runs report no change. Unlike zpool creation, this capability is **not** gated by `zfs_pools_allow_create` — it is non-destructive against an already-existing pool (confirmed against the role's current gating logic).

## Validation

- `ansible-lint` (production profile): **passes**, 0 failures on 13 files.
- `yamllint`: passes on all changed files.
- `ansible-playbook --syntax-check`: passes on both `converge.yml` and `verify.yml`.
- **NOT run against any real Proxmox host.** A full local `molecule` run was blocked by two pre-existing environment issues (the Python `docker` SDK is absent from the local nix shell, and molecule's VCS-root detection does not resolve `roles_path` from inside a git worktree); CI runs the full molecule suite.

## Follow-up (out of scope, human-gated)

pve2's actual physical disk assignment for the new `bulk-splunk` pool needs a human-supplied by-id device identifier and belongs in host-specific `host_vars/pve2.yml` (a per-host config change, gated on `zfs_pools_allow_create` + `zfs_pools_devices`) — a separate PR, not this role-capability change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESYDi9fsH3ymtn8S4BnJPW