### PR TITLE
feat: back up cluster config into the archive namespace

### DIFF
--- a/inventory/host_vars/pve3.yml
+++ b/inventory/host_vars/pve3.yml
@@ -158,6 +158,13 @@ postgres_standby_jobs: >-
         'archive_dir': '/bulk/databases/postgres-ai'}
      ] }}
 
+# Cluster config archive (pve_config_backup role). This node already owns
+# the bulk/databases dataset (sanoid-protected above), and pmxcfs replicates
+# /etc/pve to every member, so enabling this here — rather than on every
+# node — captures the whole cluster's config from one place with no
+# cross-host pull needed.
+pve_config_backup_enabled: true
+
 syncoid_jobs:
   - name: "splunk-{{ splunk_vmid }}-disk0"
     source: "root@{{ splunk_node }}:rpool/data/vm-{{ splunk_vmid }}-disk-0"

--- a/molecule/pve_config_backup/converge.yml
+++ b/molecule/pve_config_backup/converge.yml
@@ -1,0 +1,16 @@
+---
+- name: Converge
+  hosts: all
+  become: false
+  gather_facts: true
+
+  vars:
+    # Directory creation and timer enable are Docker-skipped; this proves the
+    # script + timer render the expected contract from the job definition.
+    pve_config_backup_enabled: true
+    pve_config_backup_healthcheck_url: "https://hc-ping.example/pve-config-backup"
+    pve_config_backup_archive_dir: "/bulk/databases/pve-etc"
+    pve_config_backup_retain_count: 7
+
+  roles:
+    - role: pve_config_backup

--- a/molecule/pve_config_backup/molecule.yml
+++ b/molecule/pve_config_backup/molecule.yml
@@ -1,0 +1,9 @@
+---
+platforms:
+  - name: proxmox-pve-config-backup-test
+    image: "${MOLECULE_IMAGE:-debian:stable-slim}"
+    pre_build_image: true
+    privileged: true
+    tmpfs:
+      - /run
+      - /tmp

--- a/molecule/pve_config_backup/verify.yml
+++ b/molecule/pve_config_backup/verify.yml
@@ -1,0 +1,37 @@
+---
+- name: Verify
+  hosts: all
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Read the rendered backup script
+      ansible.builtin.slurp:
+        src: /usr/local/bin/pve-config-backup.sh
+      register: pve_config_backup_script
+
+    - name: Read the rendered timer unit
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/pve-config-backup.timer
+      register: pve_config_backup_timer
+
+    - name: Decode rendered files
+      ansible.builtin.set_fact:
+        pve_config_backup_script_text: "{{ pve_config_backup_script.content | b64decode }}"
+        pve_config_backup_timer_text: "{{ pve_config_backup_timer.content | b64decode }}"
+
+    - name: Assert the backup script renders the expected contract
+      ansible.builtin.assert:
+        that:
+          - "'SRC=\"/etc/pve\"' in pve_config_backup_script_text"
+          - "'DEST=\"/bulk/databases/pve-etc\"' in pve_config_backup_script_text"
+          - "'RETAIN=7' in pve_config_backup_script_text"
+          - "'tar czf' in pve_config_backup_script_text"
+        fail_msg: "pve-config-backup script did not render the expected contract"
+
+    - name: Assert the timer is daily and persistent
+      ansible.builtin.assert:
+        that:
+          - "'OnCalendar=*-*-* 04:15:00' in pve_config_backup_timer_text"
+          - "'Persistent=true' in pve_config_backup_timer_text"
+        fail_msg: "pve-config-backup timer did not render the expected schedule"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -238,6 +238,19 @@
                 'secret_key': lookup('env', 'POSTGRES_DR_AWS_SECRET_KEY')}
              ] | selectattr('access_key', 'ne', '') | list }}
 
+    # Daily tar of the local pmxcfs mount (/etc/pve: cluster.conf,
+    # storage.cfg, firewall/HA/replication config, ACLs) into the generic
+    # <pool>/databases archive namespace — same shape as sqlite_standby /
+    # postgres_standby above, new source. pmxcfs replicates cluster-wide, so
+    # running this on any one member captures the whole cluster; inert unless
+    # a host sets pve_config_backup_enabled: true (the node that already owns
+    # the <pool>/databases dataset).
+    - role: pve_config_backup
+      tags:
+        - pve_config_backup
+      vars:
+        pve_config_backup_healthcheck_url: "https://hc-ping.com/{{ lookup('env', 'HEALTHCHECK_PING_KEY') }}/pve-config-backup"
+
     - role: idrac_kiosk
       tags:
         - idrac_kiosk

--- a/roles/pve_config_backup/README.md
+++ b/roles/pve_config_backup/README.md
@@ -1,0 +1,57 @@
+# pve_config_backup
+
+Daily tar of the local `/etc/pve` (pmxcfs) mount into the generic
+`<pool>/databases` archive namespace (see the [`zfs_pools`](../zfs_pools/README.md)
+role) — the same shape already proven by
+[`sqlite_standby`](../sqlite_standby/README.md) and
+[`postgres_standby`](../postgres_standby/README.md), applied to a new source.
+
+## Why no cross-host pull
+
+`/etc/pve` is `pmxcfs`, already replicated to every cluster member. Running
+this role locally on any one member — by convention, the node that already
+owns the `<pool>/databases` dataset — captures `cluster.conf`, `storage.cfg`,
+firewall rules, HA rules, `replication.cfg` and ACLs for the **whole
+cluster**, not just that node. A single-node loss does not lose this data;
+the real exposure this role protects against is total-cluster loss, which is
+what makes an independent, off-pmxcfs copy worth having at all.
+
+## Installation
+
+Ships in `ansible-proxmox`, applied via `playbooks/site.yml`. No separate
+install. Inert (`pve_config_backup_enabled: false`) unless set per-host.
+
+## How it works
+
+Daily (`systemd` timer): `tar czf` the source directory into a timestamped
+archive under the archive directory, then prune to the `N` most recent. The
+archive directory sits inside the existing `<pool>/databases` dataset, so it
+is already snapshotted (`sanoid`) and, once wired, cross-node replicated
+(`syncoid`) by the storage layer the same as every other archive in that
+namespace — this role only fills it.
+
+## Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `pve_config_backup_enabled` | `false` | Master enable — set per-host |
+| `pve_config_backup_source_dir` | `/etc/pve` | Directory tarred |
+| `pve_config_backup_archive_dir` | `/bulk/databases/pve-etc` | Archive destination |
+| `pve_config_backup_on_calendar` | `*-*-* 04:15:00` | `systemd` `OnCalendar` (daily) |
+| `pve_config_backup_persistent` | `true` | Run a missed schedule on next boot |
+| `pve_config_backup_retain_count` | `14` | Archives kept before pruning oldest |
+| `pve_config_backup_healthcheck_url` | `""` | Optional healthchecks.io URL |
+
+## Usage
+
+```bash
+doppler run -- ./scripts/run-ansible.sh playbooks/site.yml --tags pve_config_backup
+```
+
+## Restore
+
+Extract the newest archive under the archive directory
+(`tar xzf pve-etc-<timestamp>.tar.gz`) into a scratch location and diff
+against a live `/etc/pve` read — never `pct`/`qm` config edits directly from
+the tar. A real restore into a rebuilt cluster's `pmxcfs` is an operator
+action outside this role's scope.

--- a/roles/pve_config_backup/defaults/main.yml
+++ b/roles/pve_config_backup/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# pve_config_backup role defaults — periodic tar of /etc/pve (pmxcfs: cluster
+# config, storage.cfg, firewall rules, HA rules, replication.cfg, ACLs) into
+# the generic <pool>/databases archive namespace (see the zfs_pools role),
+# reusing the exact shape already proven by sqlite_standby/postgres_standby.
+#
+# No cross-host pull is needed: pmxcfs already replicates /etc/pve to every
+# cluster member, so running this locally on ANY one member (the archive
+# node, by convention) captures the whole cluster's config. Inert by default
+# — enable per-host in inventory, on the node that already owns the
+# <pool>/databases dataset.
+
+pve_config_backup_enabled: false
+
+pve_config_backup_source_dir: /etc/pve
+pve_config_backup_archive_dir: /bulk/databases/pve-etc
+
+# Daily, matching the sibling standby roles' cadence for the same namespace.
+pve_config_backup_on_calendar: "*-*-* 04:15:00"
+pve_config_backup_persistent: true
+
+# Local tars only, no per-guest history requirement — this is config, not
+# transactional data, so a handful of recent snapshots is the useful window
+# (pmxcfs itself, plus the ZFS snapshots sanoid takes of the dataset, already
+# provide finer-grained history behind this).
+pve_config_backup_retain_count: 14
+
+# Optional healthchecks.io URL; "<url>" pinged on success, "<url>/fail" on
+# failure. Wired from the play (env-sourced), like the sibling standby roles.
+pve_config_backup_healthcheck_url: ""

--- a/roles/pve_config_backup/handlers/main.yml
+++ b/roles/pve_config_backup/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Reload systemd so it picks up the freshly written unit files. Skipped under
+# Docker (molecule), where systemd is not PID 1.
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/roles/pve_config_backup/tasks/main.yml
+++ b/roles/pve_config_backup/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+# pve_config_backup tasks — deploy the archive script + systemd timer.
+# Directory creation and timer enable are Docker-skipped (molecule); the
+# script and unit files always render so the contract is verifiable
+# in-container.
+
+- name: Ensure the archive directory exists
+  ansible.builtin.file:
+    path: "{{ pve_config_backup_archive_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  when:
+    - pve_config_backup_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - pve_config_backup
+
+- name: Deploy the config-backup script
+  ansible.builtin.template:
+    src: pve-config-backup.sh.j2
+    dest: /usr/local/bin/pve-config-backup.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when: pve_config_backup_enabled
+  tags:
+    - pve_config_backup
+
+- name: Render the config-backup service unit
+  ansible.builtin.template:
+    src: pve-config-backup.service.j2
+    dest: /etc/systemd/system/pve-config-backup.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: pve_config_backup_enabled
+  notify: Reload systemd daemon
+  tags:
+    - pve_config_backup
+
+- name: Render the config-backup timer unit
+  ansible.builtin.template:
+    src: pve-config-backup.timer.j2
+    dest: /etc/systemd/system/pve-config-backup.timer
+    owner: root
+    group: root
+    mode: "0644"
+  when: pve_config_backup_enabled
+  notify: Reload systemd daemon
+  tags:
+    - pve_config_backup
+
+# Apply any pending daemon-reload now so the timer below enables against the
+# freshly written unit (handlers otherwise run only at end of play).
+- name: Reload systemd before enabling the timer
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start the config-backup timer
+  ansible.builtin.systemd:
+    name: pve-config-backup.timer
+    enabled: true
+    state: started
+  when:
+    - pve_config_backup_enabled
+    - ansible_virtualization_type != 'docker'
+  tags:
+    - pve_config_backup

--- a/roles/pve_config_backup/tasks/main.yml
+++ b/roles/pve_config_backup/tasks/main.yml
@@ -67,3 +67,17 @@
     - ansible_virtualization_type != 'docker'
   tags:
     - pve_config_backup
+
+# Mirrors sanoid's disable branch: a host flipped back to disabled must not
+# be left with a stale timer still firing against a removed/outdated script.
+- name: Disable the config-backup timer when backups are not wanted
+  ansible.builtin.systemd:
+    name: pve-config-backup.timer
+    enabled: false
+    state: stopped
+  when:
+    - not pve_config_backup_enabled
+    - ansible_virtualization_type != 'docker'
+  failed_when: false
+  tags:
+    - pve_config_backup

--- a/roles/pve_config_backup/templates/pve-config-backup.service.j2
+++ b/roles/pve_config_backup/templates/pve-config-backup.service.j2
@@ -1,0 +1,8 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Daily tar of the local pmxcfs mount into the archive namespace
+Documentation=https://github.com/dryvist/ansible-proxmox/tree/main/roles/pve_config_backup
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/pve-config-backup.sh

--- a/roles/pve_config_backup/templates/pve-config-backup.sh.j2
+++ b/roles/pve_config_backup/templates/pve-config-backup.sh.j2
@@ -29,7 +29,7 @@ fi
 mapfile -t existing < <(find "$DEST" -maxdepth 1 -name 'pve-etc-*.tar.gz' -type f | sort)
 excess=$(( ${#existing[@]} - RETAIN ))
 if [ "$excess" -gt 0 ]; then
-  printf '%s\n' "${existing[@]:0:$excess}" | xargs -r rm -f
+  printf '%s\0' "${existing[@]:0:$excess}" | xargs -0 -r rm -f
 fi
 
 ping_hc "${HC}"

--- a/roles/pve_config_backup/templates/pve-config-backup.sh.j2
+++ b/roles/pve_config_backup/templates/pve-config-backup.sh.j2
@@ -1,0 +1,35 @@
+#!/bin/bash
+# pve-config-backup — daily tar of the local pmxcfs mount into the archive
+# namespace. Managed by Ansible — do not edit manually.
+#
+# pmxcfs replicates /etc/pve cluster-wide, so this file, run on any one
+# member, captures cluster.conf, storage.cfg, firewall rules, HA rules,
+# replication.cfg and ACLs for the whole cluster — not just this node.
+set -uo pipefail
+
+SRC="{{ pve_config_backup_source_dir }}"
+DEST="{{ pve_config_backup_archive_dir }}"
+RETAIN={{ pve_config_backup_retain_count }}
+HC="{{ pve_config_backup_healthcheck_url }}"
+
+ping_hc() { [ -n "$HC" ] && curl -fsS -m 10 --retry 3 -o /dev/null "$1" >/dev/null 2>&1 || true; }
+
+mkdir -p "$DEST"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+archive="${DEST}/pve-etc-${stamp}.tar.gz"
+
+if ! tar czf "$archive" -C "$(dirname "$SRC")" "$(basename "$SRC")"; then
+  echo "pve-config-backup: tar of ${SRC} FAILED" >&2
+  rm -f "$archive"
+  ping_hc "${HC}/fail"
+  exit 1
+fi
+
+# Prune to the RETAIN most recent archives; oldest first.
+mapfile -t existing < <(find "$DEST" -maxdepth 1 -name 'pve-etc-*.tar.gz' -type f | sort)
+excess=$(( ${#existing[@]} - RETAIN ))
+if [ "$excess" -gt 0 ]; then
+  printf '%s\n' "${existing[@]:0:$excess}" | xargs -r rm -f
+fi
+
+ping_hc "${HC}"

--- a/roles/pve_config_backup/templates/pve-config-backup.timer.j2
+++ b/roles/pve_config_backup/templates/pve-config-backup.timer.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Daily tar of the local pmxcfs mount into the archive namespace
+Documentation=https://github.com/dryvist/ansible-proxmox/tree/main/roles/pve_config_backup
+
+[Timer]
+OnCalendar={{ pve_config_backup_on_calendar }}
+Persistent={{ pve_config_backup_persistent | ternary('true', 'false') }}
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- New `pve_config_backup` role: daily tar of the local pmxcfs mount into the existing `<pool>/databases` archive namespace, reusing the same timer/script shape as `sqlite_standby`/`postgres_standby`.
- Wired into `playbooks/site.yml` (inert unless a host sets `pve_config_backup_enabled: true`) and enabled on the node that already owns the archive dataset.

## Test plan
- [x] `ansible-lint` passes clean (production profile, 137 files)
- [ ] CI Molecule scenario (`pve_config_backup`) — could not run locally, pre-existing devshell gap (missing Python `docker` module used by the molecule docker driver; reproduces identically on unrelated pre-existing scenarios, unrelated to this change)
- [ ] Converge on the target host, confirm timer renders and an initial archive is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)