### PR TITLE
fix(evacuation): resume verified managed transfers

### DIFF
--- a/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
+++ b/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
@@ -37,3 +37,69 @@
     - name: Assert incomplete managed-volume inputs fail closed
       ansible.builtin.assert:
         that: [pve_guest_evacuation_lxc_managed_volumes_input_failed | default(false)]
+
+    - name: Create isolated absolute-symlink ACL regression directories
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: managed-volume-acl-
+      register: pve_guest_evacuation_lxc_managed_volumes_acl_tmp
+
+    - name: Prove physical ACL manifests accept identical broken absolute symlinks
+      ansible.builtin.shell: |
+        set -euo pipefail
+        mkdir -p "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/bin"
+        printf '%s\n' '#!/bin/bash' 'test "$1" = --physical' 'shift' 'printf "%s\\n" "$@"' >"{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/bin/getfacl"
+        chmod 0700 "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/bin/getfacl"
+        export PATH="{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/bin:$PATH"
+        mkdir -p "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/source" "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/target"
+        ln -s /var/lib/clickhouse/store/missing "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/source/absolute-link"
+        ln -s /var/lib/clickhouse/store/missing "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/target/absolute-link"
+        source_acl=$(cd "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/source" && find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfacl --physical --absolute-names --numeric --skip-base --no-effective | sha256sum)
+        target_acl=$(cd "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}/target" && find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfacl --physical --absolute-names --numeric --skip-base --no-effective | sha256sum)
+        test "$source_acl" = "$target_acl"
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+    - name: Remove isolated ACL regression directories
+      ansible.builtin.file:
+        path: "{{ pve_guest_evacuation_lxc_managed_volumes_acl_tmp.path }}"
+        state: absent
+
+    - name: Create isolated checksum dry-run regression directories
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: managed-volume-rsync-
+      register: pve_guest_evacuation_lxc_managed_volumes_rsync_tmp
+
+    - name: Prove delete dry run reports arbitrary extra target content
+      ansible.builtin.shell: |
+        set -euo pipefail
+        mkdir -p "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}/source" "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}/target"
+        printf source >"{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}/source/payload"
+        cp "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}/source/payload" "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}/target/payload"
+        printf arbitrary >"{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}/target/extra"
+        output=$(nix shell nixpkgs#rsync -c rsync --archive --checksum --dry-run --delete --itemize-changes \
+          "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}/source/" \
+          "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}/target/")
+        test -n "$output"
+        printf '%s\n' "$output" | grep -F '*deleting   extra'
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+    - name: Prove a populated target is accepted only by explicit resume
+      ansible.builtin.assert:
+        that:
+          - pve_guest_evacuation_lxc_managed_volumes_synthetic_target_content | length > 0
+          - pve_guest_evacuation_lxc_managed_volumes_synthetic_resume_run_id | length > 0
+          - pve_guest_evacuation_lxc_managed_volumes_synthetic_empty_run_id | length == 0
+      vars:
+        pve_guest_evacuation_lxc_managed_volumes_synthetic_target_content: payload
+        pve_guest_evacuation_lxc_managed_volumes_synthetic_resume_run_id: failed-transfer-1
+        pve_guest_evacuation_lxc_managed_volumes_synthetic_empty_run_id: ""
+
+    - name: Remove isolated checksum dry-run regression directories
+      ansible.builtin.file:
+        path: "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}"
+        state: absent

--- a/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
+++ b/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
@@ -88,17 +88,6 @@
         executable: /bin/bash
       changed_when: false
 
-    - name: Prove a populated target is accepted only by explicit resume
-      ansible.builtin.assert:
-        that:
-          - pve_guest_evacuation_lxc_managed_volumes_synthetic_target_content | length > 0
-          - pve_guest_evacuation_lxc_managed_volumes_synthetic_resume_run_id | length > 0
-          - pve_guest_evacuation_lxc_managed_volumes_synthetic_empty_run_id | length == 0
-      vars:
-        pve_guest_evacuation_lxc_managed_volumes_synthetic_target_content: payload
-        pve_guest_evacuation_lxc_managed_volumes_synthetic_resume_run_id: failed-transfer-1
-        pve_guest_evacuation_lxc_managed_volumes_synthetic_empty_run_id: ""
-
     - name: Remove isolated checksum dry-run regression directories
       ansible.builtin.file:
         path: "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_tmp.path }}"

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/defaults/main.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/defaults/main.yml
@@ -9,6 +9,8 @@ pve_guest_evacuation_lxc_managed_volumes_evidence_dir: /bulk/evacuation-816/evid
 pve_guest_evacuation_lxc_managed_volumes_archive_run_id: ""
 pve_guest_evacuation_lxc_managed_volumes_restore_run_id: ""
 pve_guest_evacuation_lxc_managed_volumes_run_id: ""
+pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id: ""
+pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256: ""
 pve_guest_evacuation_lxc_managed_volumes_expected_vmid: null
 pve_guest_evacuation_lxc_managed_volumes_expected_config_digest: ""
 pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256: ""
@@ -32,3 +34,5 @@ pve_guest_evacuation_lxc_managed_volumes_restore_evidence_path: >-
   {{ pve_guest_evacuation_lxc_managed_volumes_evidence_dir }}/restore-{{ pve_guest_evacuation_lxc_managed_volumes_restore_run_id }}-{{ pve_guest_evacuation_lxc_managed_volumes_expected_vmid }}.json
 pve_guest_evacuation_lxc_managed_volumes_result_evidence_path: >-
   {{ pve_guest_evacuation_lxc_managed_volumes_evidence_dir }}/managed-volumes-{{ pve_guest_evacuation_lxc_managed_volumes_run_id }}-{{ pve_guest_evacuation_lxc_managed_volumes_expected_vmid }}.json
+pve_guest_evacuation_lxc_managed_volumes_resume_evidence_path: >-
+  {{ pve_guest_evacuation_lxc_managed_volumes_evidence_dir }}/managed-volumes-{{ pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id }}-{{ pve_guest_evacuation_lxc_managed_volumes_expected_vmid }}.json

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/preflight_contract.yml
@@ -12,6 +12,15 @@
       - pve_guest_evacuation_lxc_managed_volumes_archive_run_id is match('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')
       - pve_guest_evacuation_lxc_managed_volumes_restore_run_id is match('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')
       - pve_guest_evacuation_lxc_managed_volumes_run_id is match('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')
+      - >-
+        pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length == 0
+        or pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id is match('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')
+      - >-
+        (pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length == 0
+         and pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256 | length == 0)
+        or (pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length > 0
+            and pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256 is match('^[A-Fa-f0-9]{64}$'))
+      - pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id != pve_guest_evacuation_lxc_managed_volumes_run_id
       - pve_guest_evacuation_lxc_managed_volumes_restore_run_id != pve_guest_evacuation_lxc_managed_volumes_run_id
       - pve_guest_evacuation_lxc_managed_volumes_expected_vmid | string is match('^[1-9][0-9]*$')
       - pve_guest_evacuation_lxc_managed_volumes_expected_config_digest is match('^[A-Fa-f0-9]{40,64}$')

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
@@ -71,12 +71,13 @@
 - name: Require protected immutable failed-transfer evidence
   ansible.builtin.assert:
     that:
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.exists | default(false)
       - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.isreg | default(false)
       - not (pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.islnk | default(false))
-      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.pw_name == 'root'
-      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.gr_name == 'root'
-      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.mode == '0600'
-      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.checksum == pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.pw_name | default('') == 'root'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.gr_name | default('') == 'root'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.mode | default('') == '0600'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.checksum | default('') == pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256
     fail_msg: Resume evidence must be the exact root-owned, mode 0600, immutable failed-run record.
     quiet: true
   when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0
@@ -426,7 +427,7 @@
       This workflow never overwrites, merges with, or deletes target payloads.
     quiet: true
   loop: "{{ pve_guest_evacuation_lxc_managed_volumes_target_contents.results }}"
-  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length == 0
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length == 0
 
 - name: Require populated preserved targets for an explicit resume
   ansible.builtin.assert:
@@ -434,7 +435,7 @@
     fail_msg: Resume target {{ item.item.key }} is empty; use a normal transfer with a new skeleton.
     quiet: true
   loop: "{{ pve_guest_evacuation_lxc_managed_volumes_target_contents.results }}"
-  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length > 0
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0
 
 - name: Require metadata manifest tools on pve2 and pve540
   ansible.builtin.command:
@@ -531,7 +532,7 @@
   loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
   register: pve_guest_evacuation_lxc_managed_volumes_rsync_copy
   changed_when: true
-  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length == 0
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length == 0
 
 - name: Require checksum dry run to report no remaining differences
   ansible.builtin.command:

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
@@ -60,6 +60,71 @@
     pve_guest_evacuation_lxc_managed_volumes_restore_evidence: >-
       {{ pve_guest_evacuation_lxc_managed_volumes_evidence_raw.results[1].content | b64decode | from_json }}
 
+- name: Read exact failed-transfer evidence metadata for an explicit resume
+  ansible.builtin.stat:
+    path: "{{ pve_guest_evacuation_lxc_managed_volumes_resume_evidence_path }}"
+    checksum_algorithm: sha256
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0
+
+- name: Require protected immutable failed-transfer evidence
+  ansible.builtin.assert:
+    that:
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.isreg | default(false)
+      - not (pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.islnk | default(false))
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.pw_name == 'root'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.gr_name == 'root'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.mode == '0600'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_stat.stat.checksum == pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256
+    fail_msg: Resume evidence must be the exact root-owned, mode 0600, immutable failed-run record.
+    quiet: true
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0
+
+- name: Read exact immutable failed-transfer evidence for an explicit resume
+  ansible.builtin.slurp:
+    src: "{{ pve_guest_evacuation_lxc_managed_volumes_resume_evidence_path }}"
+  delegate_to: "{{ pve_guest_evacuation_lxc_managed_volumes_staging_host }}"
+  register: pve_guest_evacuation_lxc_managed_volumes_resume_evidence_raw
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0
+
+- name: Decode immutable failed-transfer evidence
+  ansible.builtin.set_fact:
+    pve_guest_evacuation_lxc_managed_volumes_resume_evidence: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_resume_evidence_raw.content | b64decode | from_json }}
+    pve_guest_evacuation_lxc_managed_volumes_resume_evidence_actual_sha256: >-
+      {{ pve_guest_evacuation_lxc_managed_volumes_resume_evidence_raw.content | b64decode | hash('sha256') }}
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0
+
+- name: Require exact post-copy manifest failure evidence for resume
+  ansible.builtin.assert:
+    that:
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence_actual_sha256 == pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.schema_version | int == 1
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.checkpoint == 'transfer_failed'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.run_id == pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.input_archive.path == pve_guest_evacuation_lxc_managed_volumes_archive_evidence_path
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.input_archive.run_id == pve_guest_evacuation_lxc_managed_volumes_archive_run_id
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.input_archive.vmid | int == pve_guest_evacuation_lxc_managed_volumes_expected_vmid | int
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.input_archive.source_config_digest == pve_guest_evacuation_lxc_managed_volumes_expected_config_digest
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.input_archive.sha256 == pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.input_restore.run_id == pve_guest_evacuation_lxc_managed_volumes_restore_run_id
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.input_restore.path == pve_guest_evacuation_lxc_managed_volumes_restore_evidence_path
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.input_restore.target_storage == pve_guest_evacuation_lxc_managed_volumes_target_storage
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.source.node == pve_guest_evacuation_lxc_managed_volumes_source_node
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.source.config_digest == pve_guest_evacuation_lxc_managed_volumes_expected_config_digest
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.source.status.status == 'stopped'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.target.node == pve_guest_evacuation_lxc_managed_volumes_target_node
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.target.config_digest == pve_guest_evacuation_lxc_managed_volumes_restore_evidence.target.config_digest
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.target.status.status == 'stopped'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.failure.task == 'Build deterministic source byte file metadata ACL xattr manifests'
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync.copy | length == pve_guest_evacuation_lxc_managed_volumes_resume_evidence.volumes | length
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync.checksum_dry_run | length == pve_guest_evacuation_lxc_managed_volumes_resume_evidence.volumes | length
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync.checksum_dry_run | flatten | length == 0
+    fail_msg: Resume requires the exact immutable evidence from a completed copy that failed only while building the source manifest.
+    quiet: true
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0
+
 - name: Require exact verified archive and pending managed-volume restore evidence
   ansible.builtin.assert:
     that:
@@ -318,6 +383,14 @@
     quiet: true
   loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
 
+- name: Require resumed volume mappings to match immutable failure evidence
+  ansible.builtin.assert:
+    that:
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.volumes == pve_guest_evacuation_lxc_managed_volumes_dataset_mappings
+    fail_msg: Current managed-volume mappings differ from the immutable failed transfer.
+    quiet: true
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0
+
 - name: Assert no ZFS snapshots exist on either evacuation node
   ansible.builtin.command:
     argv: [zfs, list, -H, -t, snapshot, -o, name]
@@ -353,6 +426,15 @@
       This workflow never overwrites, merges with, or deletes target payloads.
     quiet: true
   loop: "{{ pve_guest_evacuation_lxc_managed_volumes_target_contents.results }}"
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length == 0
+
+- name: Require populated preserved targets for an explicit resume
+  ansible.builtin.assert:
+    that: [item.stdout | trim | length > 0]
+    fail_msg: Resume target {{ item.item.key }} is empty; use a normal transfer with a new skeleton.
+    quiet: true
+  loop: "{{ pve_guest_evacuation_lxc_managed_volumes_target_contents.results }}"
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length > 0
 
 - name: Require metadata manifest tools on pve2 and pve540
   ansible.builtin.command:
@@ -449,6 +531,7 @@
   loop: "{{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings }}"
   register: pve_guest_evacuation_lxc_managed_volumes_rsync_copy
   changed_when: true
+  when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length == 0
 
 - name: Require checksum dry run to report no remaining differences
   ansible.builtin.command:
@@ -464,6 +547,7 @@
       - --protect-args
       - --checksum
       - --dry-run
+      - --delete
       - --itemize-changes
       - -e
       - "{{ pve_guest_evacuation_lxc_managed_volumes_rsync_rsh }}"
@@ -496,7 +580,7 @@
     printf 'hardlinks '
     find . -xdev -type f -links +1 -printf '%i\t%p\0' | LC_ALL=C perl -0ne 's/\0\z//; ($inode, $path) = split /\t/, $_, 2; push @{$groups{$inode}}, $path; END { for my $group (sort map { join("\0", sort @{$_}) } values %groups) { print "$group\0\0"; } }' | sha256sum
     printf 'acl '
-    find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfacl --absolute-names --numeric --skip-base --no-effective | sha256sum
+    find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfacl --physical --absolute-names --numeric --skip-base --no-effective | sha256sum
     printf 'xattr '
     find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfattr --absolute-names --no-dereference --encoding=hex -d -m - | sha256sum
   args:
@@ -520,7 +604,7 @@
     printf 'hardlinks '
     find . -xdev -type f -links +1 -printf '%i\t%p\0' | LC_ALL=C perl -0ne 's/\0\z//; ($inode, $path) = split /\t/, $_, 2; push @{$groups{$inode}}, $path; END { for my $group (sort map { join("\0", sort @{$_}) } values %groups) { print "$group\0\0"; } }' | sha256sum
     printf 'acl '
-    find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfacl --absolute-names --numeric --skip-base --no-effective | sha256sum
+    find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfacl --physical --absolute-names --numeric --skip-base --no-effective | sha256sum
     printf 'xattr '
     find . -xdev -print0 | LC_ALL=C sort -z | xargs -0 -r getfattr --absolute-names --no-dereference --encoding=hex -d -m - | sha256sum
   args:

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/templates/managed-volumes-evidence.json.j2
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/templates/managed-volumes-evidence.json.j2
@@ -2,6 +2,11 @@
   "schema_version": 1,
   "run_id": {{ pve_guest_evacuation_lxc_managed_volumes_run_id | to_json }},
   "checkpoint": {{ pve_guest_evacuation_lxc_managed_volumes_checkpoint | to_json }},
+  "resume": {
+    "from_run_id": {{ pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | to_json }},
+    "evidence_path": {{ (pve_guest_evacuation_lxc_managed_volumes_resume_evidence_path if pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length > 0 else '') | to_json }},
+    "evidence_sha256": {{ pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256 | to_json }}
+  },
   "input_archive": {
     "path": {{ pve_guest_evacuation_lxc_managed_volumes_archive_evidence_path | to_json }},
     "run_id": {{ pve_guest_evacuation_lxc_managed_volumes_archive_run_id | to_json }},

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -393,7 +393,7 @@ def test_resume_is_bound_to_exact_post_copy_failure_and_never_recopies() -> None
     assert "Require populated preserved targets for an explicit resume" in transfer
     copy_task = transfer[transfer.index("- name: Copy each stopped-source managed volume"):]
     copy_task = copy_task[:copy_task.index("- name: Require checksum dry run")]
-    assert "resume_from_run_id | length == 0" in copy_task
+    assert "resume_from_run_id | default('') | length == 0" in copy_task
     assert '"resume": {' in evidence
     assert "resume_evidence_sha256" in contract
 

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -407,6 +407,21 @@ def test_checksum_verification_rejects_extra_target_content_and_acl_is_physical(
     assert transfer.count("getfacl --physical --absolute-names --numeric") == 2
 
 
+def test_missing_resume_evidence_metadata_fails_cleanly() -> None:
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+    evidence_gate = transfer[transfer.index("- name: Require protected immutable failed-transfer evidence"):]
+    evidence_gate = evidence_gate[:evidence_gate.index("- name: Read exact immutable failed-transfer evidence")]
+
+    assert "stat.exists | default(false)" in evidence_gate
+    assert "stat.isreg | default(false)" in evidence_gate
+    assert "stat.islnk | default(false)" in evidence_gate
+    for field in ("pw_name", "gr_name", "mode", "checksum"):
+        assert f"stat.{field} | default('')" in evidence_gate
+    resume_conditions = [line for line in transfer.splitlines() if line.lstrip().startswith("when:") and "resume_from_run_id" in line]
+    assert resume_conditions
+    assert all("| default('') | length" in line for line in resume_conditions)
+
+
 if __name__ == "__main__":
     test_role_is_inert_and_requires_exact_three_record_identity()
     test_rsync_endpoint_keeps_the_literal_inventory_fast_path()
@@ -419,3 +434,4 @@ if __name__ == "__main__":
     test_evidence_is_immutable_and_failure_preserves_the_target()
     test_resume_is_bound_to_exact_post_copy_failure_and_never_recopies()
     test_checksum_verification_rejects_extra_target_content_and_acl_is_physical()
+    test_missing_resume_evidence_metadata_fails_cleanly()

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -270,7 +270,7 @@ def test_transfer_preserves_metadata_and_proves_each_volume() -> None:
         assert rsync_flag in transfer
     for manifest in ("bytes", "files", "metadata", "content", "hardlinks", "acl", "xattr"):
         assert f"printf '{manifest} " in transfer
-    assert "getfacl --absolute-names --numeric" in transfer
+    assert "getfacl --physical --absolute-names --numeric" in transfer
     assert "getfattr --absolute-names --no-dereference --encoding=hex" in transfer
     assert "-printf '%y\\t%m\\t%U\\t%G\\t%s" in transfer
     assert "(?:[^,]+,)*mp=/[^,]+" in transfer
@@ -376,6 +376,37 @@ def test_evidence_is_immutable_and_failure_preserves_the_target() -> None:
     assert "target_manifests" in evidence
 
 
+def test_resume_is_bound_to_exact_post_copy_failure_and_never_recopies() -> None:
+    defaults = (ROLE / "defaults" / "main.yml").read_text()
+    contract = (ROLE / "tasks" / "preflight_contract.yml").read_text()
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+    evidence = (ROLE / "templates" / "managed-volumes-evidence.json.j2").read_text()
+
+    assert 'pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id: ""' in defaults
+    assert 'pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256: ""' in defaults
+    assert "managed-volumes-{{ pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id }}" in defaults
+    assert "resume_evidence_actual_sha256 == pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256" in transfer
+    assert "checkpoint == 'transfer_failed'" in transfer
+    assert "failure.task == 'Build deterministic source byte file metadata ACL xattr manifests'" in transfer
+    assert "resume_evidence.volumes == pve_guest_evacuation_lxc_managed_volumes_dataset_mappings" in transfer
+    assert "rsync.checksum_dry_run | flatten | length == 0" in transfer
+    assert "Require populated preserved targets for an explicit resume" in transfer
+    copy_task = transfer[transfer.index("- name: Copy each stopped-source managed volume"):]
+    copy_task = copy_task[:copy_task.index("- name: Require checksum dry run")]
+    assert "resume_from_run_id | length == 0" in copy_task
+    assert '"resume": {' in evidence
+    assert "resume_evidence_sha256" in contract
+
+
+def test_checksum_verification_rejects_extra_target_content_and_acl_is_physical() -> None:
+    transfer = (ROLE / "tasks" / "transfer.yml").read_text()
+    verify = transfer[transfer.index("- name: Require checksum dry run"):]
+    verify = verify[:verify.index("- name: Assert checksum dry runs")]
+    assert "- --dry-run" in verify
+    assert "- --delete" in verify
+    assert transfer.count("getfacl --physical --absolute-names --numeric") == 2
+
+
 if __name__ == "__main__":
     test_role_is_inert_and_requires_exact_three_record_identity()
     test_rsync_endpoint_keeps_the_literal_inventory_fast_path()
@@ -386,3 +417,5 @@ if __name__ == "__main__":
     test_transfer_preserves_metadata_and_proves_each_volume()
     test_zfs_dataset_identity_parser_contract_uses_field_parsing()
     test_evidence_is_immutable_and_failure_preserves_the_target()
+    test_resume_is_bound_to_exact_post_copy_failure_and_never_recopies()
+    test_checksum_verification_rejects_extra_target_content_and_acl_is_physical()


### PR DESCRIPTION
## Summary
- bind managed-volume resume to exact immutable failed-run evidence and skip payload recopy
- reject arbitrary target additions with a checksum `--delete` dry run
- keep ACL manifests physical so absolute in-container symlinks remain valid

## Validation
- `nix develop -c pytest -q tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py` (19 passed)
- production `ansible-lint` (0 failures, 0 warnings)
- `nix develop -c molecule test -s pve_guest_evacuation_lxc_managed_volumes`
- `git diff --check`

## Live evidence binding
The preserved CT405000 failure record remains root-owned, mode 0600, regular, and non-symlink. Its SHA256 is supplied only at runtime and is not committed.