### PR TITLE
fix(evacuation): render skipped resume evidence safely

### DIFF
--- a/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
+++ b/molecule/pve_guest_evacuation_lxc_managed_volumes/verify.yml
@@ -4,6 +4,31 @@
   become: false
   connection: local
   gather_facts: false
+  vars:
+    pve_guest_evacuation_lxc_managed_volumes_run_id: render-regression
+    pve_guest_evacuation_lxc_managed_volumes_checkpoint: transfer_verified
+    pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id: prior-run
+    pve_guest_evacuation_lxc_managed_volumes_resume_evidence_path: /bulk/evacuation-816/evidence/prior.json
+    pve_guest_evacuation_lxc_managed_volumes_resume_evidence_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    pve_guest_evacuation_lxc_managed_volumes_resume_evidence:
+      rsync:
+        copy:
+          - [prior-copy]
+    pve_guest_evacuation_lxc_managed_volumes_archive_evidence_path: /bulk/evacuation-816/evidence/archive.json
+    pve_guest_evacuation_lxc_managed_volumes_archive_run_id: archive-run
+    pve_guest_evacuation_lxc_managed_volumes_expected_vmid: 405000
+    pve_guest_evacuation_lxc_managed_volumes_expected_config_digest: config-digest
+    pve_guest_evacuation_lxc_managed_volumes_expected_archive_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    pve_guest_evacuation_lxc_managed_volumes_restore_evidence_path: /bulk/evacuation-816/evidence/restore.json
+    pve_guest_evacuation_lxc_managed_volumes_restore_run_id: restore-run
+    pve_guest_evacuation_lxc_managed_volumes_target_storage: local-zfs
+    pve_guest_evacuation_lxc_managed_volumes_source_node: pve2
+    pve_guest_evacuation_lxc_managed_volumes_target_node: pve540
+    pve_guest_evacuation_lxc_managed_volumes_source_status: {status: stopped}
+    pve_guest_evacuation_lxc_managed_volumes_target_status: {status: stopped}
+    pve_guest_evacuation_lxc_managed_volumes_source_config: {digest: source-digest}
+    pve_guest_evacuation_lxc_managed_volumes_target_config: {digest: target-digest}
+    pve_guest_evacuation_lxc_managed_volumes_dataset_mappings: [{key: mp0}]
   tasks:
     - name: Assert the inert role created no pve3 evidence directory
       ansible.builtin.stat:
@@ -49,6 +74,67 @@
           - pve_guest_evacuation_lxc_managed_volumes_resume_regression.rsync['copy'] | length == 1
           - pve_guest_evacuation_lxc_managed_volumes_resume_regression.rsync['checksum_dry_run'] | length == 1
           - pve_guest_evacuation_lxc_managed_volumes_resume_regression.rsync['checksum_dry_run'] | flatten | length == 0
+
+    - name: Create isolated evidence-render regression directory
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: managed-volume-evidence-
+      register: pve_guest_evacuation_lxc_managed_volumes_evidence_tmp
+
+    - name: Render successful resume evidence with a skipped copy result
+      ansible.builtin.template:
+        src: ../../roles/pve_guest_evacuation_lxc_managed_volumes/templates/managed-volumes-evidence.json.j2
+        dest: "{{ pve_guest_evacuation_lxc_managed_volumes_evidence_tmp.path }}/success.json"
+        mode: '0600'
+      vars:
+        pve_guest_evacuation_lxc_managed_volumes_rsync_copy:
+          results: [{skipped: true}]
+        pve_guest_evacuation_lxc_managed_volumes_rsync_verify:
+          results: [{stdout_lines: []}]
+        pve_guest_evacuation_lxc_managed_volumes_source_manifests:
+          results: [{stdout_lines: [source-manifest]}]
+        pve_guest_evacuation_lxc_managed_volumes_target_manifests:
+          results: [{stdout_lines: [target-manifest]}]
+
+    - name: Render rescued resume evidence with partial registered results
+      ansible.builtin.template:
+        src: ../../roles/pve_guest_evacuation_lxc_managed_volumes/templates/managed-volumes-evidence.json.j2
+        dest: "{{ pve_guest_evacuation_lxc_managed_volumes_evidence_tmp.path }}/rescue.json"
+        mode: '0600'
+      vars:
+        pve_guest_evacuation_lxc_managed_volumes_checkpoint: transfer_failed
+        pve_guest_evacuation_lxc_managed_volumes_failure: {task: manifest}
+        pve_guest_evacuation_lxc_managed_volumes_rsync_copy:
+          results: [{skipped: true}]
+        pve_guest_evacuation_lxc_managed_volumes_rsync_verify:
+          results: [{stdout_lines: null}]
+        pve_guest_evacuation_lxc_managed_volumes_source_manifests:
+          results: null
+        pve_guest_evacuation_lxc_managed_volumes_target_manifests: null
+
+    - name: Decode rendered resume evidence regressions
+      ansible.builtin.set_fact:
+        pve_guest_evacuation_lxc_managed_volumes_success_render: >-
+          {{ lookup('ansible.builtin.file', pve_guest_evacuation_lxc_managed_volumes_evidence_tmp.path + '/success.json') | from_json }}
+        pve_guest_evacuation_lxc_managed_volumes_rescue_render: >-
+          {{ lookup('ansible.builtin.file', pve_guest_evacuation_lxc_managed_volumes_evidence_tmp.path + '/rescue.json') | from_json }}
+
+    - name: Assert success and rescue resume evidence remain auditable
+      ansible.builtin.assert:
+        that:
+          - pve_guest_evacuation_lxc_managed_volumes_success_render.rsync['copy'] == [['prior-copy']]
+          - pve_guest_evacuation_lxc_managed_volumes_success_render.rsync['checksum_dry_run'] == [[]]
+          - pve_guest_evacuation_lxc_managed_volumes_success_render.source_manifests == [['source-manifest']]
+          - pve_guest_evacuation_lxc_managed_volumes_success_render.target_manifests == [['target-manifest']]
+          - pve_guest_evacuation_lxc_managed_volumes_rescue_render.rsync['copy'] == [['prior-copy']]
+          - pve_guest_evacuation_lxc_managed_volumes_rescue_render.rsync['checksum_dry_run'] == [[]]
+          - pve_guest_evacuation_lxc_managed_volumes_rescue_render.source_manifests == []
+          - pve_guest_evacuation_lxc_managed_volumes_rescue_render.target_manifests == []
+
+    - name: Remove isolated evidence-render regression directory
+      ansible.builtin.file:
+        path: "{{ pve_guest_evacuation_lxc_managed_volumes_evidence_tmp.path }}"
+        state: absent
 
     - name: Create isolated absolute-symlink ACL regression directories
       ansible.builtin.tempfile:

--- a/roles/pve_guest_evacuation_lxc_managed_volumes/templates/managed-volumes-evidence.json.j2
+++ b/roles/pve_guest_evacuation_lxc_managed_volumes/templates/managed-volumes-evidence.json.j2
@@ -1,3 +1,20 @@
+{% set evidence_outputs = namespace(copy=[], verify=[], source=[], target=[]) %}
+{% if pve_guest_evacuation_lxc_managed_volumes_resume_from_run_id | length > 0 and pve_guest_evacuation_lxc_managed_volumes_resume_evidence is defined %}
+{% set evidence_outputs.copy = pve_guest_evacuation_lxc_managed_volumes_resume_evidence.rsync['copy'] | default([], true) %}
+{% else %}
+{% for result in (pve_guest_evacuation_lxc_managed_volumes_rsync_copy | default({}, true)).results | default([], true) %}
+{% set evidence_outputs.copy = evidence_outputs.copy + [result.stdout_lines | default([], true)] %}
+{% endfor %}
+{% endif %}
+{% for result in (pve_guest_evacuation_lxc_managed_volumes_rsync_verify | default({}, true)).results | default([], true) %}
+{% set evidence_outputs.verify = evidence_outputs.verify + [result.stdout_lines | default([], true)] %}
+{% endfor %}
+{% for result in (pve_guest_evacuation_lxc_managed_volumes_source_manifests | default({}, true)).results | default([], true) %}
+{% set evidence_outputs.source = evidence_outputs.source + [result.stdout_lines | default([], true)] %}
+{% endfor %}
+{% for result in (pve_guest_evacuation_lxc_managed_volumes_target_manifests | default({}, true)).results | default([], true) %}
+{% set evidence_outputs.target = evidence_outputs.target + [result.stdout_lines | default([], true)] %}
+{% endfor %}
 {
   "schema_version": 1,
   "run_id": {{ pve_guest_evacuation_lxc_managed_volumes_run_id | to_json }},
@@ -31,11 +48,11 @@
   },
   "volumes": {{ pve_guest_evacuation_lxc_managed_volumes_dataset_mappings | default([]) | to_json }},
   "rsync": {
-    "copy": {{ pve_guest_evacuation_lxc_managed_volumes_rsync_copy.results | default([]) | map(attribute='stdout_lines') | list | to_json }},
-    "checksum_dry_run": {{ pve_guest_evacuation_lxc_managed_volumes_rsync_verify.results | default([]) | map(attribute='stdout_lines') | list | to_json }}
+    "copy": {{ evidence_outputs.copy | to_json }},
+    "checksum_dry_run": {{ evidence_outputs.verify | to_json }}
   },
-  "source_manifests": {{ pve_guest_evacuation_lxc_managed_volumes_source_manifests.results | default([]) | map(attribute='stdout_lines') | list | to_json }},
-  "target_manifests": {{ pve_guest_evacuation_lxc_managed_volumes_target_manifests.results | default([]) | map(attribute='stdout_lines') | list | to_json }},
+  "source_manifests": {{ evidence_outputs.source | to_json }},
+  "target_manifests": {{ evidence_outputs.target | to_json }},
   "failure": {{ pve_guest_evacuation_lxc_managed_volumes_failure | default({}) | to_json }},
   "written_at_utc": {{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') | to_json }}
 }

--- a/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
+++ b/tests/pve_guest_evacuation_lxc_managed_volumes/test_managed_volume_contract.py
@@ -374,6 +374,11 @@ def test_evidence_is_immutable_and_failure_preserves_the_target() -> None:
     assert "target_dataset_identity" in transfer
     assert "source_manifests" in evidence
     assert "target_manifests" in evidence
+    assert "evidence_outputs.copy" in evidence
+    assert "resume_evidence.rsync['copy']" in evidence
+    assert evidence.count("result.stdout_lines | default([], true)") == 4
+    assert evidence.count("default({}, true)") == 4
+    assert "map(attribute='stdout_lines')" not in evidence
 
 
 def test_resume_is_bound_to_exact_post_copy_failure_and_never_recopies() -> None:


### PR DESCRIPTION
## Summary
- derive resumed copy audit data from the immutable prior evidence
- normalize skipped and partial registered results for all evidence outputs
- render and decode both success and rescue resume evidence in Molecule

## Validation
- pytest: 20 passed
- ansible-lint production profile: 0 failures, 0 warnings
- molecule test -s pve_guest_evacuation_lxc_managed_volumes: passed

Closes #816