### PR TITLE
fix(node_watchdog): never restart watchdog-mux on a live node

### DIFF
--- a/roles/node_watchdog/handlers/main.yml
+++ b/roles/node_watchdog/handlers/main.yml
@@ -9,12 +9,17 @@
     state: restarted
   when: node_watchdog_arm | default(true)
 
-# watchdog-mux is restarted rather than reloaded because it reads
-# WATCHDOG_MODULE only at start. On a node with active HA services this briefly
-# drops the armed watchdog, which is safe: nothing is being petted during the
-# gap, and the LRM re-arms on reconnect.
-- name: Restart watchdog-mux
-  ansible.builtin.systemd_service:
-    name: watchdog-mux
-    state: restarted
-  failed_when: false
+# There is deliberately no "Restart watchdog-mux" handler. watchdog-mux reads
+# WATCHDOG_MODULE only at start, but restarting it on a node with active HA is
+# what makes this role reset the node it exists to protect: watchdog-mux exits
+# "with active connections", the kernel refuses to disarm the device
+# ("watchdog0: watchdog did not stop!"), and with nothing petting an armed
+# hardware watchdog the board resets seconds later. Observed on a live node,
+# whose journal ends mid-converge on exactly that kernel line.
+- name: Report watchdog module change
+  ansible.builtin.debug:
+    msg: >-
+      WATCHDOG_MODULE is now '{{ node_watchdog_module }}'. watchdog-mux reads it
+      only at start and is deliberately NOT restarted, because that resets a node
+      with active HA. The change takes effect at this node's next reboot; until
+      then the previously loaded module remains in use.

--- a/roles/node_watchdog/tasks/main.yml
+++ b/roles/node_watchdog/tasks/main.yml
@@ -69,7 +69,10 @@
     owner: root
     group: root
     mode: "0644"
-  notify: Restart watchdog-mux
+  # Deliberately notifies a reporting handler, NOT a watchdog-mux restart. See
+  # handlers/main.yml: restarting watchdog-mux on a node with active HA resets
+  # the node this role exists to protect.
+  notify: Report watchdog module change
 
 # --- Layer 2: liveness daemon -------------------------------------------------
 #


### PR DESCRIPTION
This role resets the nodes it exists to protect, and it does so silently — the reboot leaves no panic, so it reads as an unexplained clean restart.

A live node's journal ends mid-converge on exactly this sequence:

```
03:16:57 ansible ... systemd_service name=watchdog-mux state=restarted
03:16:57 watchdog-mux: got terminate request
03:16:57 watchdog-mux: exit watchdog-mux with active connections
03:16:57 systemd: Stopping watchdog-mux.service
03:16:57 kernel: watchdog: watchdog0: watchdog did not stop!
         <- boot ends here; next boot 30s later
```

The kernel refuses to disarm the device on close, so once watchdog-mux stops there is nothing petting an armed hardware watchdog and the board resets.

The removed handler's comment asserted the opposite — that dropping the armed watchdog was safe *because* "nothing is being petted during the gap". That is the failure condition, not a safety property.

`WATCHDOG_MODULE` is read only at watchdog-mux start, so the change now simply takes effect at the node's next reboot, and a handler states that plainly instead of forcing it.

Verified: `ansible-lint` production profile passes (0 failures, 0 warnings).