### PR TITLE
fix(molecule): quote a membership operand and drop an unloadable assertion

### DIFF
--- a/molecule/docker_lxc_features/verify.yml
+++ b/molecule/docker_lxc_features/verify.yml
@@ -74,7 +74,9 @@
           - docker_lxc_features_verify_service_vmids['dify'] == '90003'
           - docker_lxc_features_verify_service_vmids['langflow'] == '90004'
           - docker_lxc_features_verify_service_vmids['assistant-01'] == '90005'
-          - analytics not in docker_lxc_features_verify_service_vmids
+          # Quoted: unquoted, Jinja reads `analytics` as a variable name and
+          # the conditional fails as undefined rather than testing membership.
+          - "'analytics' not in docker_lxc_features_verify_service_vmids"
 
     - name: Assert the pct CLI is absent under Docker
       ansible.builtin.command:

--- a/molecule/idrac_power/verify.yml
+++ b/molecule/idrac_power/verify.yml
@@ -4,15 +4,12 @@
   become: true
   gather_facts: true
 
+  # No "defaults are defined" assertion here. A verify play does not include
+  # the role, so its defaults/main.yml is never loaded into this play's scope
+  # and such an assertion can only ever fail — it tested the harness, not the
+  # role. That the defaults load is already proven by the converge play, which
+  # runs the role and would fail without them.
   tasks:
-    - name: Assert idrac_power defaults loaded
-      ansible.builtin.assert:
-        that:
-          - idrac_power_enabled is defined
-          - idrac_power_action is defined
-          - idrac_power_controller is defined
-        fail_msg: "idrac_power role defaults did not load"
-
     - name: Assert ipmitool was NOT installed under Docker (tasks skipped)
       ansible.builtin.command: dpkg -s ipmitool
       register: ipmitool_check


### PR DESCRIPTION
## What

Two independent scenario fixes. Both are defects in the tests, not in the roles.

**`docker_lxc_features`** — `verify.yml` had an unquoted literal on the left of a `not in` conditional, so Jinja resolved it as a variable name and the conditional errored as undefined instead of testing membership. Now quoted.

**`idrac_power`** — `verify.yml` asserted that the role's defaults were defined. A verify play does not include the role, so `defaults/main.yml` is never loaded into its scope and the assertion could not pass as written. Removed; the converge play runs the role and already covers it.

## Scope

This covers 2 of the 5 currently-red scenarios on `develop`. The other three are separate causes and are **not** addressed here:

- `pve_guest_evacuation_lxc_managed_volumes` — fails on `inventory_hostname == …_source_node`, from the explicit-node contract introduced in #650. Belongs with that change.
- `nas_storage`, `node_scheduled_wake` — fail while reading credentials from the secret store, i.e. an environment dependency rather than test logic.

## On extending the existing detector

`tests/test_assert_conditionals.py` cannot be extended to catch the quoting defect above. It flags `that:` elements that parse as non-strings; an unquoted bare word parses as a perfectly ordinary string, and is indistinguishable from a legitimate variable reference (`foo is defined`, `item not in list`) without knowing which names are meant as literals. A detector for it would either miss the case or fire on valid conditionals, so none is added here.

## Verification

`tests/test_assert_conditionals.py` passes (587 `that:` elements across 291 files). `ansible-lint` production profile passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)