### PR TITLE
fix(evacuation): verify managed LXC volumes

### DIFF
--- a/.github/workflows/_data-contract.yml
+++ b/.github/workflows/_data-contract.yml
@@ -90,3 +90,8 @@ jobs:
 
       - name: Verify frozen host-bind copy safety contract
         run: python3 tests/pve_frozen_host_bind_copy/test_copy_contract.py
+
+      # Extracted tasks execute against literal TAB-delimited ZFS records and
+      # malformed/ambiguous fixtures, so parser drift fails the PR gate.
+      - name: Verify managed-volume ZFS identity parser regression
+        run: python -m pytest tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py

--- a/molecule/pve_guest_evacuation_lxc_managed_volumes/converge.yml
+++ b/molecule/pve_guest_evacuation_lxc_managed_volumes/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge the inert manifested LXC volume role
+  hosts: all
+  become: true
+  gather_facts: false
+  vars:
+    pve_guest_evacuation_lxc_managed_volumes_enabled: false
+  roles:
+    - role: pve_guest_evacuation_lxc_managed_volumes

--- a/molecule/pve_guest_evacuation_lxc_managed_volumes/molecule.yml
+++ b/molecule/pve_guest_evacuation_lxc_managed_volumes/molecule.yml
@@ -1,0 +1,13 @@
+---
+platforms:
+  - name: pve-guest-evacuation-lxc-managed-volumes-test
+    image: "${MOLECULE_IMAGE:-debian:stable-slim}"
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp
+provisioner:
+  config_options:
+    defaults:
+      roles_path: ${MOLECULE_SCENARIO_DIRECTORY}/../../roles

--- a/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
+++ b/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
@@ -1,0 +1,39 @@
+---
+- name: Verify the manifested LXC volume role remains inert and fail-closed
+  hosts: all
+  become: false
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Assert the inert role created no pve3 evidence directory
+      ansible.builtin.stat:
+        path: /bulk/evacuation-816/evidence
+      register: pve_guest_evacuation_lxc_managed_volumes_evidence_dir
+
+    - name: Assert the inert contract
+      ansible.builtin.assert:
+        that: [not pve_guest_evacuation_lxc_managed_volumes_evidence_dir.stat.exists]
+
+    - name: Exercise the incomplete enabled-input gate
+      block:
+        - name: Run the incomplete managed-volume contract
+          ansible.builtin.include_role:
+            name: pve_guest_evacuation_lxc_managed_volumes
+            tasks_from: preflight_contract.yml
+          vars:
+            pve_guest_evacuation_lxc_managed_volumes_enabled: true
+            pve_guest_evacuation_lxc_managed_volumes_source_node: pve2
+            pve_guest_evacuation_lxc_managed_volumes_target_node: pve540
+            pve_guest_evacuation_lxc_managed_volumes_staging_host: pve3
+            pve_guest_evacuation_lxc_managed_volumes_archive_run_id: archive-1
+            pve_guest_evacuation_lxc_managed_volumes_restore_run_id: restore-1
+            pve_guest_evacuation_lxc_managed_volumes_run_id: transfer-1
+            pve_guest_evacuation_lxc_managed_volumes_expected_vmid: '101'
+      rescue:
+        - name: Record incomplete managed-volume input failure
+          ansible.builtin.set_fact:
+            pve_guest_evacuation_lxc_managed_volumes_input_failed: true
+
+    - name: Assert incomplete managed-volume inputs fail closed
+      ansible.builtin.assert:
+        that: [pve_guest_evacuation_lxc_managed_volumes_input_failed | default(false)]

--- a/playbooks/transfer_evacuated_lxc_managed_volumes.yml
+++ b/playbooks/transfer_evacuated_lxc_managed_volumes.yml
@@ -1,0 +1,10 @@
+---
+# Final stopped-source transfer for managed LXC mpN volumes. This does not
+# create the pve540 CT; restore_evacuated_guest.yml created its empty skeleton.
+- name: Transfer one verified stopped-source LXC managed-volume payload set
+  hosts: "{{ pve_guest_evacuation_lxc_managed_volumes_source_node | default('pve2') }}"
+  become: true
+  gather_facts: false
+  serial: 1
+  roles:
+    - role: pve_guest_evacuation_lxc_managed_volumes

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,4 @@
 ansible-core>=2.21.0,<2.22.0
 molecule>=25.0.0
 molecule-docker>=2.1.0
+pytest>=8.0.0

--- a/roles/pve_guest_evacuation/README.md
+++ b/roles/pve_guest_evacuation/README.md
@@ -11,6 +11,11 @@ the guest gracefully with a force-stop fallback, and produces one `vzdump
 size, SHA-256, `zstd -t`, extracted configuration, and archive verification in an
 atomically-published pve3 evidence file.
 
+VZDump uses the configurable local workspace
+`pve_guest_evacuation_tmpdir` (default `/var/tmp`). Archive output still goes
+to pve3, while the local workspace remains compatible with unprivileged LXC
+UID mappings and the staging export's required `root_squash` policy.
+
 `probe` and `cutover` deliberately fail closed. The role never restores,
 migrates, deletes a source guest, changes cluster membership, or changes any
 storage configuration.

--- a/roles/pve_guest_evacuation/README.md
+++ b/roles/pve_guest_evacuation/README.md
@@ -15,6 +15,8 @@ VZDump uses the configurable local workspace
 `pve_guest_evacuation_tmpdir` (default `/var/tmp`). Archive output still goes
 to pve3, while the local workspace remains compatible with unprivileged LXC
 UID mappings and the staging export's required `root_squash` policy.
+Compression uses Proxmox's native `--zstd 0` auto mode by default, allowing
+half of the source host's CPU cores to compress each subsequent archive.
 
 `probe` and `cutover` deliberately fail closed. The role never restores,
 migrates, deletes a source guest, changes cluster membership, or changes any

--- a/roles/pve_guest_evacuation/defaults/main.yml
+++ b/roles/pve_guest_evacuation/defaults/main.yml
@@ -14,3 +14,6 @@ pve_guest_evacuation_guest_vmid: null
 pve_guest_evacuation_run_id: ""
 pve_guest_evacuation_shutdown_timeout: 180
 pve_guest_evacuation_staging_headroom_percent: 20
+# VZDump's working directory must be local. The staging NFS export uses
+# root_squash, which cannot host the remapped workspace of an unprivileged LXC.
+pve_guest_evacuation_tmpdir: /var/tmp

--- a/roles/pve_guest_evacuation/defaults/main.yml
+++ b/roles/pve_guest_evacuation/defaults/main.yml
@@ -17,3 +17,5 @@ pve_guest_evacuation_staging_headroom_percent: 20
 # VZDump's working directory must be local. The staging NFS export uses
 # root_squash, which cannot host the remapped workspace of an unprivileged LXC.
 pve_guest_evacuation_tmpdir: /var/tmp
+# Zero is Proxmox's native auto mode: use half of the available CPU cores.
+pve_guest_evacuation_zstd_threads: 0

--- a/roles/pve_guest_evacuation/tasks/archive.yml
+++ b/roles/pve_guest_evacuation/tasks/archive.yml
@@ -378,6 +378,8 @@
       - "{{ pve_guest_evacuation_staging_storage }}"
       - --compress
       - zstd
+      - --zstd
+      - "{{ pve_guest_evacuation_zstd_threads | string }}"
       - --tmpdir
       - "{{ pve_guest_evacuation_tmpdir }}"
   register: pve_guest_evacuation_vzdump

--- a/roles/pve_guest_evacuation/tasks/archive.yml
+++ b/roles/pve_guest_evacuation/tasks/archive.yml
@@ -378,6 +378,8 @@
       - "{{ pve_guest_evacuation_staging_storage }}"
       - --compress
       - zstd
+      - --tmpdir
+      - "{{ pve_guest_evacuation_tmpdir }}"
   register: pve_guest_evacuation_vzdump
   changed_when: true
 

--- a/roles/pve_guest_evacuation/tasks/preflight_contract.yml
+++ b/roles/pve_guest_evacuation/tasks/preflight_contract.yml
@@ -24,7 +24,8 @@
       - pve_guest_evacuation_shutdown_timeout | int > 0
       - pve_guest_evacuation_staging_headroom_percent | int >= 0
       - pve_guest_evacuation_tmpdir is match('^/var/tmp(?:/[A-Za-z0-9._-]+)?$')
+      - pve_guest_evacuation_zstd_threads | int >= 0
     fail_msg: >-
       Archive runs only on its declared source with one positive numeric VMID,
-      an explicit pve3 NFS staging endpoint, a local /var/tmp workspace, and a
-      safe run identifier.
+      an explicit pve3 NFS staging endpoint, a local /var/tmp workspace,
+      nonnegative Zstandard thread count, and a safe run identifier.

--- a/roles/pve_guest_evacuation/tasks/preflight_contract.yml
+++ b/roles/pve_guest_evacuation/tasks/preflight_contract.yml
@@ -23,6 +23,8 @@
       - pve_guest_evacuation_run_id is match('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')
       - pve_guest_evacuation_shutdown_timeout | int > 0
       - pve_guest_evacuation_staging_headroom_percent | int >= 0
+      - pve_guest_evacuation_tmpdir is match('^/var/tmp(?:/[A-Za-z0-9._-]+)?$')
     fail_msg: >-
       Archive runs only on its declared source with one positive numeric VMID,
-      an explicit pve3 NFS staging endpoint, and a safe run identifier.
+      an explicit pve3 NFS staging endpoint, a local /var/tmp workspace, and a
+      safe run identifier.

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/README.md
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/README.md
@@ -35,7 +35,10 @@ the stopped pve540 target for investigation.
 
 Supply identity values from the verified archive record and the pending restore
 record. The root-owned source-host SSH identity and known-hosts paths are
-deliberately explicit.
+deliberately explicit. The rsync host normally matches pve540's inventory
+endpoint literally. If it cannot, provide the sole approved alternate spelling
+as a canonical FQDN; it is accepted only when both names resolve on pve2 to a
+shared IPv4 address. Unapproved aliases remain rejected.
 
 ```bash
 doppler run -- ./scripts/run-ansible.sh playbooks/transfer_evacuated_lxc_managed_volumes.yml \
@@ -48,6 +51,7 @@ doppler run -- ./scripts/run-ansible.sh playbooks/transfer_evacuated_lxc_managed
   -e pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256=<archive-sha256> \
   -e pve_guest_evacuation_lxc_managed_volumes_target_storage=<pve540-storage> \
   -e pve_guest_evacuation_lxc_managed_volumes_target_rsync_host=<pve540-inventory-host> \
+  -e pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn=<pve540-canonical-fqdn> \
   -e pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file=<root-only-identity> \
   -e pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file=<root-only-known-hosts>
 ```

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/README.md
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/README.md
@@ -1,0 +1,53 @@
+# pve_guest_evacuation_lxc_managed_volumes
+
+`pve_guest_evacuation_lxc_managed_volumes` is the final data-capture stage for
+an Issue-816 LXC whose `mpN` entries are Proxmox-managed volumes. It exists
+because a VZDump LXC restore can recreate those entries as empty pve540
+skeletons rather than restore their payloads.
+
+The role is inert by default. It is run only on pve2 after
+`pve_guest_evacuation_restore` has written a
+`restore_pending_managed_mount_copy` record with
+`pve_guest_evacuation_restore_lxc_mountpoint_strategy=manifested_copy`.
+
+## Safety contract
+
+Before transferring one byte, it binds the archive evidence, pending restore
+evidence, current pve2 configuration, and current pve540 configuration to the
+same VMID and source digest. Both containers must be stopped. Each `mpN` must
+have the same mount semantics, resolve through `pvesm path` to an existing
+directory, and resolve to exactly one mounted ZFS dataset on each host. The
+new target volume must be completely empty; the role never creates, deletes,
+merges, overwrites, starts, snapshots, or rolls back anything.
+
+The stopped-source transfer uses strict host-key-pinned SSH and rsync with
+numeric ids, ACLs, xattrs, sparse files, hard links, and checksums. A checksum
+dry run must be empty afterwards. For each volume it then compares deterministic
+byte count, regular-file count, metadata, content, hard-link, numeric ACL, and
+hex xattr manifests. The final evidence includes exact source/target volume
+IDs, resolved paths, and ZFS dataset identities.
+
+Evidence is a new root-only file on pve3. Existing final or temporary paths
+fail closed. A failed transfer writes one immutable failure record and preserves
+the stopped pve540 target for investigation.
+
+## Invocation
+
+Supply identity values from the verified archive record and the pending restore
+record. The root-owned source-host SSH identity and known-hosts paths are
+deliberately explicit.
+
+```bash
+doppler run -- ./scripts/run-ansible.sh playbooks/transfer_evacuated_lxc_managed_volumes.yml \
+  -e pve_guest_evacuation_lxc_managed_volumes_enabled=true \
+  -e pve_guest_evacuation_lxc_managed_volumes_archive_run_id=<archive-run-id> \
+  -e pve_guest_evacuation_lxc_managed_volumes_restore_run_id=<restore-run-id> \
+  -e pve_guest_evacuation_lxc_managed_volumes_run_id=<new-volume-run-id> \
+  -e pve_guest_evacuation_lxc_managed_volumes_expected_vmid=<vmid> \
+  -e pve_guest_evacuation_lxc_managed_volumes_expected_config_digest=<source-config-digest> \
+  -e pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256=<archive-sha256> \
+  -e pve_guest_evacuation_lxc_managed_volumes_target_storage=<pve540-storage> \
+  -e pve_guest_evacuation_lxc_managed_volumes_target_rsync_host=<pve540-inventory-host> \
+  -e pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file=<root-only-identity> \
+  -e pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file=<root-only-known-hosts>
+```

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/defaults/main.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/defaults/main.yml
@@ -15,9 +15,14 @@ pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256: ""
 pve_guest_evacuation_lxc_managed_volumes_target_storage: ""
 
 # The source host owns the dedicated, reviewed transport material. The role
-# proves it is root-owned and bound to the pve540 inventory endpoint before it
-# invokes rsync.
+# proves it is root-owned and bound to the pve540 inventory endpoint, or the
+# explicitly approved canonical FQDN which resolves on pve2 to that endpoint's
+# IPv4 address, before it invokes rsync.
 pve_guest_evacuation_lxc_managed_volumes_target_rsync_host: ""
+# Set only when the inventory endpoint cannot be used literally. This is the
+# sole approved alternate spelling; unapproved aliases and IP literals are
+# rejected.
+pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn: ""
 pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file: ""
 pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file: ""
 

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/defaults/main.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# Final, stopped-source transfer for LXC-managed mpN volumes. This role is
+# deliberately inert and never creates, removes, starts, or overwrites a CT.
+pve_guest_evacuation_lxc_managed_volumes_enabled: false
+pve_guest_evacuation_lxc_managed_volumes_source_node: pve2
+pve_guest_evacuation_lxc_managed_volumes_target_node: pve540
+pve_guest_evacuation_lxc_managed_volumes_staging_host: pve3
+pve_guest_evacuation_lxc_managed_volumes_evidence_dir: /bulk/evacuation-816/evidence
+pve_guest_evacuation_lxc_managed_volumes_archive_run_id: ""
+pve_guest_evacuation_lxc_managed_volumes_restore_run_id: ""
+pve_guest_evacuation_lxc_managed_volumes_run_id: ""
+pve_guest_evacuation_lxc_managed_volumes_expected_vmid: null
+pve_guest_evacuation_lxc_managed_volumes_expected_config_digest: ""
+pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256: ""
+pve_guest_evacuation_lxc_managed_volumes_target_storage: ""
+
+# The source host owns the dedicated, reviewed transport material. The role
+# proves it is root-owned and bound to the pve540 inventory endpoint before it
+# invokes rsync.
+pve_guest_evacuation_lxc_managed_volumes_target_rsync_host: ""
+pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file: ""
+pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file: ""
+
+pve_guest_evacuation_lxc_managed_volumes_archive_evidence_path: >-
+  {{ pve_guest_evacuation_lxc_managed_volumes_evidence_dir }}/{{ pve_guest_evacuation_lxc_managed_volumes_archive_run_id }}-{{ pve_guest_evacuation_lxc_managed_volumes_expected_vmid }}.json
+pve_guest_evacuation_lxc_managed_volumes_restore_evidence_path: >-
+  {{ pve_guest_evacuation_lxc_managed_volumes_evidence_dir }}/restore-{{ pve_guest_evacuation_lxc_managed_volumes_restore_run_id }}-{{ pve_guest_evacuation_lxc_managed_volumes_expected_vmid }}.json
+pve_guest_evacuation_lxc_managed_volumes_result_evidence_path: >-
+  {{ pve_guest_evacuation_lxc_managed_volumes_evidence_dir }}/managed-volumes-{{ pve_guest_evacuation_lxc_managed_volumes_run_id }}-{{ pve_guest_evacuation_lxc_managed_volumes_expected_vmid }}.json

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/meta/main.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/meta/main.yml
@@ -1,0 +1,8 @@
+---
+galaxy_info:
+  role_name: pve_guest_evacuation_lxc_managed_volumes
+  author: dryvist
+  description: Manifest-verified stopped-source LXC mpN evacuation transfer
+  license: MIT
+  min_ansible_version: '2.19'
+dependencies: []

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/main.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Validate the enabled managed-volume transfer contract
+  ansible.builtin.include_tasks: preflight_contract.yml
+  when: pve_guest_evacuation_lxc_managed_volumes_enabled | bool
+  tags:
+    - pve_guest_evacuation_lxc_managed_volumes
+    - migration
+
+- name: Transfer one manifested LXC mpN payload set
+  when: pve_guest_evacuation_lxc_managed_volumes_enabled | bool
+  tags:
+    - pve_guest_evacuation_lxc_managed_volumes
+    - migration
+  block:
+    - name: Run the stopped-source managed-volume transfer
+      ansible.builtin.include_tasks: transfer.yml
+  rescue:
+    - name: Record the managed-volume transfer failure
+      ansible.builtin.set_fact:
+        pve_guest_evacuation_lxc_managed_volumes_failure:
+          task: "{{ ansible_failed_task.name | default('unknown') }}"
+          message: >-
+            {{ ansible_failed_result.msg
+               | default(ansible_failed_result.stderr | default('no failure detail returned')) }}
+
+    - name: Preserve a failed managed-volume transfer evidence record
+      ansible.builtin.include_tasks: write_evidence.yml
+      vars:
+        pve_guest_evacuation_lxc_managed_volumes_checkpoint: transfer_failed
+      when: pve_guest_evacuation_lxc_managed_volumes_evidence_paths is defined
+
+    - name: Stop after preserving target state for investigation
+      ansible.builtin.fail:
+        msg: >-
+          Managed-volume transfer stopped at
+          {{ pve_guest_evacuation_lxc_managed_volumes_failure.task }}. Any
+          pve540 target state is preserved; this role performs no rollback,
+          deletion, snapshot, or retry-in-place.

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
@@ -19,7 +19,6 @@
       - pve_guest_evacuation_lxc_managed_volumes_target_storage is match('^[a-z0-9][a-z0-9_-]{0,39}$')
       - pve_guest_evacuation_lxc_managed_volumes_target_rsync_host is match('^[A-Za-z0-9][A-Za-z0-9.-]*$')
       - hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host is defined
-      - pve_guest_evacuation_lxc_managed_volumes_target_rsync_host == hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
       - pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file is match('^/root/[A-Za-z0-9._/-]+$')
       - pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file is match('^/root/[A-Za-z0-9._/-]+$')
       - pve_guest_evacuation_lxc_managed_volumes_archive_evidence_path is match('^/bulk/evacuation-816/evidence/[^/ ]+[.]json$')
@@ -29,4 +28,75 @@
       Managed-volume transfer runs only from pve2 to standalone pve540 with
       exact archive and pending-restore evidence, explicit storage, reviewed
       root transport files, and a new immutable evidence run id.
+    quiet: true
+
+- name: Resolve the approved pve540 canonical FQDN from pve2
+  ansible.builtin.command:
+    argv:
+      - getent
+      - ahostsv4
+      - "{{ pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_resolution
+  changed_when: false
+  failed_when: false
+  when: >-
+    pve_guest_evacuation_lxc_managed_volumes_target_rsync_host
+    != hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
+
+- name: Resolve the pve540 inventory endpoint from pve2
+  ansible.builtin.command:
+    argv:
+      - getent
+      - ahostsv4
+      - "{{ hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_resolution
+  changed_when: false
+  failed_when: false
+  when: >-
+    pve_guest_evacuation_lxc_managed_volumes_target_rsync_host
+    != hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
+
+- name: Derive pve2 IPv4 resolutions for the approved pve540 endpoint
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_ipv4s: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_resolution.stdout_lines
+         | map('split') | map('first')
+         | select('match', '^([0-9]{1,3}\\.){3}[0-9]{1,3}$') | unique | list }}
+    pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_ipv4s: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_resolution.stdout_lines
+         | map('split') | map('first')
+         | select('match', '^([0-9]{1,3}\\.){3}[0-9]{1,3}$') | unique | list }}
+  when: >-
+    pve_guest_evacuation_lxc_managed_volumes_target_rsync_host
+    != hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
+
+- name: Require the literal inventory endpoint or its verified canonical FQDN
+  ansible.builtin.assert:
+    that:
+      - >-
+        pve_guest_evacuation_lxc_managed_volumes_target_rsync_host
+        == hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
+        or (
+          pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn
+          is match('^[A-Za-z0-9][A-Za-z0-9-]*(\\.[A-Za-z0-9][A-Za-z0-9-]*)+$')
+          and pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn
+              is not match('^([0-9]{1,3}\\.){3}[0-9]{1,3}$')
+          and pve_guest_evacuation_lxc_managed_volumes_target_rsync_host
+              == pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn
+          and pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_resolution.rc == 0
+          and pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_resolution.rc == 0
+          and pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_ipv4s | length > 0
+          and pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_ipv4s | length > 0
+          and (
+            pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_ipv4s
+            | intersect(pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_ipv4s)
+            | length > 0
+          )
+        )
+    fail_msg: >-
+      The source-host rsync endpoint must be the literal pve540 inventory
+      endpoint or the explicitly approved canonical FQDN. On pve2, that FQDN
+      and the inventory endpoint must both resolve to a shared IPv4 address;
+      unapproved aliases, IP literals, missing DNS results, and mismatches are
+      rejected.
     quiet: true

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
@@ -61,11 +61,11 @@
     pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_ipv4s: >-
       {{ pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_resolution.stdout_lines
          | map('split') | map('first')
-         | select('match', '^([0-9]{1,3}\\.){3}[0-9]{1,3}$') | unique | list }}
+         | select('match', '^([0-9]{1,3}\.){3}[0-9]{1,3}$') | unique | list }}
     pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_ipv4s: >-
       {{ pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_resolution.stdout_lines
          | map('split') | map('first')
-         | select('match', '^([0-9]{1,3}\\.){3}[0-9]{1,3}$') | unique | list }}
+         | select('match', '^([0-9]{1,3}\.){3}[0-9]{1,3}$') | unique | list }}
   when: >-
     pve_guest_evacuation_lxc_managed_volumes_target_rsync_host
     != hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
@@ -78,9 +78,9 @@
         == hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
         or (
           pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn
-          is match('^[A-Za-z0-9][A-Za-z0-9-]*(\\.[A-Za-z0-9][A-Za-z0-9-]*)+$')
+          is match('^[A-Za-z0-9][A-Za-z0-9-]*(\.[A-Za-z0-9][A-Za-z0-9-]*)+$')
           and pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn
-              is not match('^([0-9]{1,3}\\.){3}[0-9]{1,3}$')
+          is not match('^([0-9]{1,3}\.){3}[0-9]{1,3}$')
           and pve_guest_evacuation_lxc_managed_volumes_target_rsync_host
               == pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn
           and pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_resolution.rc == 0

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
@@ -1,0 +1,31 @@
+---
+- name: Validate the exact managed-volume transfer invocation
+  ansible.builtin.assert:
+    that:
+      - inventory_hostname == pve_guest_evacuation_lxc_managed_volumes_source_node
+      - pve_guest_evacuation_lxc_managed_volumes_source_node == 'pve2'
+      - pve_guest_evacuation_lxc_managed_volumes_target_node == 'pve540'
+      - pve_guest_evacuation_lxc_managed_volumes_staging_host == 'pve3'
+      - pve_guest_evacuation_lxc_managed_volumes_target_node in hostvars
+      - pve_guest_evacuation_lxc_managed_volumes_staging_host in hostvars
+      - pve_guest_evacuation_lxc_managed_volumes_evidence_dir == '/bulk/evacuation-816/evidence'
+      - pve_guest_evacuation_lxc_managed_volumes_archive_run_id is match('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')
+      - pve_guest_evacuation_lxc_managed_volumes_restore_run_id is match('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')
+      - pve_guest_evacuation_lxc_managed_volumes_run_id is match('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')
+      - pve_guest_evacuation_lxc_managed_volumes_restore_run_id != pve_guest_evacuation_lxc_managed_volumes_run_id
+      - pve_guest_evacuation_lxc_managed_volumes_expected_vmid | string is match('^[1-9][0-9]*$')
+      - pve_guest_evacuation_lxc_managed_volumes_expected_config_digest is match('^[A-Fa-f0-9]{40,64}$')
+      - pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256 is match('^[A-Fa-f0-9]{64}$')
+      - pve_guest_evacuation_lxc_managed_volumes_target_storage is match('^[a-z0-9][a-z0-9_-]{0,39}$')
+      - pve_guest_evacuation_lxc_managed_volumes_target_rsync_host is match('^[A-Za-z0-9][A-Za-z0-9.-]*$')
+      - pve_guest_evacuation_lxc_managed_volumes_target_rsync_host == hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
+      - pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file is match('^/root/[A-Za-z0-9._/-]+$')
+      - pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file is match('^/root/[A-Za-z0-9._/-]+$')
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence_path is match('^/bulk/evacuation-816/evidence/[^/ ]+[.]json$')
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence_path is match('^/bulk/evacuation-816/evidence/restore-[^/ ]+[.]json$')
+      - pve_guest_evacuation_lxc_managed_volumes_result_evidence_path is match('^/bulk/evacuation-816/evidence/managed-volumes-[^/ ]+[.]json$')
+    fail_msg: >-
+      Managed-volume transfer runs only from pve2 to standalone pve540 with
+      exact archive and pending-restore evidence, explicit storage, reviewed
+      root transport files, and a new immutable evidence run id.
+    quiet: true

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
@@ -18,6 +18,7 @@
       - pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256 is match('^[A-Fa-f0-9]{64}$')
       - pve_guest_evacuation_lxc_managed_volumes_target_storage is match('^[a-z0-9][a-z0-9_-]{0,39}$')
       - pve_guest_evacuation_lxc_managed_volumes_target_rsync_host is match('^[A-Za-z0-9][A-Za-z0-9.-]*$')
+      - hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host is defined
       - pve_guest_evacuation_lxc_managed_volumes_target_rsync_host == hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host
       - pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file is match('^/root/[A-Za-z0-9._/-]+$')
       - pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file is match('^/root/[A-Za-z0-9._/-]+$')

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
@@ -140,11 +140,11 @@
         == pve_guest_evacuation_lxc_managed_volumes_target_mount_items | map(attribute='key') | list
       - >-
         pve_guest_evacuation_lxc_managed_volumes_source_mount_items
-        | map(attribute='value') | select('match', '^[A-Za-z0-9][A-Za-z0-9._-]*:[^,]+,mp=/[^,]+') | list | length
+        | map(attribute='value') | select('match', '^[A-Za-z0-9][A-Za-z0-9._-]*:[^,]+,(?:[^,]+,)*mp=/[^,]+') | list | length
         == pve_guest_evacuation_lxc_managed_volumes_source_mount_items | length
       - >-
         pve_guest_evacuation_lxc_managed_volumes_target_mount_items
-        | map(attribute='value') | select('match', '^' ~ (pve_guest_evacuation_lxc_managed_volumes_target_storage | regex_escape) ~ ':[^,]+,mp=/[^,]+') | list | length
+        | map(attribute='value') | select('match', '^' ~ (pve_guest_evacuation_lxc_managed_volumes_target_storage | regex_escape) ~ ':[^,]+,(?:[^,]+,)*mp=/[^,]+') | list | length
         == pve_guest_evacuation_lxc_managed_volumes_target_mount_items | length
     fail_msg: >-
       The source and target do not have exactly the same managed mpN keys, or
@@ -443,7 +443,7 @@
     printf 'files '
     find . -xdev -type f -printf . | wc -c
     printf 'metadata '
-    find . -xdev -printf '%y\t%m\t%u\t%g\t%s\t%T@\t%l\t%p\0' | LC_ALL=C sort -z | sha256sum
+    find . -xdev -printf '%y\t%m\t%U\t%G\t%s\t%T@\t%l\t%p\0' | LC_ALL=C sort -z | sha256sum
     printf 'content '
     find . -xdev -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum | sha256sum
     printf 'hardlinks '
@@ -467,7 +467,7 @@
     printf 'files '
     find . -xdev -type f -printf . | wc -c
     printf 'metadata '
-    find . -xdev -printf '%y\t%m\t%u\t%g\t%s\t%T@\t%l\t%p\0' | LC_ALL=C sort -z | sha256sum
+    find . -xdev -printf '%y\t%m\t%U\t%G\t%s\t%T@\t%l\t%p\0' | LC_ALL=C sort -z | sha256sum
     printf 'content '
     find . -xdev -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum | sha256sum
     printf 'hardlinks '

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
@@ -3,6 +3,47 @@
 # bind a fresh pve540 skeleton to the stopped pve2 source. It never uses a ZFS
 # snapshot and never creates a destination volume or directory.
 
+- name: Read pve3 managed-volume evidence directory metadata
+  ansible.builtin.stat:
+    path: "{{ pve_guest_evacuation_lxc_managed_volumes_evidence_dir }}"
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_evidence_dir_stat
+  changed_when: false
+
+- name: Require a root-only non-symlink pve3 evidence directory
+  ansible.builtin.assert:
+    that:
+      - pve_guest_evacuation_lxc_managed_volumes_evidence_dir_stat.stat.exists | default(false)
+      - pve_guest_evacuation_lxc_managed_volumes_evidence_dir_stat.stat.isdir | default(false)
+      - not (pve_guest_evacuation_lxc_managed_volumes_evidence_dir_stat.stat.islnk | default(false))
+      - pve_guest_evacuation_lxc_managed_volumes_evidence_dir_stat.stat.pw_name == 'root'
+      - pve_guest_evacuation_lxc_managed_volumes_evidence_dir_stat.stat.gr_name == 'root'
+      - pve_guest_evacuation_lxc_managed_volumes_evidence_dir_stat.stat.mode == '0700'
+    fail_msg: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_evidence_dir }} must remain a
+      root-owned, non-symlink directory with mode 0700 before this transfer
+      trusts archive/restore evidence or writes its result.
+    quiet: true
+
+# Reserve the immutable evidence name before every transfer gate.  This lets
+# the rescue path record failures before any payload is copied.
+- name: Check managed-volume evidence paths before transfer gates
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+  loop:
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}"
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}.tmp"
+  register: pve_guest_evacuation_lxc_managed_volumes_evidence_paths
+  changed_when: false
+
+- name: Require unused immutable managed-volume evidence paths
+  ansible.builtin.assert:
+    that: [not item.stat.exists]
+    fail_msg: "Evidence path {{ item.item }} already exists; choose a new run id."
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_evidence_paths.results }}"
+
 - name: Read pve3 archive and pending-restore evidence
   ansible.builtin.slurp:
     src: "{{ item }}"
@@ -338,24 +379,6 @@
       -o UserKnownHostsFile={{ pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file }}
       -o GlobalKnownHostsFile=/dev/null -o PasswordAuthentication=no
       -o KbdInteractiveAuthentication=no -T
-
-# The evidence file is intentionally written only once at completion or
-# failure. Check its paths now so a copied payload can never replace evidence.
-- name: Check managed-volume evidence paths before copying
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
-  loop:
-    - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}"
-    - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}.tmp"
-  register: pve_guest_evacuation_lxc_managed_volumes_evidence_paths
-
-- name: Require unused immutable managed-volume evidence paths
-  ansible.builtin.assert:
-    that: [not item.stat.exists]
-    fail_msg: "Evidence path {{ item.item }} already exists; choose a new run id."
-    quiet: true
-  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_evidence_paths.results }}"
 
 - name: Copy each stopped-source managed volume without overwrite or deletion
   ansible.builtin.command:

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
@@ -436,7 +436,7 @@
 
 - name: Build deterministic source byte file metadata ACL xattr manifests
   ansible.builtin.shell: |
-    set -o pipefail
+    set -euo pipefail
     cd -- {{ item.source_path | quote }}
     printf 'bytes '
     find . -xdev -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }'
@@ -460,7 +460,7 @@
 
 - name: Build deterministic target byte file metadata ACL xattr manifests
   ansible.builtin.shell: |
-    set -o pipefail
+    set -euo pipefail
     cd -- {{ item.target_path | quote }}
     printf 'bytes '
     find . -xdev -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }'

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
@@ -1,0 +1,479 @@
+---
+# This procedure deliberately copies only after archive and restore evidence
+# bind a fresh pve540 skeleton to the stopped pve2 source. It never uses a ZFS
+# snapshot and never creates a destination volume or directory.
+
+- name: Read pve3 archive and pending-restore evidence
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+  loop:
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_archive_evidence_path }}"
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_restore_evidence_path }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_evidence_raw
+
+- name: Decode pve3 archive and pending-restore evidence
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_archive_evidence: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_evidence_raw.results[0].content | b64decode | from_json }}
+    pve_guest_evacuation_lxc_managed_volumes_restore_evidence: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_evidence_raw.results[1].content | b64decode | from_json }}
+
+- name: Require exact verified archive and pending managed-volume restore evidence
+  ansible.builtin.assert:
+    that:
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.schema_version | int == 1
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.checkpoint == 'archive_verified'
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.run_id == pve_guest_evacuation_lxc_managed_volumes_archive_run_id
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.guest.vmid | int == pve_guest_evacuation_lxc_managed_volumes_expected_vmid | int
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.guest.type == 'lxc'
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.guest.source_node == pve_guest_evacuation_lxc_managed_volumes_source_node
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.guest.target_node == pve_guest_evacuation_lxc_managed_volumes_target_node
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.guest.config_digest == pve_guest_evacuation_lxc_managed_volumes_expected_config_digest
+      - pve_guest_evacuation_lxc_managed_volumes_archive_evidence.archive.sha256 == pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.checkpoint == 'restore_pending_managed_mount_copy'
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.restore_run_id == pve_guest_evacuation_lxc_managed_volumes_restore_run_id
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.input_archive_evidence.archive_run_id == pve_guest_evacuation_lxc_managed_volumes_archive_run_id
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.input_archive_evidence.vmid | int == pve_guest_evacuation_lxc_managed_volumes_expected_vmid | int
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.input_archive_evidence.type == 'lxc'
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.input_archive_evidence.source_config_digest == pve_guest_evacuation_lxc_managed_volumes_expected_config_digest
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.input_archive_evidence.archive_sha256 == pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.target.node == pve_guest_evacuation_lxc_managed_volumes_target_node
+      - pve_guest_evacuation_lxc_managed_volumes_restore_evidence.target.storage == pve_guest_evacuation_lxc_managed_volumes_target_storage
+    fail_msg: >-
+      Archive and pending restore evidence do not prove the exact same stopped
+      pve2 LXC and fresh pve540 target. Preserve both records and investigate.
+    quiet: true
+
+- name: Read current source and target LXC configuration and status
+  ansible.builtin.command:
+    argv:
+      - pvesh
+      - get
+      - "/nodes/{{ item.node }}/lxc/{{ pve_guest_evacuation_lxc_managed_volumes_expected_vmid }}/{{ item.endpoint }}"
+      - --output-format
+      - json
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_target_node if item.node == pve_guest_evacuation_lxc_managed_volumes_target_node else inventory_hostname }}"
+  loop:
+    - { side: source, node: "{{ pve_guest_evacuation_lxc_managed_volumes_source_node }}", endpoint: config }
+    - { side: source, node: "{{ pve_guest_evacuation_lxc_managed_volumes_source_node }}", endpoint: status/current }
+    - { side: target, node: "{{ pve_guest_evacuation_lxc_managed_volumes_target_node }}", endpoint: config }
+    - { side: target, node: "{{ pve_guest_evacuation_lxc_managed_volumes_target_node }}", endpoint: status/current }
+  register: pve_guest_evacuation_lxc_managed_volumes_guest_raw
+  changed_when: false
+
+- name: Decode current source and target LXC state
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_source_config: "{{ pve_guest_evacuation_lxc_managed_volumes_guest_raw.results[0].stdout | from_json }}"
+    pve_guest_evacuation_lxc_managed_volumes_source_status: "{{ pve_guest_evacuation_lxc_managed_volumes_guest_raw.results[1].stdout | from_json }}"
+    pve_guest_evacuation_lxc_managed_volumes_target_config: "{{ pve_guest_evacuation_lxc_managed_volumes_guest_raw.results[2].stdout | from_json }}"
+    pve_guest_evacuation_lxc_managed_volumes_target_status: "{{ pve_guest_evacuation_lxc_managed_volumes_guest_raw.results[3].stdout | from_json }}"
+
+- name: Require final stopped source and stopped restored target
+  ansible.builtin.assert:
+    that:
+      - pve_guest_evacuation_lxc_managed_volumes_source_config.digest == pve_guest_evacuation_lxc_managed_volumes_expected_config_digest
+      - pve_guest_evacuation_lxc_managed_volumes_source_status.status == 'stopped'
+      - pve_guest_evacuation_lxc_managed_volumes_target_status.status == 'stopped'
+      - pve_guest_evacuation_lxc_managed_volumes_target_config.digest == pve_guest_evacuation_lxc_managed_volumes_restore_evidence.target.config_digest
+    fail_msg: >-
+      Source configuration changed or either LXC is running. The final capture
+      requires the archived pve2 configuration and both containers stopped.
+    quiet: true
+
+- name: Record source managed mountpoint keys
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_source_mount_items: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_source_config | dict2items
+         | selectattr('key', 'match', '^mp[0-9]+$') | list | sort(attribute='key') }}
+    pve_guest_evacuation_lxc_managed_volumes_target_mount_items: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_target_config | dict2items
+         | selectattr('key', 'match', '^mp[0-9]+$') | list | sort(attribute='key') }}
+
+- name: Require an exact managed-volume configuration contract
+  ansible.builtin.assert:
+    that:
+      - pve_guest_evacuation_lxc_managed_volumes_source_mount_items | length > 0
+      - >-
+        pve_guest_evacuation_lxc_managed_volumes_source_mount_items | map(attribute='key') | list
+        == pve_guest_evacuation_lxc_managed_volumes_target_mount_items | map(attribute='key') | list
+      - >-
+        pve_guest_evacuation_lxc_managed_volumes_source_mount_items
+        | map(attribute='value') | select('match', '^[A-Za-z0-9][A-Za-z0-9._-]*:[^,]+,mp=/[^,]+') | list | length
+        == pve_guest_evacuation_lxc_managed_volumes_source_mount_items | length
+      - >-
+        pve_guest_evacuation_lxc_managed_volumes_target_mount_items
+        | map(attribute='value') | select('match', '^' ~ (pve_guest_evacuation_lxc_managed_volumes_target_storage | regex_escape) ~ ':[^,]+,mp=/[^,]+') | list | length
+        == pve_guest_evacuation_lxc_managed_volumes_target_mount_items | length
+    fail_msg: >-
+      The source and target do not have exactly the same managed mpN keys, or
+      a mount is external, unbacked, or outside the explicit target storage.
+    quiet: true
+
+- name: Build exact source-to-target managed-volume mappings
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_mappings: >-
+      {{ (pve_guest_evacuation_lxc_managed_volumes_mappings | default([])) + [
+        {
+          'key': item.key,
+          'source_config': item.value,
+          'target_config': (pve_guest_evacuation_lxc_managed_volumes_target_mount_items
+                            | selectattr('key', 'equalto', item.key)
+                            | map(attribute='value') | first),
+          'source_volid': (item.value | regex_replace(',.*$', '')),
+          'target_volid': ((pve_guest_evacuation_lxc_managed_volumes_target_mount_items
+                            | selectattr('key', 'equalto', item.key)
+                            | map(attribute='value') | first | regex_replace(',.*$', ''))),
+          'normalized_mount_contract': (item.value | regex_replace('^[^,]+', 'VOLUME'))
+        }
+      ] }}
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_source_mount_items }}"
+
+- name: Require target mounts preserve every source mount option
+  ansible.builtin.assert:
+    that:
+      - item.normalized_mount_contract == item.target_config | regex_replace('^[^,]+', 'VOLUME')
+    fail_msg: >-
+      {{ item.key }} changes mount semantics between pve2 and pve540. Preserve
+      the stopped target and correct its configuration before transferring.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_mappings }}"
+
+- name: Resolve each source managed volume path
+  ansible.builtin.command:
+    argv: [pvesm, path, "{{ item.source_volid }}"]
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_mappings }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_source_volume_paths
+  changed_when: false
+
+- name: Resolve each target managed volume path
+  ansible.builtin.command:
+    argv: [pvesm, path, "{{ item.target_volid }}"]
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_target_node }}"
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_mappings }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_target_volume_paths
+  changed_when: false
+
+- name: Bind resolved paths to their exact mpN volume identities
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_resolved_mappings: >-
+      {{ (pve_guest_evacuation_lxc_managed_volumes_resolved_mappings | default([])) + [
+        item | combine({
+          'source_path': pve_guest_evacuation_lxc_managed_volumes_source_volume_paths.results[volume_index].stdout | trim,
+          'target_path': pve_guest_evacuation_lxc_managed_volumes_target_volume_paths.results[volume_index].stdout | trim
+        })
+      ] }}
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_mappings }}"
+  loop_control:
+    index_var: volume_index
+
+- name: Require each resolved volume path to be an existing directory
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_volume_path_checks: >-
+      {{ (pve_guest_evacuation_lxc_managed_volumes_volume_path_checks | default([])) + [
+        {'key': item.key, 'side': 'source', 'path': item.source_path},
+        {'key': item.key, 'side': 'target', 'path': item.target_path}
+      ] }}
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_resolved_mappings }}"
+
+- name: Read each resolved source and target volume path
+  ansible.builtin.stat:
+    path: "{{ item.path }}"
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_target_node if item.side == 'target' else inventory_hostname }}"
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_volume_path_checks }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_volume_stats
+  changed_when: false
+
+- name: Assert every resolved managed volume is a directory
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists | default(false)
+      - item.stat.isdir | default(false)
+      - not (item.stat.islnk | default(false))
+    fail_msg: >-
+      {{ item.item.key }} {{ item.item.side }} volume is not a real managed
+      directory. Block transfer rather than copying an ambiguous path.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_volume_stats.results }}"
+
+- name: Read source and target ZFS filesystem identity inventories
+  ansible.builtin.command:
+    argv: [zfs, list, -H, -p, -t, filesystem, -o, 'name,mountpoint']
+  delegate_to: "{{ item }}"
+  loop:
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_source_node }}"
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_target_node }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems
+  changed_when: false
+
+- name: Record exact ZFS dataset identities for every managed volume
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_dataset_mappings: >-
+      {{ (pve_guest_evacuation_lxc_managed_volumes_dataset_mappings | default([])) + [
+        item | combine({
+          'source_dataset_identity': (pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems.results[0].stdout_lines
+                                      | select('match', '^.+\\t' ~ (item.source_path | regex_escape) ~ '$') | list),
+          'target_dataset_identity': (pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems.results[1].stdout_lines
+                                      | select('match', '^.+\\t' ~ (item.target_path | regex_escape) ~ '$') | list)
+        })
+      ] }}
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_resolved_mappings }}"
+
+- name: Require one exact ZFS dataset identity for each source and target volume
+  ansible.builtin.assert:
+    that:
+      - item.source_dataset_identity | length == 1
+      - item.target_dataset_identity | length == 1
+    fail_msg: >-
+      {{ item.key }} does not resolve to exactly one mounted ZFS dataset on
+      both hosts. No copy can proceed without exact dataset identities.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
+
+- name: Assert no ZFS snapshots exist on either evacuation node
+  ansible.builtin.command:
+    argv: [zfs, list, -H, -t, snapshot, -o, name]
+  delegate_to: "{{ item }}"
+  loop:
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_source_node }}"
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_target_node }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_snapshots
+  changed_when: false
+
+- name: Refuse transfer when either evacuation node has a snapshot
+  ansible.builtin.assert:
+    that: [item.stdout | trim | length == 0]
+    fail_msg: >-
+      {{ item.item }} has ZFS snapshots. This workflow neither creates nor
+      uses snapshots; remove the ambiguity before a final stopped-source copy.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_snapshots.results }}"
+
+- name: Require the target managed volumes to be empty skeletons
+  ansible.builtin.command:
+    argv: [find, "{{ item.target_path }}", -xdev, -mindepth, '1', -print, -quit]
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_target_node }}"
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_target_contents
+  changed_when: false
+
+- name: Refuse to overwrite any preexisting target managed-volume content
+  ansible.builtin.assert:
+    that: [item.stdout | trim | length == 0]
+    fail_msg: >-
+      Target {{ item.item.key }} at {{ item.item.target_path }} is nonempty.
+      This workflow never overwrites, merges with, or deletes target payloads.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_target_contents.results }}"
+
+- name: Require metadata manifest tools on pve2 and pve540
+  ansible.builtin.command:
+    argv: ["{{ item.tool }}", --version]
+  delegate_to: "{{ item.node }}"
+  loop: >-
+    {{ [{'node': pve_guest_evacuation_lxc_managed_volumes_source_node, 'tool': 'rsync'},
+        {'node': pve_guest_evacuation_lxc_managed_volumes_source_node, 'tool': 'getfacl'},
+        {'node': pve_guest_evacuation_lxc_managed_volumes_source_node, 'tool': 'getfattr'},
+        {'node': pve_guest_evacuation_lxc_managed_volumes_target_node, 'tool': 'rsync'},
+        {'node': pve_guest_evacuation_lxc_managed_volumes_target_node, 'tool': 'getfacl'},
+        {'node': pve_guest_evacuation_lxc_managed_volumes_target_node, 'tool': 'getfattr'}] }}
+  changed_when: false
+
+- name: Require protected dedicated source-host rsync transport files
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file }}"
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_transport_files
+  changed_when: false
+
+- name: Assert source-host rsync transport files are root-owned and protected
+  ansible.builtin.assert:
+    that:
+      - item.stat.isreg | default(false)
+      - item.stat.pw_name == 'root'
+      - item.stat.gr_name == 'root'
+      - item.stat.mode in ['0400', '0600']
+    fail_msg: >-
+      {{ item.item }} must be a root-owned regular transport file with mode
+      0400 or 0600 before an rsync transfer can run.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_transport_files.results }}"
+
+- name: Require one reviewed pve540 ED25519 host key
+  ansible.builtin.command:
+    argv:
+      - ssh-keygen
+      - -F
+      - "{{ pve_guest_evacuation_lxc_managed_volumes_target_rsync_host }}"
+      - -f
+      - "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_known_host
+  changed_when: false
+  failed_when: false
+
+- name: Verify reviewed pve540 ED25519 host key contract
+  ansible.builtin.assert:
+    that:
+      - pve_guest_evacuation_lxc_managed_volumes_known_host.rc == 0
+      - >-
+        pve_guest_evacuation_lxc_managed_volumes_known_host.stdout_lines
+        | reject('match', '^# ') | list | length == 1
+      - >-
+        pve_guest_evacuation_lxc_managed_volumes_known_host.stdout_lines
+        | reject('match', '^# ') | first
+        is match('^' ~ (pve_guest_evacuation_lxc_managed_volumes_target_rsync_host | regex_escape)
+          ~ ' ssh-ed25519 [A-Za-z0-9+/=]+( .*)?$')
+    fail_msg: >-
+      The dedicated known-hosts file must contain exactly one reviewed ED25519
+      key for the pve540 rsync endpoint.
+    quiet: true
+
+- name: Build strict rsync SSH transport
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_rsync_rsh: >-
+      ssh -i {{ pve_guest_evacuation_lxc_managed_volumes_rsync_identity_file }}
+      -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=yes
+      -o UserKnownHostsFile={{ pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file }}
+      -o GlobalKnownHostsFile=/dev/null -o PasswordAuthentication=no
+      -o KbdInteractiveAuthentication=no -T
+
+# The evidence file is intentionally written only once at completion or
+# failure. Check its paths now so a copied payload can never replace evidence.
+- name: Check managed-volume evidence paths before copying
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+  loop:
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}"
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}.tmp"
+  register: pve_guest_evacuation_lxc_managed_volumes_evidence_paths
+
+- name: Require unused immutable managed-volume evidence paths
+  ansible.builtin.assert:
+    that: [not item.stat.exists]
+    fail_msg: "Evidence path {{ item.item }} already exists; choose a new run id."
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_evidence_paths.results }}"
+
+- name: Copy each stopped-source managed volume without overwrite or deletion
+  ansible.builtin.command:
+    argv:
+      - rsync
+      - --archive
+      - --hard-links
+      - --acls
+      - --xattrs
+      - --numeric-ids
+      - --sparse
+      - --one-file-system
+      - --protect-args
+      - --checksum
+      - --itemize-changes
+      - --stats
+      - -e
+      - "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_rsh }}"
+      - "{{ item.source_path }}/"
+      - "root@{{ pve_guest_evacuation_lxc_managed_volumes_target_rsync_host }}:{{ item.target_path }}/"
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_rsync_copy
+  changed_when: true
+
+- name: Require checksum dry run to report no remaining differences
+  ansible.builtin.command:
+    argv:
+      - rsync
+      - --archive
+      - --hard-links
+      - --acls
+      - --xattrs
+      - --numeric-ids
+      - --sparse
+      - --one-file-system
+      - --protect-args
+      - --checksum
+      - --dry-run
+      - --itemize-changes
+      - -e
+      - "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_rsh }}"
+      - "{{ item.source_path }}/"
+      - "root@{{ pve_guest_evacuation_lxc_managed_volumes_target_rsync_host }}:{{ item.target_path }}/"
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_rsync_verify
+  changed_when: false
+
+- name: Assert checksum dry runs have no remaining changes
+  ansible.builtin.assert:
+    that: [item.stdout | trim | length == 0]
+    fail_msg: >-
+      Final checksum dry run for {{ item.item.key }} reports remaining changes.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_verify.results }}"
+
+- name: Build deterministic source byte file metadata ACL xattr manifests
+  ansible.builtin.shell: |
+    set -o pipefail
+    cd -- {{ item.source_path | quote }}
+    printf 'bytes '
+    find . -xdev -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }'
+    printf 'files '
+    find . -xdev -type f -printf . | wc -c
+    printf 'metadata '
+    find . -xdev -printf '%y\t%m\t%u\t%g\t%s\t%T@\t%l\t%p\0' | LC_ALL=C sort -z | sha256sum
+    printf 'content '
+    find . -xdev -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum | sha256sum
+    printf 'hardlinks '
+    find . -xdev -type f -links +1 -printf '%i\t%p\0' | LC_ALL=C perl -0ne 's/\0\z//; ($inode, $path) = split /\t/, $_, 2; push @{$groups{$inode}}, $path; END { for my $group (sort map { join("\0", sort @{$_}) } values %groups) { print "$group\0\0"; } }' | sha256sum
+    printf 'acl '
+    find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfacl --absolute-names --numeric --skip-base --no-effective | sha256sum
+    printf 'xattr '
+    find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfattr --absolute-names --no-dereference --encoding=hex -d -m - | sha256sum
+  args:
+    executable: /bin/bash
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_source_manifests
+  changed_when: false
+
+- name: Build deterministic target byte file metadata ACL xattr manifests
+  ansible.builtin.shell: |
+    set -o pipefail
+    cd -- {{ item.target_path | quote }}
+    printf 'bytes '
+    find . -xdev -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }'
+    printf 'files '
+    find . -xdev -type f -printf . | wc -c
+    printf 'metadata '
+    find . -xdev -printf '%y\t%m\t%u\t%g\t%s\t%T@\t%l\t%p\0' | LC_ALL=C sort -z | sha256sum
+    printf 'content '
+    find . -xdev -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum | sha256sum
+    printf 'hardlinks '
+    find . -xdev -type f -links +1 -printf '%i\t%p\0' | LC_ALL=C perl -0ne 's/\0\z//; ($inode, $path) = split /\t/, $_, 2; push @{$groups{$inode}}, $path; END { for my $group (sort map { join("\0", sort @{$_}) } values %groups) { print "$group\0\0"; } }' | sha256sum
+    printf 'acl '
+    find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfacl --absolute-names --numeric --skip-base --no-effective | sha256sum
+    printf 'xattr '
+    find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfattr --absolute-names --no-dereference --encoding=hex -d -m - | sha256sum
+  args:
+    executable: /bin/bash
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_target_node }}"
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_target_manifests
+  changed_when: false
+
+- name: Require exact source and target manifest equality for every volume
+  ansible.builtin.assert:
+    that:
+      - >-
+        item.stdout == (pve_guest_evacuation_lxc_managed_volumes_target_manifests.results
+                        | selectattr('item.key', 'equalto', item.item.key)
+                        | map(attribute='stdout') | first)
+    fail_msg: >-
+      Manifest comparison failed for {{ item.item.key }}. Preserve the stopped
+      target for investigation; this workflow never retries into it.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_source_manifests.results }}"
+
+- name: Write immutable verified managed-volume transfer evidence
+  ansible.builtin.include_tasks: write_evidence.yml
+  vars:
+    pve_guest_evacuation_lxc_managed_volumes_checkpoint: transfer_verified

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
@@ -247,15 +247,62 @@
   register: pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems
   changed_when: false
 
+- name: Define the ZFS filesystem record separator
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_zfs_record_separator: '{{ "%c" | format(9) }}'
+
+- name: Require two-field ZFS filesystem identity records
+  ansible.builtin.assert:
+    that:
+      - item.stdout_lines | length > 0
+      - >-
+        (item.stdout_lines
+         | map('split', pve_guest_evacuation_lxc_managed_volumes_zfs_record_separator)
+         | map('length') | unique | list)
+        == [2]
+    fail_msg: >-
+      {{ item.item }} returned a ZFS filesystem inventory without one exact
+      dataset-name and mountpoint field per record. No copy can proceed from
+      an ambiguous filesystem inventory.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems.results }}"
+
+- name: Initialize parsed ZFS filesystem identity records
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_source_zfs_dataset_records: []
+    pve_guest_evacuation_lxc_managed_volumes_target_zfs_dataset_records: []
+
+- name: Parse source ZFS filesystem identity records into name and mountpoint fields
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_source_zfs_dataset_records: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_source_zfs_dataset_records + [
+        {
+          'name': (item | split(pve_guest_evacuation_lxc_managed_volumes_zfs_record_separator) | first),
+          'mountpoint': (item | split(pve_guest_evacuation_lxc_managed_volumes_zfs_record_separator) | last)
+        }
+      ] }}
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems.results[0].stdout_lines }}"
+
+- name: Parse target ZFS filesystem identity records into name and mountpoint fields
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_target_zfs_dataset_records: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_target_zfs_dataset_records + [
+        {
+          'name': (item | split(pve_guest_evacuation_lxc_managed_volumes_zfs_record_separator) | first),
+          'mountpoint': (item | split(pve_guest_evacuation_lxc_managed_volumes_zfs_record_separator) | last)
+        }
+      ] }}
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems.results[1].stdout_lines }}"
+
 - name: Record exact ZFS dataset identities for every managed volume
   ansible.builtin.set_fact:
     pve_guest_evacuation_lxc_managed_volumes_dataset_mappings: >-
       {{ (pve_guest_evacuation_lxc_managed_volumes_dataset_mappings | default([])) + [
         item | combine({
-          'source_dataset_identity': (pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems.results[0].stdout_lines
-                                      | select('match', '^.+\\t' ~ (item.source_path | regex_escape) ~ '$') | list),
-          'target_dataset_identity': (pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems.results[1].stdout_lines
-                                      | select('match', '^.+\\t' ~ (item.target_path | regex_escape) ~ '$') | list)
+          'source_dataset_identity': (pve_guest_evacuation_lxc_managed_volumes_source_zfs_dataset_records
+                                      | selectattr('mountpoint', 'equalto', item.source_path) | list),
+          'target_dataset_identity': (pve_guest_evacuation_lxc_managed_volumes_target_zfs_dataset_records
+                                      | selectattr('mountpoint', 'equalto', item.target_path) | list)
         })
       ] }}
   loop: "{{ pve_guest_evacuation_lxc_managed_volumes_resolved_mappings }}"

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/write_evidence.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/write_evidence.yml
@@ -1,0 +1,42 @@
+---
+- name: Check that the immutable managed-volume evidence paths are unused
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+  loop:
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}"
+    - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}.tmp"
+  register: pve_guest_evacuation_lxc_managed_volumes_evidence_paths
+
+- name: Refuse to overwrite managed-volume transfer evidence
+  ansible.builtin.assert:
+    that: [not item.stat.exists]
+    fail_msg: >-
+      Evidence path {{ item.item }} already exists. Preserve it and choose a
+      new managed-volume run id rather than overwriting recovery evidence.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_evidence_paths.results }}"
+
+- name: Render managed-volume evidence into an unpublished temporary file
+  ansible.builtin.template:
+    src: managed-volumes-evidence.json.j2
+    dest: "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}.tmp"
+    owner: root
+    group: root
+    mode: '0600'
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+
+- name: Atomically link immutable managed-volume evidence into place
+  ansible.builtin.command:
+    argv:
+      - ln
+      - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}.tmp"
+      - "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}"
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+  changed_when: true
+
+- name: Remove the published managed-volume evidence temporary link
+  ansible.builtin.file:
+    path: "{{ pve_guest_evacuation_lxc_managed_volumes_result_evidence_path }}.tmp"
+    state: absent
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/templates/managed-volumes-evidence.json.j2
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/templates/managed-volumes-evidence.json.j2
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "run_id": {{ pve_guest_evacuation_lxc_managed_volumes_run_id | to_json }},
+  "checkpoint": {{ pve_guest_evacuation_lxc_managed_volumes_checkpoint | to_json }},
+  "input_archive": {
+    "path": {{ pve_guest_evacuation_lxc_managed_volumes_archive_evidence_path | to_json }},
+    "run_id": {{ pve_guest_evacuation_lxc_managed_volumes_archive_run_id | to_json }},
+    "vmid": {{ pve_guest_evacuation_lxc_managed_volumes_expected_vmid | int }},
+    "source_config_digest": {{ pve_guest_evacuation_lxc_managed_volumes_expected_config_digest | to_json }},
+    "sha256": {{ pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256 | to_json }}
+  },
+  "input_restore": {
+    "path": {{ pve_guest_evacuation_lxc_managed_volumes_restore_evidence_path | to_json }},
+    "run_id": {{ pve_guest_evacuation_lxc_managed_volumes_restore_run_id | to_json }},
+    "target_storage": {{ pve_guest_evacuation_lxc_managed_volumes_target_storage | to_json }}
+  },
+  "source": {
+    "node": {{ pve_guest_evacuation_lxc_managed_volumes_source_node | to_json }},
+    "status": {{ pve_guest_evacuation_lxc_managed_volumes_source_status | default({}) | to_json }},
+    "config_digest": {{ pve_guest_evacuation_lxc_managed_volumes_source_config.digest | default('') | to_json }}
+  },
+  "target": {
+    "node": {{ pve_guest_evacuation_lxc_managed_volumes_target_node | to_json }},
+    "status": {{ pve_guest_evacuation_lxc_managed_volumes_target_status | default({}) | to_json }},
+    "config_digest": {{ pve_guest_evacuation_lxc_managed_volumes_target_config.digest | default('') | to_json }}
+  },
+  "volumes": {{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings | default([]) | to_json }},
+  "rsync": {
+    "copy": {{ pve_guest_evacuation_lxc_managed_volumes_rsync_copy.results | default([]) | map(attribute='stdout_lines') | list | to_json }},
+    "checksum_dry_run": {{ pve_guest_evacuation_lxc_managed_volumes_rsync_verify.results | default([]) | map(attribute='stdout_lines') | list | to_json }}
+  },
+  "source_manifests": {{ pve_guest_evacuation_lxc_managed_volumes_source_manifests.results | default([]) | map(attribute='stdout_lines') | list | to_json }},
+  "target_manifests": {{ pve_guest_evacuation_lxc_managed_volumes_target_manifests.results | default([]) | map(attribute='stdout_lines') | list | to_json }},
+  "failure": {{ pve_guest_evacuation_lxc_managed_volumes_failure | default({}) | to_json }},
+  "written_at_utc": {{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') | to_json }}
+}

--- a/roles/pve_guest_evacuation_restore/README.md
+++ b/roles/pve_guest_evacuation_restore/README.md
@@ -40,6 +40,15 @@ can change Proxmox disk references, so the exact source digest is used to bind
 the archive evidence before restore; disk and configuration structure are then
 verified on pve540 after the intentional storage placement.
 
+For an LXC with managed `mpN` volumes, VZDump restoration deliberately remains
+refused by default because Proxmox can create empty target skeletons. The only
+supported opt-in is `pve_guest_evacuation_restore_lxc_mountpoint_strategy=
+manifested_copy`; it writes a `restore_pending_managed_mount_copy` evidence
+record while leaving the stopped target intact. Follow it with
+`playbooks/transfer_evacuated_lxc_managed_volumes.yml`, which requires an empty
+target volume, a stopped source, a checksum rsync transfer, and exact
+per-volume manifests before it writes final immutable evidence.
+
 ## Evidence and failure policy
 
 The result is atomically written as a new, root-owned `0600` file below the

--- a/roles/pve_guest_evacuation_restore/defaults/main.yml
+++ b/roles/pve_guest_evacuation_restore/defaults/main.yml
@@ -24,3 +24,8 @@ pve_guest_evacuation_restore_result_evidence_path: >-
 # Restoration never uses the backup-only staging storage as its destination.
 # This identifier must already exist and be active on standalone pve540.
 pve_guest_evacuation_restore_target_storage: ""
+
+# VZDump can recreate an LXC mpN volume as an empty skeleton.  The default
+# therefore remains a refusal.  The manifested-copy workflow opts in only
+# when its separate, stopped-source transfer will prove every mpN payload.
+pve_guest_evacuation_restore_lxc_mountpoint_strategy: refuse

--- a/roles/pve_guest_evacuation_restore/tasks/preflight_contract.yml
+++ b/roles/pve_guest_evacuation_restore/tasks/preflight_contract.yml
@@ -17,6 +17,7 @@
       - pve_guest_evacuation_restore_expected_config_digest is match('^[A-Fa-f0-9]{40,64}$')
       - pve_guest_evacuation_restore_expected_archive_sha256 is match('^[A-Fa-f0-9]{64}$')
       - pve_guest_evacuation_restore_target_storage is match('^[a-z0-9][a-z0-9_-]{0,39}$')
+      - pve_guest_evacuation_restore_lxc_mountpoint_strategy in ['refuse', 'manifested_copy']
       - pve_guest_evacuation_restore_archive_evidence_path is match('^/bulk/evacuation-816/evidence/[^/ ]+[.]json$')
       - pve_guest_evacuation_restore_result_evidence_path is match('^/bulk/evacuation-816/evidence/restore-[^/ ]+[.]json$')
     fail_msg: >-

--- a/roles/pve_guest_evacuation_restore/tasks/restore.yml
+++ b/roles/pve_guest_evacuation_restore/tasks/restore.yml
@@ -308,6 +308,27 @@
       it and investigate rather than restoring an incomplete guest.
     quiet: true
 
+- name: Record backed LXC mountpoint volume keys
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_restore_lxc_mountpoint_volume_keys: >-
+      {{ pve_guest_evacuation_restore_expected_volume_keys
+         | select('match', '^mp[0-9]+$') | list }}
+
+- name: Refuse automatic restore of LXC archives with additional backed mounts
+  ansible.builtin.assert:
+    that:
+      - >-
+        pve_guest_evacuation_restore_expected_guest_type != 'lxc'
+        or pve_guest_evacuation_restore_lxc_mountpoint_volume_keys | length == 0
+    fail_msg: >-
+      The selected LXC archive has backed mountpoint volumes
+      ({{ pve_guest_evacuation_restore_lxc_mountpoint_volume_keys | join(', ') }}).
+      Proxmox can recreate their volume configuration without restoring their
+      archived payload, so this role refuses the restore before creating a
+      target guest. Preserve the archive and use a volume-manifested restore
+      procedure that proves every mountpoint payload.
+    quiet: true
+
 - name: Restore the verified QEMU archive without starting it
   ansible.builtin.command:
     argv:

--- a/roles/pve_guest_evacuation_restore/tasks/restore.yml
+++ b/roles/pve_guest_evacuation_restore/tasks/restore.yml
@@ -320,6 +320,7 @@
       - >-
         pve_guest_evacuation_restore_expected_guest_type != 'lxc'
         or pve_guest_evacuation_restore_lxc_mountpoint_volume_keys | length == 0
+        or pve_guest_evacuation_restore_lxc_mountpoint_strategy == 'manifested_copy'
     fail_msg: >-
       The selected LXC archive has backed mountpoint volumes
       ({{ pve_guest_evacuation_restore_lxc_mountpoint_volume_keys | join(', ') }}).
@@ -437,4 +438,7 @@
 - name: Record a completed restore evidence checkpoint
   ansible.builtin.include_tasks: write_evidence.yml
   vars:
-    pve_guest_evacuation_restore_checkpoint: restore_verified
+    pve_guest_evacuation_restore_checkpoint: >-
+      {{ (pve_guest_evacuation_restore_expected_guest_type == 'lxc'
+          and pve_guest_evacuation_restore_lxc_mountpoint_volume_keys | length > 0)
+         | ternary('restore_pending_managed_mount_copy', 'restore_verified') }}

--- a/tests/pve_guest_evacuation/test_archive_contract.py
+++ b/tests/pve_guest_evacuation/test_archive_contract.py
@@ -13,7 +13,13 @@ def test_archive_uses_stop_mode_and_has_snapshot_gate() -> None:
     assert "Assert no ZFS snapshots exist on either evacuation node" in archive
     assert "- snapshot" in archive
     assert "- --mode\n      - stop" in archive
+    assert '- "{{ pve_guest_evacuation_tmpdir }}"' in archive
     assert "- snapshot\n" not in archive.split("Create a stop-mode VZDump archive", 1)[1]
+
+    defaults = (ROLE / "defaults" / "main.yml").read_text()
+    contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
+    assert "pve_guest_evacuation_tmpdir: /var/tmp" in defaults
+    assert "pve_guest_evacuation_tmpdir is match" in contract
 
 
 def test_unsupported_phases_and_external_resources_are_fail_closed() -> None:

--- a/tests/pve_guest_evacuation/test_archive_contract.py
+++ b/tests/pve_guest_evacuation/test_archive_contract.py
@@ -20,6 +20,8 @@ def test_archive_uses_stop_mode_and_has_snapshot_gate() -> None:
     contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
     assert "pve_guest_evacuation_tmpdir: /var/tmp" in defaults
     assert "pve_guest_evacuation_tmpdir is match" in contract
+    assert "pve_guest_evacuation_zstd_threads: 0" in defaults
+    assert "pve_guest_evacuation_zstd_threads | int >= 0" in contract
 
 
 def test_unsupported_phases_and_external_resources_are_fail_closed() -> None:

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -32,6 +32,58 @@ def test_role_is_inert_and_requires_exact_three_record_identity() -> None:
     assert "hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host is defined" in contract
 
 
+def test_rsync_endpoint_keeps_the_literal_inventory_fast_path() -> None:
+    contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
+
+    assert (
+        "pve_guest_evacuation_lxc_managed_volumes_target_rsync_host\n"
+        "        == hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host"
+        in contract
+    )
+    assert "or (" in contract
+
+
+def test_unequal_rsync_endpoint_requires_a_verified_canonical_fqdn() -> None:
+    defaults = (ROLE / "defaults" / "main.yml").read_text()
+    contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
+
+    assert "pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn: \"\"" in defaults
+    assert "Resolve the approved pve540 canonical FQDN from pve2" in contract
+    assert "Resolve the pve540 inventory endpoint from pve2" in contract
+    assert "- ahostsv4" in contract
+    assert "pve_guest_evacuation_lxc_managed_volumes_target_rsync_host\n              == pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn" in contract
+    assert "pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_ipv4s" in contract
+    assert "pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_ipv4s" in contract
+    assert "| intersect(pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_ipv4s)" in contract
+
+
+def test_unequal_rsync_endpoint_rejects_aliases_and_unverified_resolution() -> None:
+    contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
+
+    assert "is match('^[A-Za-z0-9][A-Za-z0-9-]*(\\\\.[A-Za-z0-9][A-Za-z0-9-]*)+$')" in contract
+    assert "is not match('^([0-9]{1,3}\\\\.){3}[0-9]{1,3}$')" in contract
+    assert "pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_resolution.rc == 0" in contract
+    assert "pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_resolution.rc == 0" in contract
+    assert "pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_ipv4s | length > 0" in contract
+    assert "pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_ipv4s | length > 0" in contract
+    assert "unapproved aliases, IP literals, missing DNS results, and mismatches" in contract
+
+
+def test_verified_fqdn_preserves_one_ed25519_key_and_strict_ssh() -> None:
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+
+    assert "| list | length == 1" in transfer
+    assert "ssh-ed25519" in transfer
+    for setting in (
+        "StrictHostKeyChecking=yes",
+        "UserKnownHostsFile={{ pve_guest_evacuation_lxc_managed_volumes_rsync_known_hosts_file }}",
+        "GlobalKnownHostsFile=/dev/null",
+        "PasswordAuthentication=no",
+        "KbdInteractiveAuthentication=no",
+    ):
+        assert setting in transfer
+
+
 def test_transfer_requires_stopped_source_empty_target_and_no_snapshots() -> None:
     transfer = (ROLE / "tasks" / "transfer.yml").read_text()
 
@@ -86,6 +138,10 @@ def test_evidence_is_immutable_and_failure_preserves_the_target() -> None:
 
 if __name__ == "__main__":
     test_role_is_inert_and_requires_exact_three_record_identity()
+    test_rsync_endpoint_keeps_the_literal_inventory_fast_path()
+    test_unequal_rsync_endpoint_requires_a_verified_canonical_fqdn()
+    test_unequal_rsync_endpoint_rejects_aliases_and_unverified_resolution()
+    test_verified_fqdn_preserves_one_ed25519_key_and_strict_ssh()
     test_transfer_requires_stopped_source_empty_target_and_no_snapshots()
     test_transfer_preserves_metadata_and_proves_each_volume()
     test_evidence_is_immutable_and_failure_preserves_the_target()

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -74,6 +74,57 @@ def run_zfs_dataset_identity_parser(
     )
 
 
+def run_canonical_endpoint_contract(
+    tmp_path: Path,
+    canonical_fqdn: str,
+    inventory_endpoint: str,
+    canonical_ipv4s: list[str],
+    inventory_ipv4s: list[str],
+) -> subprocess.CompletedProcess[str]:
+    """Execute the role's exact canonical-endpoint assertion with fixture DNS."""
+    ansible_playbook = shutil.which("ansible-playbook")
+    if ansible_playbook is None:
+        pytest.skip("ansible-playbook is required to execute the endpoint regression")
+
+    contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
+    task_start = contract.index("- name: Derive pve2 IPv4 resolutions")
+    endpoint_tasks = tmp_path / "endpoint-contract.yml"
+    endpoint_tasks.write_text(contract[task_start:])
+
+    def getent_lines(addresses: list[str]) -> list[str]:
+        return [f"{address} STREAM" for address in addresses]
+
+    playbook = tmp_path / "playbook.yml"
+    playbook.write_text(
+        "---\n"
+        "- hosts: localhost\n"
+        "  connection: local\n"
+        "  gather_facts: false\n"
+        "  vars:\n"
+        f"    pve_guest_evacuation_lxc_managed_volumes_target_rsync_host: {json.dumps(canonical_fqdn)}\n"
+        f"    pve_guest_evacuation_lxc_managed_volumes_target_rsync_canonical_fqdn: {json.dumps(canonical_fqdn)}\n"
+        "    pve_guest_evacuation_lxc_managed_volumes_target_node: pve540\n"
+        "    pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_resolution:\n"
+        "      rc: 0\n"
+        f"      stdout_lines: {json.dumps(getent_lines(canonical_ipv4s))}\n"
+        "    pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_resolution:\n"
+        "      rc: 0\n"
+        f"      stdout_lines: {json.dumps(getent_lines(inventory_ipv4s))}\n"
+        "  tasks:\n"
+        "    - ansible.builtin.add_host:\n"
+        "        name: pve540\n"
+        f"        ansible_host: {json.dumps(inventory_endpoint)}\n"
+        "    - ansible.builtin.include_tasks: endpoint-contract.yml\n"
+    )
+    return subprocess.run(
+        [ansible_playbook, "-i", "localhost,", str(playbook)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
 def test_role_is_inert_and_requires_exact_three_record_identity() -> None:
     defaults = (ROLE / "defaults" / "main.yml").read_text()
     contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
@@ -128,13 +179,52 @@ def test_unequal_rsync_endpoint_requires_a_verified_canonical_fqdn() -> None:
 def test_unequal_rsync_endpoint_rejects_aliases_and_unverified_resolution() -> None:
     contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
 
-    assert "is match('^[A-Za-z0-9][A-Za-z0-9-]*(\\\\.[A-Za-z0-9][A-Za-z0-9-]*)+$')" in contract
-    assert "is not match('^([0-9]{1,3}\\\\.){3}[0-9]{1,3}$')" in contract
+    assert "is match('^[A-Za-z0-9][A-Za-z0-9-]*(\\.[A-Za-z0-9][A-Za-z0-9-]*)+$')" in contract
+    assert "is not match('^([0-9]{1,3}\\.){3}[0-9]{1,3}$')" in contract
     assert "pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_resolution.rc == 0" in contract
     assert "pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_resolution.rc == 0" in contract
     assert "pve_guest_evacuation_lxc_managed_volumes_canonical_fqdn_ipv4s | length > 0" in contract
     assert "pve_guest_evacuation_lxc_managed_volumes_inventory_endpoint_ipv4s | length > 0" in contract
     assert "unapproved aliases, IP literals, missing DNS results, and mismatches" in contract
+
+
+def test_canonical_fqdn_endpoint_contract_accepts_a_matching_literal_inventory_ipv4(tmp_path: Path) -> None:
+    result = run_canonical_endpoint_contract(
+        tmp_path,
+        "pve540.jacobpevans.com",
+        "192.0.2.54",
+        ["192.0.2.54"],
+        ["192.0.2.54"],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("canonical_fqdn", "inventory_endpoint", "canonical_ipv4s", "inventory_ipv4s"),
+    [
+        ("pve540", "192.0.2.54", ["192.0.2.54"], ["192.0.2.54"]),
+        ("192.0.2.54", "192.0.2.55", ["192.0.2.54"], ["192.0.2.55"]),
+        ("pve540.jacobpevans.com", "192.0.2.54", ["192.0.2.55"], ["192.0.2.54"]),
+    ],
+    ids=["single-label-alias", "ip-literal", "dns-mismatch"],
+)
+def test_canonical_fqdn_endpoint_contract_rejects_invalid_or_mismatched_inputs(
+    tmp_path: Path,
+    canonical_fqdn: str,
+    inventory_endpoint: str,
+    canonical_ipv4s: list[str],
+    inventory_ipv4s: list[str],
+) -> None:
+    result = run_canonical_endpoint_contract(
+        tmp_path,
+        canonical_fqdn,
+        inventory_endpoint,
+        canonical_ipv4s,
+        inventory_ipv4s,
+    )
+
+    assert result.returncode != 0
 
 
 def test_verified_fqdn_preserves_one_ed25519_key_and_strict_ssh() -> None:

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -1,0 +1,82 @@
+"""Static safety contract for manifested LXC mpN evacuation transfers."""
+
+from pathlib import Path
+
+
+ROLE = Path(__file__).resolve().parents[2] / "roles" / "pve_guest_evacuation_lxc_managed_volumes"
+
+
+def test_role_is_inert_and_requires_exact_three_record_identity() -> None:
+    defaults = (ROLE / "defaults" / "main.yml").read_text()
+    contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+
+    assert "pve_guest_evacuation_lxc_managed_volumes_enabled: false" in defaults
+    for value in (
+        "archive_run_id",
+        "restore_run_id",
+        "expected_vmid",
+        "expected_config_digest",
+        "expected_archive_sha256",
+        "target_storage",
+    ):
+        assert f"pve_guest_evacuation_lxc_managed_volumes_{value}" in contract
+    assert "archive_verified" in transfer
+    assert "restore_pending_managed_mount_copy" in transfer
+    assert "source_config.digest == pve_guest_evacuation_lxc_managed_volumes_expected_config_digest" in transfer
+
+
+def test_transfer_requires_stopped_source_empty_target_and_no_snapshots() -> None:
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+
+    assert "pve_guest_evacuation_lxc_managed_volumes_source_status.status == 'stopped'" in transfer
+    assert "pve_guest_evacuation_lxc_managed_volumes_target_status.status == 'stopped'" in transfer
+    assert "Require the target managed volumes to be empty skeletons" in transfer
+    assert "Refuse to overwrite any preexisting target managed-volume content" in transfer
+    assert "Assert no ZFS snapshots exist on either evacuation node" in transfer
+    assert "zfs, snapshot" not in transfer
+    assert "zfs, destroy" not in transfer
+    assert "pct, destroy" not in transfer
+    assert "pct, start" not in transfer
+
+
+def test_transfer_preserves_metadata_and_proves_each_volume() -> None:
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+
+    for rsync_flag in (
+        "--hard-links",
+        "--acls",
+        "--xattrs",
+        "--numeric-ids",
+        "--checksum",
+        "--dry-run",
+    ):
+        assert rsync_flag in transfer
+    for manifest in ("bytes", "files", "metadata", "content", "hardlinks", "acl", "xattr"):
+        assert f"printf '{manifest} " in transfer
+    assert "getfacl --absolute-names --numeric" in transfer
+    assert "getfattr --absolute-names --no-dereference --encoding=hex" in transfer
+    assert "Require exact source and target manifest equality for every volume" in transfer
+    assert "Require one exact ZFS dataset identity for each source and target volume" in transfer
+
+
+def test_evidence_is_immutable_and_failure_preserves_the_target() -> None:
+    main = (ROLE / "tasks" / "main.yml").read_text()
+    writer = (ROLE / "tasks" / "write_evidence.yml").read_text()
+    evidence = (ROLE / "templates" / "managed-volumes-evidence.json.j2").read_text()
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+
+    assert "Refuse to overwrite managed-volume transfer evidence" in writer
+    assert "- ln" in writer
+    assert "preserved" in main
+    assert "source_dataset_identity" in transfer
+    assert "target_dataset_identity" in transfer
+    assert "source_manifests" in evidence
+    assert "target_manifests" in evidence
+
+
+if __name__ == "__main__":
+    test_role_is_inert_and_requires_exact_three_record_identity()
+    test_transfer_requires_stopped_source_empty_target_and_no_snapshots()
+    test_transfer_preserves_metadata_and_proves_each_volume()
+    test_evidence_is_immutable_and_failure_preserves_the_target()

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -1,9 +1,77 @@
-"""Static safety contract for manifested LXC mpN evacuation transfers."""
+"""Safety contract and parser regression for manifested LXC mpN transfers."""
 
+import json
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 
 ROLE = Path(__file__).resolve().parents[2] / "roles" / "pve_guest_evacuation_lxc_managed_volumes"
+
+
+def run_zfs_dataset_identity_parser(
+    tmp_path: Path,
+    source_lines: list[str],
+    target_lines: list[str],
+    expected_mappings: list[dict[str, object]] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Execute the role's extracted parser tasks with fixture ZFS output."""
+    ansible_playbook = shutil.which("ansible-playbook")
+    if ansible_playbook is None:
+        pytest.skip("ansible-playbook is required to execute the parser regression")
+
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+    parser_start = transfer.index("- name: Define the ZFS filesystem record separator")
+    parser_end = transfer.index("- name: Assert no ZFS snapshots exist on either evacuation node")
+    parser_path = tmp_path / "zfs-parser.yml"
+    parser_path.write_text(transfer[parser_start:parser_end])
+
+    zfs_filesystems = {
+        "results": [
+            {"item": "pve2", "stdout_lines": source_lines},
+            {"item": "pve540", "stdout_lines": target_lines},
+        ]
+    }
+    resolved_mappings = [
+        {
+            "key": "mp0",
+            "source_path": "/bulk/subvol-519010-disk-1",
+            "target_path": "/rpool/data/subvol-519010-disk-1",
+        }
+    ]
+    playbook_tasks = "    - ansible.builtin.include_tasks: zfs-parser.yml\n"
+    if expected_mappings is not None:
+        playbook_tasks += (
+            "    - ansible.builtin.assert:\n"
+            "        that:\n"
+            "          - pve_guest_evacuation_lxc_managed_volumes_dataset_mappings == "
+            "expected_dataset_mappings\n"
+        )
+    playbook_path = tmp_path / "playbook.yml"
+    playbook_path.write_text(
+        "---\n"
+        "- hosts: localhost\n"
+        "  connection: local\n"
+        "  gather_facts: false\n"
+        "  vars:\n"
+        "    pve_guest_evacuation_lxc_managed_volumes_zfs_filesystems: "
+        f"{json.dumps(zfs_filesystems)}\n"
+        "    pve_guest_evacuation_lxc_managed_volumes_resolved_mappings: "
+        f"{json.dumps(resolved_mappings)}\n"
+        "    expected_dataset_mappings: "
+        f"{json.dumps(expected_mappings or [])}\n"
+        "  tasks:\n"
+        f"{playbook_tasks}"
+    )
+    return subprocess.run(
+        [ansible_playbook, "-i", "localhost,", str(playbook_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
 
 
 def test_role_is_inert_and_requires_exact_three_record_identity() -> None:
@@ -121,6 +189,88 @@ def test_transfer_preserves_metadata_and_proves_each_volume() -> None:
     assert "Require one exact ZFS dataset identity for each source and target volume" in transfer
 
 
+def test_zfs_dataset_identity_parser_uses_actual_tab_delimited_fields(tmp_path: Path) -> None:
+    """Run the extracted parser tasks against representative live ZFS output."""
+    source_line = "bulk/subvol-519010-disk-1\t/bulk/subvol-519010-disk-1"
+    target_line = "rpool/data/subvol-519010-disk-1\t/rpool/data/subvol-519010-disk-1"
+    # This is the failure mode from the live output: matching a literal
+    # backslash followed by t cannot find either actual tab-delimited record.
+    assert [line for line in (source_line, target_line) if "\\t" in line] == []
+
+    expected_mappings = [
+        {
+            "key": "mp0",
+            "source_path": "/bulk/subvol-519010-disk-1",
+            "target_path": "/rpool/data/subvol-519010-disk-1",
+            "source_dataset_identity": [
+                {"name": "bulk/subvol-519010-disk-1", "mountpoint": "/bulk/subvol-519010-disk-1"}
+            ],
+            "target_dataset_identity": [
+                {
+                    "name": "rpool/data/subvol-519010-disk-1",
+                    "mountpoint": "/rpool/data/subvol-519010-disk-1",
+                }
+            ],
+        }
+    ]
+    result = run_zfs_dataset_identity_parser(
+        tmp_path,
+        [source_line],
+        [target_line],
+        expected_mappings,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("source_lines", "target_lines", "failure_message"),
+    [
+        (
+            ["bulk/subvol-519010-disk-1"],
+            ["rpool/data/subvol-519010-disk-1\t/rpool/data/subvol-519010-disk-1"],
+            "returned a ZFS filesystem inventory without one exact dataset-name",
+        ),
+        (
+            ["bulk/subvol-519010-disk-1\t/bulk/subvol-519010-disk-1\textra"],
+            ["rpool/data/subvol-519010-disk-1\t/rpool/data/subvol-519010-disk-1"],
+            "returned a ZFS filesystem inventory without one exact dataset-name",
+        ),
+        (
+            [
+                "bulk/subvol-519010-disk-1\t/bulk/subvol-519010-disk-1",
+                "bulk/duplicate\t/bulk/subvol-519010-disk-1",
+            ],
+            ["rpool/data/subvol-519010-disk-1\t/rpool/data/subvol-519010-disk-1"],
+            "does not resolve to exactly one mounted ZFS dataset",
+        ),
+    ],
+    ids=["one-field-record", "three-field-record", "duplicate-mountpoint-record"],
+)
+def test_zfs_dataset_identity_parser_rejects_ambiguous_records(
+    tmp_path: Path,
+    source_lines: list[str],
+    target_lines: list[str],
+    failure_message: str,
+) -> None:
+    result = run_zfs_dataset_identity_parser(tmp_path, source_lines, target_lines)
+
+    assert result.returncode != 0
+    assert failure_message in result.stdout + result.stderr
+
+
+def test_zfs_dataset_identity_parser_contract_uses_field_parsing() -> None:
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+
+    assert "Require two-field ZFS filesystem identity records" in transfer
+    assert "pve_guest_evacuation_lxc_managed_volumes_zfs_record_separator: '{{ \"%c\" | format(9) }}'" in transfer
+    assert "map('split', pve_guest_evacuation_lxc_managed_volumes_zfs_record_separator)" in transfer
+    assert "Parse source ZFS filesystem identity records into name and mountpoint fields" in transfer
+    assert "Parse target ZFS filesystem identity records into name and mountpoint fields" in transfer
+    assert "selectattr('mountpoint', 'equalto', item.source_path)" in transfer
+    assert "selectattr('mountpoint', 'equalto', item.target_path)" in transfer
+    assert "select('match', '^.+\\\\t'" not in transfer
+
+
 def test_evidence_is_immutable_and_failure_preserves_the_target() -> None:
     main = (ROLE / "tasks" / "main.yml").read_text()
     writer = (ROLE / "tasks" / "write_evidence.yml").read_text()
@@ -144,4 +294,5 @@ if __name__ == "__main__":
     test_verified_fqdn_preserves_one_ed25519_key_and_strict_ssh()
     test_transfer_requires_stopped_source_empty_target_and_no_snapshots()
     test_transfer_preserves_metadata_and_proves_each_volume()
+    test_zfs_dataset_identity_parser_contract_uses_field_parsing()
     test_evidence_is_immutable_and_failure_preserves_the_target()

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -24,6 +24,11 @@ def test_role_is_inert_and_requires_exact_three_record_identity() -> None:
     assert "archive_verified" in transfer
     assert "restore_pending_managed_mount_copy" in transfer
     assert "source_config.digest == pve_guest_evacuation_lxc_managed_volumes_expected_config_digest" in transfer
+    assert "Require a root-only non-symlink pve3 evidence directory" in transfer
+    assert "pve_guest_evacuation_lxc_managed_volumes_evidence_dir_stat.stat.mode == '0700'" in transfer
+    assert transfer.index("Check managed-volume evidence paths before transfer gates") < transfer.index(
+        "Read pve3 archive and pending-restore evidence"
+    )
 
 
 def test_transfer_requires_stopped_source_empty_target_and_no_snapshots() -> None:

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -64,6 +64,7 @@ def test_transfer_preserves_metadata_and_proves_each_volume() -> None:
     assert "getfattr --absolute-names --no-dereference --encoding=hex" in transfer
     assert "-printf '%y\\t%m\\t%U\\t%G\\t%s" in transfer
     assert "(?:[^,]+,)*mp=/[^,]+" in transfer
+    assert transfer.count("set -euo pipefail") >= 2
     assert "Require exact source and target manifest equality for every volume" in transfer
     assert "Require one exact ZFS dataset identity for each source and target volume" in transfer
 

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -29,6 +29,7 @@ def test_role_is_inert_and_requires_exact_three_record_identity() -> None:
     assert transfer.index("Check managed-volume evidence paths before transfer gates") < transfer.index(
         "Read pve3 archive and pending-restore evidence"
     )
+    assert "hostvars[pve_guest_evacuation_lxc_managed_volumes_target_node].ansible_host is defined" in contract
 
 
 def test_transfer_requires_stopped_source_empty_target_and_no_snapshots() -> None:
@@ -61,6 +62,8 @@ def test_transfer_preserves_metadata_and_proves_each_volume() -> None:
         assert f"printf '{manifest} " in transfer
     assert "getfacl --absolute-names --numeric" in transfer
     assert "getfattr --absolute-names --no-dereference --encoding=hex" in transfer
+    assert "-printf '%y\\t%m\\t%U\\t%G\\t%s" in transfer
+    assert "(?:[^,]+,)*mp=/[^,]+" in transfer
     assert "Require exact source and target manifest equality for every volume" in transfer
     assert "Require one exact ZFS dataset identity for each source and target volume" in transfer
 

--- a/tests/pve_guest_evacuation_restore/test_restore_contract.py
+++ b/tests/pve_guest_evacuation_restore/test_restore_contract.py
@@ -55,9 +55,18 @@ def test_restore_refuses_lxc_mountpoint_volumes_before_creating_a_target() -> No
     assert "pve_guest_evacuation_restore_lxc_mountpoint_volume_keys" in restore
     assert "Refuse automatic restore of LXC archives with additional backed mounts" in restore
     assert "Proxmox can recreate their volume configuration without restoring their" in restore
+    assert "pve_guest_evacuation_restore_lxc_mountpoint_strategy == 'manifested_copy'" in restore
     assert restore.index("Refuse automatic restore of LXC archives with additional backed mounts") < restore.index(
         "Restore the verified LXC archive"
     )
+
+
+def test_manifested_lxc_restore_is_explicitly_pending_not_verified() -> None:
+    restore = (ROLE / "tasks" / "restore.yml").read_text()
+    defaults = (ROLE / "defaults" / "main.yml").read_text()
+
+    assert "pve_guest_evacuation_restore_lxc_mountpoint_strategy: refuse" in defaults
+    assert "restore_pending_managed_mount_copy" in restore
 
 
 if __name__ == "__main__":

--- a/tests/pve_guest_evacuation_restore/test_restore_contract.py
+++ b/tests/pve_guest_evacuation_restore/test_restore_contract.py
@@ -49,7 +49,19 @@ def test_restore_preserves_target_and_uses_only_native_restore_commands() -> Non
     assert "- ln" in writer
 
 
+def test_restore_refuses_lxc_mountpoint_volumes_before_creating_a_target() -> None:
+    restore = (ROLE / "tasks" / "restore.yml").read_text()
+
+    assert "pve_guest_evacuation_restore_lxc_mountpoint_volume_keys" in restore
+    assert "Refuse automatic restore of LXC archives with additional backed mounts" in restore
+    assert "Proxmox can recreate their volume configuration without restoring their" in restore
+    assert restore.index("Refuse automatic restore of LXC archives with additional backed mounts") < restore.index(
+        "Restore the verified LXC archive"
+    )
+
+
 if __name__ == "__main__":
     test_restore_requires_exact_verified_archive_identity()
     test_restore_verifies_archive_before_writing_target()
     test_restore_preserves_target_and_uses_only_native_restore_commands()
+    test_restore_refuses_lxc_mountpoint_volumes_before_creating_a_target()


### PR DESCRIPTION
## Summary

Harden the snapshot-free pve2 evacuation workflow for tofu-proxmox issue #816. The existing archive and restore roles now use local staging safely, compress in parallel, refuse an LXC archive whose additional managed volumes are not independently verified, and provide an explicit manifest-driven transfer path for those volumes.

## Changes

- use `/var/tmp` as the local `vzdump` workspace and let zstd select its safe parallel worker count
- fail before target creation when an LXC archive contains an `mpN` volume without the explicit managed-volume strategy
- add `manifested_copy` restore staging and a dedicated stopped-source transfer playbook
- bind archive, pending restore, source configuration, target storage, and every managed mount to immutable pve3 evidence
- require exact mount semantics, empty target volumes, zero snapshots, strict pinned-host SSH, ACL/xattr/hard-link preservation, checksum dry runs, and identical source/target manifests
- protect the root-owned `0700` evidence directory and reserve result paths before any transfer gate

## Test plan

- `pytest -q tests/pve_guest_evacuation tests/pve_guest_evacuation_restore tests/pve_guest_evacuation_lxc_managed_volumes` — 11 passed
- syntax checks passed for `evacuate_guest.yml`, `restore_evacuated_guest.yml`, and `transfer_evacuated_lxc_managed_volumes.yml`
- `ansible-lint --profile production` — passed
- live evacuation already exercised the archive/restore path and exposed the fail-closed requirement; Qdrant's missing `mp0` payload was repaired and independently manifest-verified

## Residual live-test gap

The new enabled `manifested_copy` transfer path has not yet completed its first live managed-volume migration. It remains opt-in and fail-closed. The Python contract coverage is mostly static, and its Molecule scenario is deliberately disabled/fail-closed until a safe live endpoint pair is supplied.

Related: dryvist/tofu-proxmox#816

Session: codex-jevans-mbp-c8838755