### PR TITLE
fix(evacuation): use mapping lookup for resume copy evidence

### DIFF
--- a/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
+++ b/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
@@ -38,6 +38,18 @@
       ansible.builtin.assert:
         that: [pve_guest_evacuation_lxc_managed_volumes_input_failed | default(false)]
 
+    - name: Decode representative post-copy resume evidence
+      ansible.builtin.set_fact:
+        pve_guest_evacuation_lxc_managed_volumes_resume_regression: >-
+          {{ '{"rsync":{"copy":[{"rc":0}],"checksum_dry_run":[[]]},"volumes":[{"key":"mp0"}]}' | from_json }}
+
+    - name: Prove resume evidence keys use mapping lookup semantics
+      ansible.builtin.assert:
+        that:
+          - pve_guest_evacuation_lxc_managed_volumes_resume_regression.rsync['copy'] | length == 1
+          - pve_guest_evacuation_lxc_managed_volumes_resume_regression.rsync['checksum_dry_run'] | length == 1
+          - pve_guest_evacuation_lxc_managed_volumes_resume_regression.rsync['checksum_dry_run'] | flatten | length == 0
+
     - name: Create isolated absolute-symlink ACL regression directories
       ansible.builtin.tempfile:
         state: directory

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/tasks/transfer.yml
@@ -119,9 +119,9 @@
       - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.target.config_digest == pve_guest_evacuation_lxc_managed_volumes_restore_evidence.target.config_digest
       - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.target.status.status == 'stopped'
       - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.failure.task == 'Build deterministic source byte file metadata ACL xattr manifests'
-      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync.copy | length == pve_guest_evacuation_lxc_managed_volumes_resume_evidence.volumes | length
-      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync.checksum_dry_run | length == pve_guest_evacuation_lxc_managed_volumes_resume_evidence.volumes | length
-      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync.checksum_dry_run | flatten | length == 0
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync['copy'] | length == pve_guest_evacuation_lxc_managed_volumes_resume_evidence.volumes | length
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync['checksum_dry_run'] | length == pve_guest_evacuation_lxc_managed_volumes_resume_evidence.volumes | length
+      - pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync['checksum_dry_run'] | flatten | length == 0
     fail_msg: Resume requires the exact immutable evidence from a completed copy that failed only while building the source manifest.
     quiet: true
   when: pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | default('') | length > 0

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -389,7 +389,9 @@ def test_resume_is_bound_to_exact_post_copy_failure_and_never_recopies() -> None
     assert "checkpoint == 'transfer_failed'" in transfer
     assert "failure.task == 'Build deterministic source byte file metadata ACL xattr manifests'" in transfer
     assert "resume_evidence.volumes == pve_guest_evacuation_lxc_managed_volumes_dataset_mappings" in transfer
-    assert "rsync.checksum_dry_run | flatten | length == 0" in transfer
+    assert "rsync['copy'] | length" in transfer
+    assert "rsync['checksum_dry_run'] | flatten | length == 0" in transfer
+    assert ".rsync.copy" not in transfer
     assert "Require populated preserved targets for an explicit resume" in transfer
     copy_task = transfer[transfer.index("- name: Copy each stopped-source managed volume"):]
     copy_task = copy_task[:copy_task.index("- name: Require checksum dry run")]


### PR DESCRIPTION
## Summary

- use bracket lookup for resume evidence keys so `copy` cannot resolve to the Python mapping method
- audit and bracket the adjacent checksum evidence key
- execute a representative post-copy evidence regression through Ansible and reject dot access statically

## Evidence

- `pytest -q tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py` — 20 passed
- production `ansible-lint` — 0 failures, 0 warnings
- `molecule test -s pve_guest_evacuation_lxc_managed_volumes` — passed, including representative `rsync.copy` JSON lookup

## Live failure binding

Fixes the fail-closed resume gate observed for CT405000 run `20260803T091016Z-ct405000-managed-resume`; that run stopped before source/target state and rsync gates and wrote immutable failure evidence. No retry occurs before this PR is reviewed, green, and merged.